### PR TITLE
chore(github): add code-review-finding issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/code-review-finding.yml
+++ b/.github/ISSUE_TEMPLATE/code-review-finding.yml
@@ -1,0 +1,99 @@
+name: Code review finding
+description: Report a bug, defect, or correctness gap discovered while reading the code, reviewing a PR, or running targeted manual tests. Not for end-user symptom reports.
+title: "[Finding] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for issues found by reading or reviewing the code, not for user-observed symptoms. Each finding should be a single, scoped bug — open a separate issue per finding even if you discovered them in the same review pass.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the finding.
+      placeholder: e.g. OllamaGemmaProvider.infer() creates a fresh event loop per call, breaking AsyncClient reuse on the second call.
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Impact when the bug fires. Severity is about how bad it is, not how urgent — see Priority for urgency.
+      options:
+        - "Critical — broken feature, data loss, or security issue"
+        - "High — correctness gap that fires under realistic conditions"
+        - "Medium — degraded correctness, defensive gap, or partial guarantee"
+        - "Low — convention leak, robustness concern, minor polish"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Urgency. Distinct from severity — a low-severity bug blocking a release can still be high-priority. Leave blank if triage will set it later.
+      options:
+        - "P0 — drop everything"
+        - "P1 — current iteration"
+        - "P2 — next iteration"
+        - "P3 — backlog"
+    validations:
+      required: false
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: File and line references. Use `path/to/file.py:LINE` format, one per line. Permalinks to the commit SHA are even better.
+      placeholder: |
+        apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py:219
+        apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py:122
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: What the code does today, anchored to the locations above.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What the code should do, and why. If the right fix is a docs/contract change rather than a code change, say so here so triage can decide.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction or evidence
+      description: How you reproduced or verified the finding. Concrete steps, test output, or logs are far more useful than "I think this happens".
+      placeholder: |
+        1. Start a local keep-alive HTTP stub on :8080
+        2. provider = OllamaGemmaProvider(...)
+        3. provider.infer(["p1"]) — succeeds
+        4. provider.infer(["p2"]) — RuntimeError: Event loop is closed
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+      description: Optional. Proposed approach. Keep it separate from the diagnosis so triage can accept the diagnosis without committing to your specific fix.
+    validations:
+      required: false
+  - type: textarea
+    id: scope-note
+    attributes:
+      label: Scope or ownership note
+      description: Optional. Anything reviewers should know about scope or ownership — e.g. "technically lives in feature X's adapter but affects this provider class because it is registered as the LangExtract provider".
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Optional. Related issues, related PRs, links, or anything else that helps reviewers.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/code-review-finding.yml`, a YAML issue form for filing bugs and correctness gaps discovered during code review or targeted manual testing.
- Splits **severity** (impact) and **priority** (urgency) into distinct dropdowns so triage can express each independently — a low-severity bug blocking a release can still be high-priority.
- Marks **summary**, **severity**, **location**, **current behavior**, **expected behavior**, and **reproduction/evidence** as required so diagnosis-only or symptom-only reports can't sneak through.
- Defaults to the existing `bug` label only — no new labels created.

## Why a form, not a markdown template
GitHub renders YAML issue forms as a real form with required-field validation. Markdown templates are just prefilled bodies that reporters can (and do) delete the headings out of. Forms make the structure load-bearing instead of advisory.

## Why "code-review finding" specifically
Code-review findings have a different shape from end-user bug reports: the reporter has already walked the code path and can name files and lines, but they may not have user-facing reproduction steps. The form is tuned for diagnosis-plus-evidence rather than steps-from-a-user-perspective.

The first batch of issues this template will host are six findings about the extraction pipeline (`OllamaGemmaProvider` event-loop reuse, `StructuredOutputValidator` skill-schema gap, `_raw_generate` httpx error scope, `SubBlockMatcher` unicode composition, `DoclingDocumentParser` sync factory, `Skill.from_schema` mutable examples). They will be filed under this template once it lands.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/code-review-finding.yml'))"` parses without error
- [x] pre-commit `check-yaml` passes
- [x] pre-push backend unit tests pass
- [ ] After merge: open a test issue via the template chooser to confirm GitHub renders the form correctly