### PR TITLE
docs(CLAUDE.md): replace manual trailer mandate with git config recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,22 +190,36 @@ The only working path is the ruleset, which binds on `opened` /
    sign in as Ioana. If PR creation goes through gh in the terminal,
    the VSCode extension's identity is irrelevant.
 
-### Contribution credit for cosmin (via local git config)
+### Contribution credit for cosmin (via global git config)
 
 Cosmin's contribution-graph credit on Ioana-authored PRs flows through
 the `Co-authored-by:` trailer that GitHub **auto-extracts** from each
 branch commit's `author` field at squash-merge time. The load-bearing
-step is local git config, set once per machine:
+step is the git **global** (per-user) config, set once per machine:
 
 ```
 git config --global user.email "91669989+cosminneamtiu02@users.noreply.github.com"
 git config --global user.name  "cosminneamtiu02"
 ```
 
+This is `--global`, not `--local` — in git terminology `--local` means
+per-repository (stored in `.git/config`), `--global` means per-user
+(stored in `~/.gitconfig`). The `--global` choice is deliberate: it
+applies to every worktree on this machine and every parallel Claude
+session, which is what we want for this project. Cross-repo side
+effect: it also becomes the default identity for commits on any other
+repo on this machine. If you also work on repos where that's
+undesirable, override per-repo with `git config user.email ...` (no
+`--global`) inside those repos.
+
 User ID `91669989` was fetched from `/users/cosminneamtiu02`. The
-`<user-id>+<login>@users.noreply.github.com` form is the only email
-GitHub treats as verified for the account when resolving trailer-based
-contribution credit.
+`<user-id>+<login>@users.noreply.github.com` form is the recommended
+reliable choice because GitHub auto-provisions it for every account
+and it never requires user action to verify. GitHub also resolves
+trailer-based contribution credit using **any** other email verified
+on the credited account (via Settings → Emails), so a personal
+verified email would also work — the no-reply form is simply the one
+we can rely on without out-of-band setup.
 
 With that config set, every commit's `author` field is
 `cosminneamtiu02 <91669989+cosminneamtiu02@users.noreply.github.com>`,
@@ -214,14 +228,17 @@ and when Ioana squash-merges a PR on this repo, GitHub auto-appends a
 commit message, matching the verified email → contribution graph
 credits cosmin.
 
-Do NOT write manual `Co-Authored-By:` trailers in commit messages or
+Do NOT write manual `Co-authored-by:` trailers in commit messages or
 PR body text on this repo. They are redundant with the auto-extracted
 trailer and, worse, long trailer lines get line-wrapped during the
 PR-body-to-squash-commit transformation (observed on PR #20: an 89-char
 trailer broke across two lines and became unparseable). The auto-
-extraction path is robust; the manual path is fragile.
+extraction path is robust; the manual path is fragile. (Git's trailer
+parser is case-insensitive, so `Co-Authored-By:` and `Co-authored-by:`
+are functionally identical — the prohibition applies to both forms.
+The lowercase form is git's canonical convention.)
 
-The Claude AI-attribution trailer (`Co-Authored-By: Claude Opus 4.6 (1M
+The Claude AI-attribution trailer (`Co-authored-by: Claude Opus 4.6 (1M
 context) <noreply@anthropic.com>`) is separate and optional — Anthropic
 has no GitHub account to credit, so it serves only as transparency
 about AI-assisted commits. Omit it if it would wrap a trailer line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,37 +190,48 @@ The only working path is the ruleset, which binds on `opened` /
    sign in as Ioana. If PR creation goes through gh in the terminal,
    the VSCode extension's identity is irrelevant.
 
-### Commit trailers (mandatory on every commit)
+### Contribution credit for cosmin (via local git config)
 
-Every commit on this repo must include both of these trailers, in this
-order, at the end of the commit message body:
+Cosmin's contribution-graph credit on Ioana-authored PRs flows through
+the `Co-authored-by:` trailer that GitHub **auto-extracts** from each
+branch commit's `author` field at squash-merge time. The load-bearing
+step is local git config, set once per machine:
 
 ```
-Co-Authored-By: cosminneamtiu02 <91669989+cosminneamtiu02@users.noreply.github.com>
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+git config --global user.email "91669989+cosminneamtiu02@users.noreply.github.com"
+git config --global user.name  "cosminneamtiu02"
 ```
 
-The `cosminneamtiu02` trailer exists so that cosmin accrues
-contribution-graph credit on his profile even though Ioana is the PR
-author. GitHub only counts trailer-based co-authorship when the email
-in the trailer matches a verified email on the credited account — the
-`<user-id>+<login>@users.noreply.github.com` form is GitHub's always-
-valid no-reply address for the account (user ID `91669989` was retrieved
-from `/users/cosminneamtiu02`). Any other email form (personal address,
-typo, wrong ID) produces a trailer that GitHub displays but does NOT
-count toward contributions. Lost contribution credit cannot be
-retroactively added.
+User ID `91669989` was fetched from `/users/cosminneamtiu02`. The
+`<user-id>+<login>@users.noreply.github.com` form is the only email
+GitHub treats as verified for the account when resolving trailer-based
+contribution credit.
 
-The `Claude Opus 4.6` trailer exists to identify AI-assisted commits.
+With that config set, every commit's `author` field is
+`cosminneamtiu02 <91669989+cosminneamtiu02@users.noreply.github.com>`,
+and when Ioana squash-merges a PR on this repo, GitHub auto-appends a
+`Co-authored-by: cosminneamtiu02 <91669989+...>` trailer to the squash
+commit message, matching the verified email → contribution graph
+credits cosmin.
+
+Do NOT write manual `Co-Authored-By:` trailers in commit messages or
+PR body text on this repo. They are redundant with the auto-extracted
+trailer and, worse, long trailer lines get line-wrapped during the
+PR-body-to-squash-commit transformation (observed on PR #20: an 89-char
+trailer broke across two lines and became unparseable). The auto-
+extraction path is robust; the manual path is fragile.
+
+The Claude AI-attribution trailer (`Co-Authored-By: Claude Opus 4.6 (1M
+context) <noreply@anthropic.com>`) is separate and optional — Anthropic
+has no GitHub account to credit, so it serves only as transparency
+about AI-assisted commits. Omit it if it would wrap a trailer line.
 
 ### At squash-merge time
 
-GitHub's squash-merge UI auto-populates `Co-Authored-By` trailers from
-the PR's commits into the final squash commit message. Do NOT delete
-either trailer from the squash-merge message box. The final commit that
-lands on `main` must carry both trailers — the contribution graph
-records attribution based on the commit on the default branch, not on
-the branch commits that get discarded during squash.
+Do NOT delete the auto-extracted `Co-authored-by:` trailer from the
+squash-merge message box. If the commit that lands on `main` does not
+carry it, cosmin's contribution-graph credit for that PR is lost and
+cannot be retroactively added.
 
 ## Dependabot
 


### PR DESCRIPTION
## Summary

PR #20 told contributors to write `Co-Authored-By:` trailers by hand in every commit body and PR body. Inspection of PR #20's **own** squash commit proved that advice is fragile: the 89-character trailer line got wrapped into two lines during the PR-body-to-squash-commit transformation, yielding an unparseable trailer. On future Ioana-authored PRs, no contribution credit would have accrued via that path.

The robust path is to let GitHub's squash-merge process auto-extract the `Co-authored-by:` trailer from each branch commit's `author` field. That requires exactly one machine-local setup step (already applied on this machine):

```bash
git config --global user.email "91669989+cosminneamtiu02@users.noreply.github.com"
git config --global user.name  "cosminneamtiu02"
```

With that set, every commit cosmin authors carries the verified no-reply email, and GitHub auto-appends `Co-authored-by: cosminneamtiu02 <91669989+...>` to the squash commit message on every Ioana-merged PR.

## Changes (CLAUDE.md only, 34+/23-)

- Replace the "Commit trailers (mandatory on every commit)" subsection with "Contribution credit for cosmin (via local git config)".
- Explicitly forbid manual `Co-Authored-By:` trailers in commit messages and PR bodies on this repo, and explain the line-wrap failure mode that exposed the problem.
- Downgrade the Claude AI-attribution trailer from "mandatory" to "separate and optional" — Anthropic has no GitHub account to credit, so it serves only transparency; should be omitted if it would wrap a trailer line.
- Rewrite "At squash-merge time" to talk about preserving the auto-extracted trailer, not the manual ones.

## Dual-purpose: this PR is also the workflow validation

This is the first PR on this repo opened by `ioanaecaterinastan-collab` after the 2026-04-14 auth switch. Merging it exercises the full new workflow end-to-end:

- [x] `task check` passes (lint, pyright strict, import-linter, 11 tests, codegen drift-free)
- [ ] After merge, verify Copilot posts a review within ~2 minutes (proves the ruleset fires for Ioana-authored PRs on this repo)
- [ ] After merge, inspect the squash commit with `gh api /repos/.../commits/<sha> --jq .commit.message` and confirm it contains `Co-authored-by: cosminneamtiu02 <91669989+cosminneamtiu02@users.noreply.github.com>` — proves contribution credit flows correctly through GitHub's auto-extraction