### PR TITLE
docs(graph): mark PDFX-E005-F003 as implemented

### DIFF
--- a/docs/graphs/PDFX/PDFX-E005-F003.md
+++ b/docs/graphs/PDFX/PDFX-E005-F003.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E005-F003
 parent: PDFX-E005
 title: SpanResolver with multi-block, cross-page, and ungrounded handling
-status: verifiable
+status: implemented
 priority: 210
 dependencies: [PDFX-E005-F001, PDFX-E005-F002, PDFX-E004-F003, PDFX-E006-F001]
 ---


### PR DESCRIPTION
## Summary
- Updates the feature graph status of PDFX-E005-F003 (SpanResolver) from `verifiable` to `implemented`
- SpanResolver was implemented and merged in PR #45 (commit f6ce523) — this PR catches up the graph metadata

## Test plan
- [ ] Verify `docs/graphs/PDFX/PDFX-E005-F003.md` frontmatter shows `status: implemented`
- [ ] No code changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)