### PR TITLE
fix(check): wire errors:check + contract tests; tighten SkillDoclingConfig

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,9 +28,10 @@ tasks:
       - task: check:errors
 
   check:lint:
-    desc: Run the linter
+    desc: Run the linter and verify formatting (read-only)
     cmds:
       - task: lint
+      - task: format:check
 
   check:types:
     desc: Run the type checker
@@ -99,6 +100,12 @@ tasks:
     dir: "{{.BACKEND_DIR}}"
     cmds:
       - uv run ruff format .
+
+  format:check:
+    desc: Verify formatting without rewriting files (CI parity with ruff format --check)
+    dir: "{{.BACKEND_DIR}}"
+    cmds:
+      - uv run ruff format --check .
 
   # ── Skills ───────────────────────────────────────────────────
   skills:validate:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,15 +44,16 @@ tasks:
       - uv run lint-imports --config architecture/import-linter-contracts.ini
 
   check:test:
-    desc: Run unit and integration tests
+    desc: Run unit, integration, and contract tests
     cmds:
       - task: test:unit
       - task: test:integration
+      - task: test:contract
 
   check:errors:
-    desc: Regenerate error contracts from errors.yaml (idempotent when in sync)
+    desc: Fail on generated error contract drift vs errors.yaml
     cmds:
-      - task: errors:generate
+      - task: errors:check
 
   # ── Testing ──────────────────────────────────────────────────
   test:

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -6,6 +6,8 @@ from typing import Annotated
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from app.core.docling_modes import OcrMode, TableMode
+
 # `app/core/config.py` -> `app/core/` -> `app/` -> `apps/backend/`
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent.parent
 _DEFAULT_SKILLS_DIR = _BACKEND_ROOT / "skills"
@@ -34,8 +36,8 @@ class Settings(BaseSettings):
     structured_output_max_retries: Annotated[int, Field(ge=0)] = 3
 
     skills_dir: Path = Field(default_factory=lambda: _DEFAULT_SKILLS_DIR)
-    docling_ocr_default: str | None = None
-    docling_table_mode_default: str | None = None
+    docling_ocr_default: OcrMode | None = None
+    docling_table_mode_default: TableMode | None = None
 
     ollama_base_url: str = "http://host.docker.internal:11434"
     ollama_model: str = "gemma4:e2b"

--- a/apps/backend/app/core/docling_modes.py
+++ b/apps/backend/app/core/docling_modes.py
@@ -1,13 +1,19 @@
-"""Shared vocabulary for Docling pipeline knobs.
+"""Single source of truth for Docling pipeline knob vocabularies.
 
-Defined in `app.core` so both `Settings` (core) and `SkillDoclingConfig`
-(features) can reference the same Literal aliases without `core` having to
-import from `features` — which the `shared-no-features` import-linter
-contract forbids.
+Defined in `app.core` so `Settings` (core), `SkillDoclingConfig` (features,
+skill layer) and `DoclingConfig` (features, parser layer) can all reference
+the same `Literal` aliases without `core` having to import from `features` —
+the `shared-no-features` import-linter contract forbids that direction.
 
-The vocabulary itself is authoritative: the parser layer's `DoclingConfig`
-enforces the same strings at runtime, and every layer in between is closed-
-shape on these aliases so a typo fails at the earliest possible boundary.
+Every consumer is closed-shape on these aliases:
+
+- `Settings.docling_ocr_default` / `docling_table_mode_default` reject bad
+  values at process start via pydantic-settings.
+- `SkillDoclingConfig` rejects bad values at `SkillYamlSchema.load_from_file`
+  time via pydantic.
+- `DoclingConfig` (parser layer) both types its fields on these aliases and
+  derives its runtime `_VALID_*` sets from `typing.get_args(...)`, so adding
+  a new mode here propagates everywhere without a second edit.
 """
 
 from typing import Literal

--- a/apps/backend/app/core/docling_modes.py
+++ b/apps/backend/app/core/docling_modes.py
@@ -1,0 +1,16 @@
+"""Shared vocabulary for Docling pipeline knobs.
+
+Defined in `app.core` so both `Settings` (core) and `SkillDoclingConfig`
+(features) can reference the same Literal aliases without `core` having to
+import from `features` — which the `shared-no-features` import-linter
+contract forbids.
+
+The vocabulary itself is authoritative: the parser layer's `DoclingConfig`
+enforces the same strings at runtime, and every layer in between is closed-
+shape on these aliases so a typo fails at the earliest possible boundary.
+"""
+
+from typing import Literal
+
+OcrMode = Literal["auto", "force", "off"]
+TableMode = Literal["fast", "accurate"]

--- a/apps/backend/app/features/extraction/parsing/docling_config.py
+++ b/apps/backend/app/features/extraction/parsing/docling_config.py
@@ -7,15 +7,18 @@ only when PDFX-E003-F002 actually needs to pass them to Docling.
 """
 
 from dataclasses import dataclass
+from typing import get_args
 
-_VALID_OCR_MODES: frozenset[str] = frozenset({"auto", "force", "off"})
-_VALID_TABLE_MODES: frozenset[str] = frozenset({"fast", "accurate"})
+from app.core.docling_modes import OcrMode, TableMode
+
+_VALID_OCR_MODES: frozenset[str] = frozenset(get_args(OcrMode))
+_VALID_TABLE_MODES: frozenset[str] = frozenset(get_args(TableMode))
 
 
 @dataclass(frozen=True)
 class DoclingConfig:
-    ocr: str
-    table_mode: str
+    ocr: OcrMode
+    table_mode: TableMode
 
     def __post_init__(self) -> None:
         # Fail fast on typos. `DoclingDocumentParser._default_converter_factory`

--- a/apps/backend/app/features/extraction/skills/skill_docling_config.py
+++ b/apps/backend/app/features/extraction/skills/skill_docling_config.py
@@ -7,16 +7,19 @@ values — applying them to a real Docling object is the parser layer's job
 
 from pydantic import BaseModel, ConfigDict
 
+from app.core.docling_modes import OcrMode, TableMode
+
 
 class SkillDoclingConfig(BaseModel):
     """Closed-shape Docling override block. All fields optional.
 
-    The exact named fields are intentionally minimal here; richer per-field
-    validation against Docling's actual configuration surface lives in the
-    parsing layer (PDFX-E003-F003).
+    Values are validated at construction time against the same vocabulary the
+    parser layer enforces in `DoclingConfig` (PDFX-E003-F003), so a typo in a
+    skill YAML fails at `SkillYamlSchema.load_from_file` instead of leaking
+    through to runtime Docling configuration drift.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    ocr: str | None = None
-    table_mode: str | None = None
+    ocr: OcrMode | None = None
+    table_mode: TableMode | None = None

--- a/apps/backend/tests/integration/test_skill_manifest_startup.py
+++ b/apps/backend/tests/integration/test_skill_manifest_startup.py
@@ -108,7 +108,7 @@ async def test_docling_override_flows_from_settings(tmp_path: Path) -> None:
     # pydantic-settings loads the remaining fields from env / defaults
     settings = Settings(  # type: ignore[reportCallIssue]
         skills_dir=tmp_path,
-        docling_ocr_default="on",
+        docling_ocr_default="auto",
         docling_table_mode_default="fast",
     )
     app = create_app(settings)

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill.py
@@ -88,7 +88,7 @@ def test_skill_output_schema_is_deeply_immutable() -> None:
 
 def test_docling_config_is_merged_not_raw_override() -> None:
     schema = _valid_schema(docling=SkillDoclingConfig(ocr="auto"))
-    default = SkillDoclingConfig(ocr="none", table_mode="fast")
+    default = SkillDoclingConfig(ocr="off", table_mode="fast")
 
     skill = Skill.from_schema(schema, default_docling=default)
 
@@ -127,7 +127,7 @@ def test_from_schema_after_load_from_file_merges_yaml_docling(
     schema = SkillYamlSchema.load_from_file(path)
     skill = Skill.from_schema(
         schema,
-        default_docling=SkillDoclingConfig(ocr="none", table_mode="fast"),
+        default_docling=SkillDoclingConfig(ocr="off", table_mode="fast"),
     )
 
     assert isinstance(skill.docling_config, SkillDoclingConfig)

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_loader.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_loader.py
@@ -144,11 +144,11 @@ def test_load_applies_docling_defaults(tmp_path: Path) -> None:
     _write_skill(tmp_path, dir_name="invoice", file_name="1.yaml", version=1)
 
     loader = SkillLoader(
-        default_docling=SkillDoclingConfig(ocr="on", table_mode="fast"),
+        default_docling=SkillDoclingConfig(ocr="auto", table_mode="fast"),
     )
     loaded = loader.load(tmp_path)
 
-    assert loaded[("invoice", 1)].docling_config.ocr == "on"
+    assert loaded[("invoice", 1)].docling_config.ocr == "auto"
     assert loaded[("invoice", 1)].docling_config.table_mode == "fast"
 
 
@@ -162,7 +162,7 @@ def test_load_skill_override_beats_default(tmp_path: Path) -> None:
     )
 
     loader = SkillLoader(
-        default_docling=SkillDoclingConfig(ocr="on", table_mode="fast"),
+        default_docling=SkillDoclingConfig(ocr="auto", table_mode="fast"),
     )
     loaded = loader.load(tmp_path)
 

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
@@ -298,3 +298,38 @@ def test_description_and_docling_populate_when_provided(tmp_path: Path) -> None:
     assert schema.docling is not None
     assert schema.docling.ocr == "auto"
     assert schema.docling.table_mode == "fast"
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("ocr", "banana"),
+        ("ocr", "on"),
+        ("table_mode", "turbo"),
+        ("table_mode", "slow"),
+    ],
+)
+def test_docling_rejects_invalid_values_at_load_time(
+    tmp_path: Path, field: str, bad_value: str
+) -> None:
+    """Typos in a skill's `docling:` block must fail at YAML load, not at runtime.
+
+    Prior to PDFX-E002-F001 hardening, `SkillDoclingConfig.ocr` and
+    `.table_mode` were typed as plain `str`, so `ocr: banana` loaded
+    successfully and only surfaced as a runtime `DoclingConfig` ValueError
+    deep in the parser layer — exactly the silent-drift the closed-shape
+    validator is supposed to prevent.
+    """
+    body: dict[str, object] = {
+        "name": "invoice",
+        "version": 1,
+        "prompt": "p",
+        "examples": [{"input": "x", "output": {}}],
+        "output_schema": {"type": "object"},
+        "docling": {field: bad_value},
+    }
+    path = tmp_path / "1.yaml"
+    path.write_text(yaml.safe_dump(body), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        SkillYamlSchema.load_from_file(path)


### PR DESCRIPTION
## Summary

Three correctness gaps on `main`, bundled because they share a fix path and the same integration tests exercise them together.

### 1. `check:errors` was regenerating instead of diffing
`task check` → `check:errors` → `errors:generate`. The regenerator would silently heal any drift between `errors.yaml` and `apps/backend/app/exceptions/_generated/` during the check run, so drift never failed the build. The real guard (`errors:check`, which runs `git diff --exit-code` on the generated files) already existed — it just was not wired in. Now `check:errors` calls `errors:check`.

### 2. `check:test` omitted contract tests
`docs/superpowers/specs/testing.md` declares unit + integration + contract mandatory, but `check:test` only chained the first two. `test:contract` (which already exists and passes) is now part of the check run.

### 3. `SkillDoclingConfig.ocr` / `.table_mode` accepted any string at load time
`ocr: banana` and `table_mode: turbo` loaded successfully through `SkillYamlSchema.load_from_file` because both fields were typed `str | None`. The parser-layer `DoclingConfig.__post_init__` has always validated the same vocabulary at request time, so a typo would surface as a deferred runtime error instead of a load-time rejection — defeating the whole point of a closed-shape skill YAML schema.

Fix: the authoritative vocabulary moves to a new `app/core/docling_modes.py` module (two `Literal` aliases — `OcrMode`, `TableMode`). `SkillDoclingConfig` (features layer) and `Settings` (core layer) both consume those aliases. The module lives in `core` so that `core/config.py` does not have to import from `features/` — the `shared-no-features` import-linter contract would otherwise reject it.

Adds a parametrized TDD test covering `ocr` and `table_mode` invalid values at `SkillYamlSchema.load_from_file` time. Pre-existing tests were passing `ocr=\"on\"` and `ocr=\"none\"` as default-docling values — neither is a legal DoclingConfig mode — so they were silently exercising the bug; updated to use valid values (`auto`, `off`).

## Test plan

- [x] `task check` passes end-to-end in an isolated worktree (lint, types, arch, unit, integration, contract, errors drift)
- [x] New parametrized TDD test rejects `ocr: banana`, `ocr: on`, `table_mode: turbo`, `table_mode: slow` at `SkillYamlSchema.load_from_file` time
- [x] Existing `test_docling_override_flows_from_settings` still passes with valid vocabulary
- [x] Import-linter `shared-no-features` contract still passes (vocabulary lives in `core`, not `features`)