### PR TITLE
fix(extraction): emit placeholders for empty text

### DIFF
--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -137,12 +137,11 @@ class ExtractionEngine:
         """Run LangExtract against `concatenated_text` using `skill` + `provider`.
 
         Returns one `RawExtraction` per distinct field name declared in
-        `skill.output_schema`. Empty input text short-circuits to an empty
-        result without touching the provider.
+        `skill.output_schema`. Empty input text short-circuits LangExtract
+        but still emits a placeholder row per declared field so the
+        "every declared field always present" invariant (CLAUDE.md:104)
+        holds on the empty-text path too.
         """
-        if not concatenated_text:
-            return []
-
         declared_fields = _declared_field_names(skill)
         if not declared_fields:
             # No declared fields means no API contract to honor — short-
@@ -151,6 +150,18 @@ class ExtractionEngine:
             # upstream by `SkillYamlSchema` validation, but the engine
             # stays strict here as defense in depth.
             return []
+
+        if not concatenated_text:
+            # No prompt is worth sending for empty text, but downstream
+            # assembly still needs one row per declared field. Route
+            # through the same placeholder path `_to_raw_extractions`
+            # uses for declared-but-missing fields so the shape is
+            # identical to the normal "LangExtract returned nothing"
+            # branch.
+            return self._to_raw_extractions(
+                AnnotatedDocument(extractions=[], text=""),
+                declared_fields,
+            )
 
         examples = self._build_examples(skill.examples)
         # Capture the running loop so the adapter, once LangExtract calls

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -373,14 +373,25 @@ async def test_extract_with_zero_declared_fields_returns_empty_without_calling_l
     assert patch_extract.calls == []  # type: ignore[attr-defined]
 
 
-async def test_extract_with_empty_text_returns_empty_list_without_invoking_langextract(
+async def test_extract_with_empty_text_returns_placeholders_without_invoking_langextract(
     patch_extract: Any,
 ) -> None:
-    skill = _build_skill(("name",))
+    """Empty input text must still honor the "every declared field always
+    present" invariant (CLAUDE.md:104). The engine short-circuits LangExtract
+    — no prompt is worth sending for empty text — but returns one placeholder
+    `RawExtraction` per declared field so downstream assembly can still look
+    each field up by name and see `status=missing`.
+    """
+
+    skill = _build_skill(("name", "age", "email"))
 
     results = await ExtractionEngine().extract("", skill, _FakeProvider())
 
-    assert results == []
+    assert [r.field_name for r in results] == ["name", "age", "email"]
+    assert all(r.value is None for r in results)
+    assert all(r.grounded is False for r in results)
+    assert all(r.char_offset_start is None for r in results)
+    assert all(r.char_offset_end is None for r in results)
     assert patch_extract.calls == []  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
## Summary
- Fixes a violation of the "every declared field always present" invariant (CLAUDE.md:104). `ExtractionEngine.extract` returned `[]` on empty input text, skipping the placeholder-emission path that declared-but-missing fields already used.
- Empty text now routes through the existing `_to_raw_extractions` path with an empty `AnnotatedDocument`, producing one placeholder `RawExtraction(value=None, grounded=False)` per declared field — identical shape to the "LangExtract returned nothing" branch.
- LangExtract is still short-circuited (no prompt worth sending for empty text). The zero-declared-fields skill case is reordered ahead of the empty-text check so a degenerate skill still returns `[]` with no provider call.

## Test plan
- [x] Updated `test_extract_with_empty_text_*` to assert the invariant: one placeholder per declared field, all `value=None`/`grounded=False`/offsets `None`, LangExtract never invoked.
- [x] Watched it fail (RED) before implementing, then pass (GREEN) after.
- [x] `task check` green: 20 extraction-engine unit tests + full unit/integration/contract suites + `errors:check`.