### PR TITLE
fix(docker): drop stale alembic COPY lines from backend.Dockerfile

### DIFF
--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -13,8 +13,6 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 # Copy application source
 COPY apps/backend/app ./app
-COPY apps/backend/alembic ./alembic
-COPY apps/backend/alembic.ini ./
 
 # Install the project
 COPY apps/backend/pyproject.toml ./
@@ -32,8 +30,6 @@ WORKDIR /app
 # Copy the virtual environment and application from the builder
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/app /app/app
-COPY --from=builder /app/alembic /app/alembic
-COPY --from=builder /app/alembic.ini /app/alembic.ini
 
 # Put the venv on PATH
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary

- Remove the four stale `alembic` / `alembic.ini` `COPY` directives from [infra/docker/backend.Dockerfile](infra/docker/backend.Dockerfile) (two in the builder stage, two in the runtime stage).

## Root cause

The template strip in `f4813d1` deleted `apps/backend/alembic/` and `apps/backend/alembic.ini` along with the `sqlalchemy`/`asyncpg`/`alembic` Python deps ([docs/bootstrap-decisions.md:25, 76](docs/bootstrap-decisions.md#L25)), but missed the Dockerfile. Every `Deploy` run on `main` since `f4813d1` has failed at:

```
COPY apps/backend/alembic ./alembic
ERROR: failed to calculate checksum ... "/apps/backend/alembic": not found
```

PDFX has no database by design ([CLAUDE.md](CLAUDE.md), [docs/decisions.md:131](docs/decisions.md#L131)), so there is no alembic tree to copy.

## Test plan

- [x] `ls apps/backend/` confirms neither `alembic/` nor `alembic.ini` exist
- [x] Diff is `-4 / +0` across both stages, no other changes
- [ ] `Deploy` workflow on this PR reaches a green backend image build (verified post-push)

Co-Authored-By: cosminneamtiu02 <91669989+cosminneamtiu02@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>