### PR TITLE
feat(api): POST /api/v1/extract router (PDFX-E006-F003)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ DOCLING_TABLE_MODE_DEFAULT=fast
 # Maximum PDF page count. Parser rejects larger PDFs with PDF_TOO_MANY_PAGES (413)
 # before running OCR or layout analysis. Defaults to 200.
 MAX_PDF_PAGES=200
+# Maximum upload byte size. Router rejects uploads exceeding this before parsing.
+# Defaults to 50 MB (52428800 bytes).
+MAX_PDF_BYTES=52428800
 
 # Ollama LLM backend (PDFX-E004-F002)
 OLLAMA_BASE_URL=http://host.docker.internal:11434

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ DOCLING_TABLE_MODE_DEFAULT=fast
 # Maximum PDF page count. Parser rejects larger PDFs with PDF_TOO_MANY_PAGES (413)
 # before running OCR or layout analysis. Defaults to 200.
 MAX_PDF_PAGES=200
-# Maximum upload byte size. Router rejects uploads exceeding this before parsing.
+# Maximum upload byte size. Router rejects uploads exceeding this before
+# PDF parsing (Docling) is allocated. The multipart form is still parsed
+# by Starlette; this guard prevents the expensive downstream pipeline.
 # Defaults to 50 MB (52428800 bytes).
 MAX_PDF_BYTES=52428800
 

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -40,6 +40,7 @@ from app.features.extraction.intelligence.structured_output_validator import (
 from app.features.extraction.parsing.docling_document_parser import (
     DoclingDocumentParser,
 )
+from app.features.extraction.service import ExtractionService
 
 _dep_init_lock = threading.RLock()
 
@@ -114,3 +115,21 @@ def get_document_parser(request: Request) -> DoclingDocumentParser:
                 )
                 state.document_parser = parser
     return parser
+
+
+def get_extraction_service(request: Request) -> ExtractionService:
+    """Return (and lazily cache) the extraction service bound to this app.
+
+    The service is constructed with just ``Settings`` for now (stub).
+    PDFX-E006-F002 will expand the constructor to accept all pipeline
+    components.
+    """
+    state = request.app.state
+    service: ExtractionService | None = getattr(state, "extraction_service", None)
+    if service is None:
+        with _dep_init_lock:
+            service = getattr(state, "extraction_service", None)
+            if service is None:
+                service = ExtractionService(settings=get_settings(request))
+                state.extraction_service = service
+    return service

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     docling_ocr_default: OcrMode = "auto"
     docling_table_mode_default: TableMode = "fast"
     max_pdf_pages: Annotated[int, Field(gt=0)] = 200
+    max_pdf_bytes: Annotated[int, Field(gt=0)] = 50 * 1024 * 1024  # 50 MB
 
     ollama_base_url: str = "http://host.docker.internal:11434"
     ollama_model: str = "gemma4:e2b"

--- a/apps/backend/app/exceptions/__init__.py
+++ b/apps/backend/app/exceptions/__init__.py
@@ -4,12 +4,14 @@ Import errors from this module, never from _generated/ directly.
 """
 
 from app.exceptions._generated import (
+    IntelligenceTimeoutError,
     IntelligenceUnavailableError,
     InternalError,
     NotFoundError,
     PdfInvalidError,
     PdfNoTextExtractableError,
     PdfPasswordProtectedError,
+    PdfTooLargeError,
     PdfTooManyPagesError,
     SkillNotFoundError,
     SkillValidationFailedError,
@@ -20,12 +22,14 @@ from app.exceptions.base import DomainError
 
 __all__ = [
     "DomainError",
+    "IntelligenceTimeoutError",
     "IntelligenceUnavailableError",
     "InternalError",
     "NotFoundError",
     "PdfInvalidError",
     "PdfNoTextExtractableError",
     "PdfPasswordProtectedError",
+    "PdfTooLargeError",
     "PdfTooManyPagesError",
     "SkillNotFoundError",
     "SkillValidationFailedError",

--- a/apps/backend/app/exceptions/_generated/__init__.py
+++ b/apps/backend/app/exceptions/_generated/__init__.py
@@ -1,11 +1,15 @@
 """Generated error classes. Do not edit."""
 
+from app.exceptions._generated.intelligence_timeout_error import IntelligenceTimeoutError
+from app.exceptions._generated.intelligence_timeout_params import IntelligenceTimeoutParams
 from app.exceptions._generated.intelligence_unavailable_error import IntelligenceUnavailableError
 from app.exceptions._generated.internal_error import InternalError
 from app.exceptions._generated.not_found_error import NotFoundError
 from app.exceptions._generated.pdf_invalid_error import PdfInvalidError
 from app.exceptions._generated.pdf_no_text_extractable_error import PdfNoTextExtractableError
 from app.exceptions._generated.pdf_password_protected_error import PdfPasswordProtectedError
+from app.exceptions._generated.pdf_too_large_error import PdfTooLargeError
+from app.exceptions._generated.pdf_too_large_params import PdfTooLargeParams
 from app.exceptions._generated.pdf_too_many_pages_error import PdfTooManyPagesError
 from app.exceptions._generated.pdf_too_many_pages_params import PdfTooManyPagesParams
 from app.exceptions._generated.skill_not_found_error import SkillNotFoundError
@@ -17,12 +21,16 @@ from app.exceptions._generated.validation_failed_error import ValidationFailedEr
 from app.exceptions._generated.validation_failed_params import ValidationFailedParams
 
 __all__ = [
+    "IntelligenceTimeoutError",
+    "IntelligenceTimeoutParams",
     "IntelligenceUnavailableError",
     "InternalError",
     "NotFoundError",
     "PdfInvalidError",
     "PdfNoTextExtractableError",
     "PdfPasswordProtectedError",
+    "PdfTooLargeError",
+    "PdfTooLargeParams",
     "PdfTooManyPagesError",
     "PdfTooManyPagesParams",
     "SkillNotFoundError",

--- a/apps/backend/app/exceptions/_generated/_registry.py
+++ b/apps/backend/app/exceptions/_generated/_registry.py
@@ -7,12 +7,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.exceptions.base import DomainError
 
+from app.exceptions._generated.intelligence_timeout_error import IntelligenceTimeoutError
 from app.exceptions._generated.intelligence_unavailable_error import IntelligenceUnavailableError
 from app.exceptions._generated.internal_error import InternalError
 from app.exceptions._generated.not_found_error import NotFoundError
 from app.exceptions._generated.pdf_invalid_error import PdfInvalidError
 from app.exceptions._generated.pdf_no_text_extractable_error import PdfNoTextExtractableError
 from app.exceptions._generated.pdf_password_protected_error import PdfPasswordProtectedError
+from app.exceptions._generated.pdf_too_large_error import PdfTooLargeError
 from app.exceptions._generated.pdf_too_many_pages_error import PdfTooManyPagesError
 from app.exceptions._generated.skill_not_found_error import SkillNotFoundError
 from app.exceptions._generated.skill_validation_failed_error import SkillValidationFailedError
@@ -31,4 +33,6 @@ ERROR_CLASSES: dict[str, type[DomainError]] = {
     "PDF_NO_TEXT_EXTRACTABLE": PdfNoTextExtractableError,
     "INTELLIGENCE_UNAVAILABLE": IntelligenceUnavailableError,
     "STRUCTURED_OUTPUT_FAILED": StructuredOutputFailedError,
+    "PDF_TOO_LARGE": PdfTooLargeError,
+    "INTELLIGENCE_TIMEOUT": IntelligenceTimeoutError,
 }

--- a/apps/backend/app/exceptions/_generated/intelligence_timeout_error.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_timeout_error.py
@@ -1,0 +1,16 @@
+"""Generated from errors.yaml. Do not edit."""
+
+from typing import ClassVar
+
+from app.exceptions._generated.intelligence_timeout_params import IntelligenceTimeoutParams
+from app.exceptions.base import DomainError
+
+
+class IntelligenceTimeoutError(DomainError):
+    """Error: INTELLIGENCE_TIMEOUT."""
+
+    code: ClassVar[str] = "INTELLIGENCE_TIMEOUT"
+    http_status: ClassVar[int] = 504
+
+    def __init__(self, *, budget_seconds: float) -> None:
+        super().__init__(params=IntelligenceTimeoutParams(budget_seconds=budget_seconds))

--- a/apps/backend/app/exceptions/_generated/intelligence_timeout_params.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_timeout_params.py
@@ -1,0 +1,9 @@
+"""Generated from errors.yaml. Do not edit."""
+
+from pydantic import BaseModel
+
+
+class IntelligenceTimeoutParams(BaseModel):
+    """Parameters for INTELLIGENCE_TIMEOUT error."""
+
+    budget_seconds: float

--- a/apps/backend/app/exceptions/_generated/pdf_too_large_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_large_error.py
@@ -1,0 +1,16 @@
+"""Generated from errors.yaml. Do not edit."""
+
+from typing import ClassVar
+
+from app.exceptions._generated.pdf_too_large_params import PdfTooLargeParams
+from app.exceptions.base import DomainError
+
+
+class PdfTooLargeError(DomainError):
+    """Error: PDF_TOO_LARGE."""
+
+    code: ClassVar[str] = "PDF_TOO_LARGE"
+    http_status: ClassVar[int] = 413
+
+    def __init__(self, *, max_bytes: int, actual_bytes: int) -> None:
+        super().__init__(params=PdfTooLargeParams(max_bytes=max_bytes, actual_bytes=actual_bytes))

--- a/apps/backend/app/exceptions/_generated/pdf_too_large_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_large_params.py
@@ -1,0 +1,10 @@
+"""Generated from errors.yaml. Do not edit."""
+
+from pydantic import BaseModel
+
+
+class PdfTooLargeParams(BaseModel):
+    """Parameters for PDF_TOO_LARGE error."""
+
+    max_bytes: int
+    actual_bytes: int

--- a/apps/backend/app/features/extraction/extraction_result.py
+++ b/apps/backend/app/features/extraction/extraction_result.py
@@ -1,0 +1,32 @@
+"""The internal result of a full extraction pipeline run.
+
+``ExtractionResult`` is the boundary type between ``ExtractionService`` and the
+router.  The service populates it; the router unpacks it into the appropriate
+HTTP response shape per ``output_mode``.
+
+This is NOT a Pydantic model — it is a frozen dataclass because it is an
+internal pipeline artefact that never crosses the serialization boundary.
+``ExtractResponse`` (the Pydantic schema) is one of its fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.features.extraction.schemas.extract_response import ExtractResponse
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Immutable result of ``ExtractionService.extract``.
+
+    Attributes:
+        response: The structured JSON response suitable for serialization.
+        annotated_pdf_bytes: The annotated PDF binary, or ``None`` when the
+            caller requested ``output_mode=JSON_ONLY``.
+    """
+
+    response: ExtractResponse
+    annotated_pdf_bytes: bytes | None

--- a/apps/backend/app/features/extraction/router.py
+++ b/apps/backend/app/features/extraction/router.py
@@ -7,9 +7,10 @@ and serializes the result into the right HTTP response shape per
 ``output_mode``.  There is no business logic here.
 
 The multipart/mixed builder (~15 lines) is inlined because it has exactly
-one consumer.  ``read_with_byte_limit`` is a private async helper that reads
-the upload in 1 MB chunks and aborts early on the first chunk that pushes
-the total over ``Settings.max_pdf_bytes``.
+one consumer.  ``read_with_byte_limit`` is a public async helper (tested
+directly by unit tests) that reads the upload in 1 MB chunks and aborts
+early on the first chunk that pushes the total over
+``Settings.max_pdf_bytes``.
 """
 
 from __future__ import annotations
@@ -101,13 +102,14 @@ def _serialize_result(result: ExtractionResult, output_mode: OutputMode) -> Resp
 
     if output_mode == OutputMode.PDF_ONLY:
         if result.annotated_pdf_bytes is None:
-            raise InternalError
+            raise InternalError()  # noqa: RSE102  # explicit instantiation for consistency
         return Response(content=result.annotated_pdf_bytes, media_type="application/pdf")
 
     if output_mode == OutputMode.BOTH:
+        if result.annotated_pdf_bytes is None:
+            raise InternalError()  # noqa: RSE102
         json_bytes = result.response.model_dump_json().encode()
-        pdf_bytes = result.annotated_pdf_bytes or b""
-        body, boundary = build_multipart_mixed(json_bytes, pdf_bytes)
+        body, boundary = build_multipart_mixed(json_bytes, result.annotated_pdf_bytes)
         return Response(content=body, media_type=f'multipart/mixed; boundary="{boundary}"')
 
     assert_never(output_mode)

--- a/apps/backend/app/features/extraction/router.py
+++ b/apps/backend/app/features/extraction/router.py
@@ -1,0 +1,133 @@
+"""Extraction router — ``POST /api/v1/extract``.
+
+This module is the thin HTTP shell at the top of the extraction feature's
+vertical slice.  It parses the multipart form, enforces the byte-size guard
+before any work is allocated, delegates to ``ExtractionService.extract``,
+and serializes the result into the right HTTP response shape per
+``output_mode``.  There is no business logic here.
+
+The multipart/mixed builder (~15 lines) is inlined because it has exactly
+one consumer.  ``read_with_byte_limit`` is a private async helper that reads
+the upload in 1 MB chunks and aborts early on the first chunk that pushes
+the total over ``Settings.max_pdf_bytes``.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import TYPE_CHECKING, Annotated, assert_never
+
+from fastapi import APIRouter, Depends, File, Form, Response, UploadFile
+from fastapi.responses import JSONResponse
+
+from app.api.deps import get_extraction_service, get_settings
+from app.core.config import (
+    Settings,  # noqa: TC001  # runtime: FastAPI resolves Annotated[..., Depends()]
+)
+from app.exceptions import InternalError, PdfTooLargeError
+from app.features.extraction.schemas.output_mode import OutputMode
+from app.features.extraction.service import ExtractionService  # noqa: TC001  # runtime: FastAPI DI
+
+if TYPE_CHECKING:
+    from app.features.extraction.extraction_result import ExtractionResult
+
+_CHUNK_SIZE = 1024 * 1024  # 1 MB
+
+
+router = APIRouter(tags=["extraction"])
+
+
+# ---------------------------------------------------------------------------
+# Public helpers (tested directly by unit tests)
+# ---------------------------------------------------------------------------
+
+
+async def read_with_byte_limit(upload: UploadFile, max_bytes: int) -> bytes:
+    """Read *upload* in chunks, raising ``PdfTooLargeError`` on overflow.
+
+    The guard aborts on the **first** chunk that pushes the accumulated total
+    past *max_bytes*.  This is a strict greater-than check: an upload of
+    exactly *max_bytes* is accepted.
+    """
+    chunks: list[bytes] = []
+    total = 0
+
+    while True:
+        chunk = await upload.read(_CHUNK_SIZE)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise PdfTooLargeError(max_bytes=max_bytes, actual_bytes=total)
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+def build_multipart_mixed(json_body: bytes, pdf_body: bytes) -> tuple[bytes, str]:
+    """Build a ``multipart/mixed`` response body with two parts.
+
+    Returns ``(body_bytes, boundary_string)``.  Uses CRLF line endings per
+    the multipart RFC.
+    """
+    boundary = secrets.token_hex(16)
+    crlf = "\r\n"
+    parts = (
+        (
+            f"--{boundary}{crlf}"
+            f'Content-Disposition: form-data; name="result"{crlf}'
+            f"Content-Type: application/json{crlf}"
+            f"{crlf}"
+        ).encode()
+        + json_body
+        + (
+            f"{crlf}"
+            f"--{boundary}{crlf}"
+            f'Content-Disposition: form-data; name="pdf"; filename="annotated.pdf"{crlf}'
+            f"Content-Type: application/pdf{crlf}"
+            f"{crlf}"
+        ).encode()
+        + pdf_body
+        + f"{crlf}--{boundary}--{crlf}".encode()
+    )
+
+    return parts, boundary
+
+
+def _serialize_result(result: ExtractionResult, output_mode: OutputMode) -> Response:
+    """Serialize *result* into the right HTTP response per *output_mode*."""
+    if output_mode == OutputMode.JSON_ONLY:
+        return JSONResponse(content=result.response.model_dump(mode="json"))
+
+    if output_mode == OutputMode.PDF_ONLY:
+        if result.annotated_pdf_bytes is None:
+            raise InternalError
+        return Response(content=result.annotated_pdf_bytes, media_type="application/pdf")
+
+    if output_mode == OutputMode.BOTH:
+        json_bytes = result.response.model_dump_json().encode()
+        pdf_bytes = result.annotated_pdf_bytes or b""
+        body, boundary = build_multipart_mixed(json_bytes, pdf_bytes)
+        return Response(content=body, media_type=f'multipart/mixed; boundary="{boundary}"')
+
+    assert_never(output_mode)
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.post("/extract")
+async def extract(  # noqa: PLR0913  # FastAPI DI handler — each param is an injected dependency
+    pdf: Annotated[UploadFile, File()],
+    skill_name: Annotated[str, Form()],
+    skill_version: Annotated[str, Form()],
+    output_mode: Annotated[OutputMode, Form()],
+    settings: Annotated[Settings, Depends(get_settings)],
+    service: Annotated[ExtractionService, Depends(get_extraction_service)],
+) -> Response:
+    """Accept a PDF and skill parameters, run extraction, return per output mode."""
+    pdf_bytes = await read_with_byte_limit(pdf, settings.max_pdf_bytes)
+    result = await service.extract(pdf_bytes, skill_name, skill_version, output_mode)
+    return _serialize_result(result, output_mode)

--- a/apps/backend/app/features/extraction/router.py
+++ b/apps/backend/app/features/extraction/router.py
@@ -2,9 +2,15 @@
 
 This module is the thin HTTP shell at the top of the extraction feature's
 vertical slice.  It parses the multipart form, enforces the byte-size guard
-before any work is allocated, delegates to ``ExtractionService.extract``,
-and serializes the result into the right HTTP response shape per
-``output_mode``.  There is no business logic here.
+before the expensive PDF-parsing pipeline (Docling, LLM, annotation) is
+allocated, delegates to ``ExtractionService.extract``, and serializes the
+result into the right HTTP response shape per ``output_mode``.  There is no
+business logic here.
+
+Note: the byte-size guard runs *after* Starlette has parsed the multipart
+form and spooled the upload to a temp file.  It does not reject at the
+HTTP framing level.  What it prevents is the downstream Docling +
+extraction pipeline from being invoked on an oversized document.
 
 The multipart/mixed builder (~15 lines) is inlined because it has exactly
 one consumer.  ``read_with_byte_limit`` is a public async helper (tested
@@ -26,8 +32,10 @@ from app.core.config import (
     Settings,  # noqa: TC001  # runtime: FastAPI resolves Annotated[..., Depends()]
 )
 from app.exceptions import InternalError, PdfTooLargeError
+from app.features.extraction.schemas.extract_request import SKILL_VERSION_PATTERN
 from app.features.extraction.schemas.output_mode import OutputMode
 from app.features.extraction.service import ExtractionService  # noqa: TC001  # runtime: FastAPI DI
+from app.schemas.error_response import ErrorResponse
 
 if TYPE_CHECKING:
     from app.features.extraction.extraction_result import ExtractionResult
@@ -120,11 +128,24 @@ def _serialize_result(result: ExtractionResult, output_mode: OutputMode) -> Resp
 # ---------------------------------------------------------------------------
 
 
-@router.post("/extract")
+@router.post(
+    "/extract",
+    responses={
+        200: {
+            "description": (
+                "Extraction succeeded. Content-Type depends on output_mode: "
+                "application/json (JSON_ONLY), application/pdf (PDF_ONLY), "
+                "or multipart/mixed (BOTH)."
+            ),
+        },
+        413: {"description": "PDF exceeds max_pdf_bytes", "model": ErrorResponse},
+        504: {"description": "Extraction pipeline timed out", "model": ErrorResponse},
+    },
+)
 async def extract(  # noqa: PLR0913  # FastAPI DI handler — each param is an injected dependency
     pdf: Annotated[UploadFile, File()],
     skill_name: Annotated[str, Form()],
-    skill_version: Annotated[str, Form()],
+    skill_version: Annotated[str, Form(pattern=SKILL_VERSION_PATTERN)],
     output_mode: Annotated[OutputMode, Form()],
     settings: Annotated[Settings, Depends(get_settings)],
     service: Annotated[ExtractionService, Depends(get_extraction_service)],

--- a/apps/backend/app/features/extraction/router.py
+++ b/apps/backend/app/features/extraction/router.py
@@ -58,19 +58,17 @@ async def read_with_byte_limit(upload: UploadFile, max_bytes: int) -> bytes:
     past *max_bytes*.  This is a strict greater-than check: an upload of
     exactly *max_bytes* is accepted.
     """
-    chunks: list[bytes] = []
-    total = 0
+    buf = bytearray()
 
     while True:
         chunk = await upload.read(_CHUNK_SIZE)
         if not chunk:
             break
-        total += len(chunk)
-        if total > max_bytes:
-            raise PdfTooLargeError(max_bytes=max_bytes, actual_bytes=total)
-        chunks.append(chunk)
+        buf.extend(chunk)
+        if len(buf) > max_bytes:
+            raise PdfTooLargeError(max_bytes=max_bytes, actual_bytes=len(buf))
 
-    return b"".join(chunks)
+    return bytes(buf)
 
 
 def build_multipart_mixed(json_body: bytes, pdf_body: bytes) -> tuple[bytes, str]:

--- a/apps/backend/app/features/extraction/schemas/extract_request.py
+++ b/apps/backend/app/features/extraction/schemas/extract_request.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 from app.features.extraction.schemas.output_mode import OutputMode
 
-_SKILL_VERSION_PATTERN = r"^(latest|[1-9][0-9]*)$"
+SKILL_VERSION_PATTERN = r"^(latest|[1-9][0-9]*)$"
 
 
 class ExtractRequest(BaseModel):
@@ -25,5 +25,5 @@ class ExtractRequest(BaseModel):
     """
 
     skill_name: str
-    skill_version: str = Field(pattern=_SKILL_VERSION_PATTERN)
+    skill_version: str = Field(pattern=SKILL_VERSION_PATTERN)
     output_mode: OutputMode

--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -1,0 +1,48 @@
+"""ExtractionService — top-level pipeline orchestrator.
+
+This is a STUB created by PDFX-E006-F003 (router).  The full implementation
+is delivered by PDFX-E006-F002.  Only the public interface used by the router
+is defined here so that the router and its tests can compile and run against
+mocks.
+
+The ``extract`` method signature is the contract between the service and the
+router.  F002 MUST keep this signature intact when it replaces the stub with
+the real orchestration logic.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.config import Settings
+    from app.features.extraction.extraction_result import ExtractionResult
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+_STUB_MSG = "ExtractionService.extract is a stub — implement in PDFX-E006-F002"
+
+
+class ExtractionService:
+    """Orchestrate the full extraction pipeline.
+
+    Constructor parameters will be filled in by PDFX-E006-F002.  The router
+    only depends on the ``extract`` method signature.
+    """
+
+    def __init__(self, *, settings: Settings) -> None:
+        self._settings = settings
+
+    async def extract(
+        self,
+        pdf_bytes: bytes,
+        skill_name: str,
+        skill_version: str,
+        output_mode: OutputMode,
+    ) -> ExtractionResult:
+        """Run the extraction pipeline and return the result.
+
+        This stub raises ``NotImplementedError``.  The full implementation is
+        delivered by PDFX-E006-F002 which wires skill resolution, parsing,
+        text concatenation, extraction, span resolution, and annotation.
+        """
+        raise NotImplementedError(_STUB_MSG)

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -91,6 +91,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     application.state.skill_manifest = SkillManifest(loaded)
 
     application.include_router(health_router)
+    # ExtractionService is a stub until PDFX-E006-F002 merges.  Requests
+    # that reach the stub hit the catch-all handler and return 500
+    # INTERNAL_ERROR, which is correct "not implemented yet" behaviour.
+    # F002 MUST merge before (or together with) this branch.
     application.include_router(extraction_router, prefix="/api/v1")
 
     return application

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.middleware import configure_middleware
 from app.core.config import Settings
 from app.core.logging import configure_logging
 from app.exceptions import SkillValidationFailedError
+from app.features.extraction.router import router as extraction_router
 from app.features.extraction.skills import (
     SkillDoclingConfig,
     SkillLoader,
@@ -90,6 +91,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     application.state.skill_manifest = SkillManifest(loaded)
 
     application.include_router(health_router)
+    application.include_router(extraction_router, prefix="/api/v1")
 
     return application
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -12,6 +12,7 @@ description = "Backend API for the project template"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.135.3",
+    "python-multipart>=0.0.20",
     "uvicorn[standard]>=0.44.0",
     "pydantic>=2.13.0",
     "pydantic-settings>=2.13.1",

--- a/apps/backend/tests/contract/test_extract_contract.py
+++ b/apps/backend/tests/contract/test_extract_contract.py
@@ -110,6 +110,11 @@ def test_openapi_contains_extract_endpoint(tmp_path: Path) -> None:
     if "enum" in output_mode_schema:
         assert set(output_mode_schema["enum"]) == {"JSON_ONLY", "PDF_ONLY", "BOTH"}
 
+    # Verify error responses are declared in the OpenAPI spec
+    responses = post_op.get("responses", {})
+    assert "413" in responses, "PDF_TOO_LARGE (413) missing from OpenAPI responses"
+    assert "504" in responses, "INTELLIGENCE_TIMEOUT (504) missing from OpenAPI responses"
+
 
 async def test_pdf_too_large_envelope_matches_contract(tmp_path: Path) -> None:
     """413 response for PDF_TOO_LARGE matches ErrorResponse schema shape."""

--- a/apps/backend/tests/contract/test_extract_contract.py
+++ b/apps/backend/tests/contract/test_extract_contract.py
@@ -1,0 +1,210 @@
+"""Contract tests for ``POST /api/v1/extract`` — PDFX-E006-F003.
+
+Validates the OpenAPI spec and error-response envelope shapes for the
+extraction endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+from starlette.testclient import TestClient
+
+from app.api.deps import get_extraction_service
+from app.core.config import Settings
+from app.exceptions import IntelligenceTimeoutError
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.extract_response import ExtractResponse
+from app.features.extraction.schemas.extracted_field import ExtractedField
+from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+from app.features.extraction.schemas.field_status import FieldStatus
+from app.features.extraction.service import ExtractionService
+from app.main import create_app
+
+
+def _write_valid_skill(base: Path) -> None:
+    body = {
+        "name": "invoice",
+        "version": 1,
+        "prompt": "Extract header fields.",
+        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
+        "output_schema": {
+            "type": "object",
+            "properties": {"number": {"type": "string"}},
+            "required": ["number"],
+        },
+    }
+    target = base / "invoice"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
+
+
+def _settings(skills_dir: Path, **overrides) -> Settings:
+    return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
+
+
+def _make_canned_result() -> ExtractionResult:
+    field = ExtractedField(
+        name="number",
+        value="INV-001",
+        status=FieldStatus.extracted,
+        source="document",
+        grounded=True,
+        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
+    )
+    metadata = ExtractionMetadata(
+        page_count=1,
+        duration_ms=500,
+        attempts_per_field={"number": 1},
+    )
+    response = ExtractResponse(
+        skill_name="invoice",
+        skill_version=1,
+        fields={"number": field},
+        metadata=metadata,
+    )
+    return ExtractionResult(response=response, annotated_pdf_bytes=None)
+
+
+def test_openapi_contains_extract_endpoint(tmp_path: Path) -> None:
+    """OpenAPI spec contains POST /api/v1/extract with correct form fields."""
+    _write_valid_skill(tmp_path)
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    spec = response.json()
+    assert "/api/v1/extract" in spec["paths"]
+
+    post_op = spec["paths"]["/api/v1/extract"]["post"]
+    assert post_op is not None
+
+    # Check that the operation expects multipart/form-data with the four fields
+    request_body = post_op.get("requestBody", {})
+    content = request_body.get("content", {})
+    assert "multipart/form-data" in content
+
+    schema = content["multipart/form-data"]["schema"]
+    # FastAPI may use a $ref — resolve through components if needed
+    if "$ref" in schema:
+        ref_path = schema["$ref"]  # e.g. "#/components/schemas/Body_..."
+        ref_name = ref_path.split("/")[-1]
+        schema = spec["components"]["schemas"][ref_name]
+
+    props = schema.get("properties", {})
+    assert "pdf" in props
+    assert "skill_name" in props
+    assert "skill_version" in props
+    assert "output_mode" in props
+
+    # Check output_mode enum values — may be inline or a $ref to OutputMode
+    output_mode_schema = props["output_mode"]
+    if "$ref" in output_mode_schema:
+        ref_name = output_mode_schema["$ref"].split("/")[-1]
+        output_mode_schema = spec["components"]["schemas"][ref_name]
+    if "enum" in output_mode_schema:
+        assert set(output_mode_schema["enum"]) == {"JSON_ONLY", "PDF_ONLY", "BOTH"}
+
+
+async def test_pdf_too_large_envelope_matches_contract(tmp_path: Path) -> None:
+    """413 response for PDF_TOO_LARGE matches ErrorResponse schema shape."""
+    stub = AsyncMock(spec=ExtractionService)
+    _write_valid_skill(tmp_path)
+    app = create_app(_settings(tmp_path, max_pdf_bytes=1024))
+    app.dependency_overrides[get_extraction_service] = lambda: stub
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("big.pdf", b"x" * 2048, "application/pdf")},
+        )
+
+    assert response.status_code == 413
+    body = response.json()
+    error = body["error"]
+    assert isinstance(error["code"], str)
+    assert error["code"] == "PDF_TOO_LARGE"
+    assert isinstance(error["params"]["max_bytes"], int)
+    assert isinstance(error["params"]["actual_bytes"], int)
+    assert "request_id" in error
+
+
+async def test_intelligence_timeout_envelope_matches_contract(tmp_path: Path) -> None:
+    """504 response for INTELLIGENCE_TIMEOUT matches ErrorResponse schema shape."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = IntelligenceTimeoutError(budget_seconds=180.0)
+
+    _write_valid_skill(tmp_path)
+    app = create_app(_settings(tmp_path))
+    app.dependency_overrides[get_extraction_service] = lambda: stub
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    assert response.status_code == 504
+    body = response.json()
+    error = body["error"]
+    assert isinstance(error["code"], str)
+    assert error["code"] == "INTELLIGENCE_TIMEOUT"
+    assert isinstance(error["params"]["budget_seconds"], (int, float))
+    assert error["params"]["budget_seconds"] == 180.0
+    assert "request_id" in error
+
+
+async def test_schemathesis_extract_endpoint_conformance(tmp_path: Path) -> None:
+    """Schemathesis validates that stubbed responses conform to the OpenAPI spec.
+
+    This is a lightweight conformance check: we verify the 200 response
+    from a valid request against the declared schema.
+    """
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.return_value = _make_canned_result()
+
+    _write_valid_skill(tmp_path)
+    app = create_app(_settings(tmp_path))
+    app.dependency_overrides[get_extraction_service] = lambda: stub
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    # Verify the response has the ExtractResponse fields
+    assert "skill_name" in body
+    assert "skill_version" in body
+    assert "fields" in body
+    assert "metadata" in body
+    # Verify metadata shape
+    metadata = body["metadata"]
+    assert "page_count" in metadata
+    assert "duration_ms" in metadata
+    assert "attempts_per_field" in metadata

--- a/apps/backend/tests/contract/test_extract_contract.py
+++ b/apps/backend/tests/contract/test_extract_contract.py
@@ -171,12 +171,8 @@ async def test_intelligence_timeout_envelope_matches_contract(tmp_path: Path) ->
     assert "request_id" in error
 
 
-async def test_schemathesis_extract_endpoint_conformance(tmp_path: Path) -> None:
-    """Schemathesis validates that stubbed responses conform to the OpenAPI spec.
-
-    This is a lightweight conformance check: we verify the 200 response
-    from a valid request against the declared schema.
-    """
+async def test_extract_response_shape_conforms_to_schema(tmp_path: Path) -> None:
+    """Verify the 200 response from a valid request matches ExtractResponse shape."""
     stub = AsyncMock(spec=ExtractionService)
     stub.extract.return_value = _make_canned_result()
 

--- a/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
+++ b/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
@@ -320,14 +320,7 @@ async def test_skill_version_latest_passes_through(tmp_path: Path) -> None:
 
 
 async def test_skill_version_zero_returns_422(tmp_path: Path) -> None:
-    """skill_version=0 is invalid per the regex and returns 422.
-
-    NOTE: This validation happens if ExtractRequest validation is applied.
-    The router uses raw Form() fields without ExtractRequest validation,
-    so skill_version=0 will pass through to the service.  The service
-    (SkillManifest.lookup) will reject it with SkillNotFoundError (404).
-    We test the router passes it through.
-    """
+    """skill_version=0 is rejected at the form-field boundary with 422."""
     stub = _stub_service()
     app = _build_app(tmp_path, stub)
     transport = ASGITransport(app=app)
@@ -342,6 +335,4 @@ async def test_skill_version_zero_returns_422(tmp_path: Path) -> None:
             files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
         )
 
-    # The router doesn't validate skill_version format — it passes through
-    # to the service. The stub service returns 200.
-    assert response.status_code == 200
+    assert response.status_code == 422

--- a/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
+++ b/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
@@ -183,14 +183,13 @@ async def test_both_returns_200_multipart_mixed(tmp_path: Path) -> None:
 
 
 async def test_oversized_pdf_returns_413(tmp_path: Path) -> None:
-    """60 MB PDF against 50 MB limit returns 413 PDF_TOO_LARGE."""
+    """Upload exceeding max_pdf_bytes returns 413 PDF_TOO_LARGE."""
     stub = _stub_service()
-    max_bytes = 50 * 1024 * 1024
+    max_bytes = 1024
     app = _build_app(tmp_path, stub, max_pdf_bytes=max_bytes)
     transport = ASGITransport(app=app)
 
-    # 60 MB of data — smaller chunk to avoid memory pressure in test
-    oversized_data = b"x" * (60 * 1024 * 1024)
+    oversized_data = b"x" * (max_bytes + 512)
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
@@ -273,13 +272,13 @@ async def test_intelligence_timeout_returns_504(tmp_path: Path) -> None:
 
 
 async def test_oversized_stream_aborts_before_service(tmp_path: Path) -> None:
-    """51 MB streamed upload returns 413 and service is never called."""
+    """Upload over the limit returns 413 and service is never called."""
     stub = _stub_service()
-    max_bytes = 50 * 1024 * 1024
+    max_bytes = 2048
     app = _build_app(tmp_path, stub, max_pdf_bytes=max_bytes)
     transport = ASGITransport(app=app)
 
-    oversized_data = b"x" * (max_bytes + 1024 * 1024)  # 51 MB
+    oversized_data = b"x" * (max_bytes + 1024)
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(

--- a/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
+++ b/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
@@ -1,0 +1,347 @@
+"""Integration tests for ``POST /api/v1/extract`` — PDFX-E006-F003.
+
+All tests boot a real FastAPI app via ``create_app`` with a temporary skill
+directory and override the ``ExtractionService`` dependency to avoid needing
+real Docling / Ollama.  The ``httpx.AsyncClient`` sends requests through
+``ASGITransport`` (in-process, no network).
+"""
+
+from __future__ import annotations
+
+import email.parser
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_extraction_service
+from app.core.config import Settings
+from app.exceptions import IntelligenceTimeoutError
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.extract_response import ExtractResponse
+from app.features.extraction.schemas.extracted_field import ExtractedField
+from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+from app.features.extraction.schemas.field_status import FieldStatus
+from app.features.extraction.service import ExtractionService
+from app.main import create_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_PDF_BYTES = b"%PDF-1.4 fake annotated content"
+
+
+def _write_valid_skill(base: Path) -> None:
+    body = {
+        "name": "invoice",
+        "version": 1,
+        "prompt": "Extract header fields.",
+        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
+        "output_schema": {
+            "type": "object",
+            "properties": {"number": {"type": "string"}},
+            "required": ["number"],
+        },
+    }
+    target = base / "invoice"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
+
+
+def _settings(skills_dir: Path, **overrides) -> Settings:
+    return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
+
+
+def _make_canned_result(
+    *,
+    annotated_pdf_bytes: bytes | None = None,
+) -> ExtractionResult:
+    field = ExtractedField(
+        name="number",
+        value="INV-001",
+        status=FieldStatus.extracted,
+        source="document",
+        grounded=True,
+        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
+    )
+    metadata = ExtractionMetadata(
+        page_count=1,
+        duration_ms=500,
+        attempts_per_field={"number": 1},
+    )
+    response = ExtractResponse(
+        skill_name="invoice",
+        skill_version=1,
+        fields={"number": field},
+        metadata=metadata,
+    )
+    return ExtractionResult(response=response, annotated_pdf_bytes=annotated_pdf_bytes)
+
+
+def _stub_service(result: ExtractionResult | None = None, *, side_effect=None) -> ExtractionService:
+    """Build a mock ``ExtractionService`` with a canned return or side effect."""
+    svc = AsyncMock(spec=ExtractionService)
+    if side_effect is not None:
+        svc.extract.side_effect = side_effect
+    else:
+        svc.extract.return_value = result or _make_canned_result()
+    return svc
+
+
+def _build_app(tmp_path: Path, stub: ExtractionService, **settings_overrides):
+    """Create a FastAPI app with the given stub service override."""
+    _write_valid_skill(tmp_path)
+    app = create_app(_settings(tmp_path, **settings_overrides))
+    app.dependency_overrides[get_extraction_service] = lambda: stub
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+async def test_json_only_returns_200_json(tmp_path: Path) -> None:
+    """POST with output_mode=JSON_ONLY returns 200 application/json."""
+    stub = _stub_service(_make_canned_result(annotated_pdf_bytes=None))
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4 small", "application/pdf")},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    body = response.json()
+    assert body["skill_name"] == "invoice"
+    assert body["skill_version"] == 1
+    assert "number" in body["fields"]
+
+
+async def test_pdf_only_returns_200_pdf(tmp_path: Path) -> None:
+    """POST with output_mode=PDF_ONLY returns 200 application/pdf."""
+    stub = _stub_service(_make_canned_result(annotated_pdf_bytes=_FAKE_PDF_BYTES))
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "PDF_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4 small", "application/pdf")},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    assert response.content.startswith(b"%PDF")
+
+
+async def test_both_returns_200_multipart_mixed(tmp_path: Path) -> None:
+    """POST with output_mode=BOTH returns 200 multipart/mixed with two parts."""
+    stub = _stub_service(_make_canned_result(annotated_pdf_bytes=_FAKE_PDF_BYTES))
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "BOTH",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4 small", "application/pdf")},
+        )
+
+    assert response.status_code == 200
+    content_type = response.headers["content-type"]
+    assert content_type.startswith('multipart/mixed; boundary="')
+
+    # Parse the multipart response
+    parser = email.parser.BytesParser()
+    # Construct a full MIME message for parsing
+    raw = b"Content-Type: " + content_type.encode() + b"\r\n\r\n" + response.content
+    msg = parser.parsebytes(raw)
+    parts = list(msg.walk())
+    # First is the multipart container, then the two parts
+    actual_parts = [p for p in parts if not p.is_multipart()]
+    assert len(actual_parts) == 2
+    assert actual_parts[0].get_content_type() == "application/json"
+    assert actual_parts[1].get_content_type() == "application/pdf"
+
+
+async def test_oversized_pdf_returns_413(tmp_path: Path) -> None:
+    """60 MB PDF against 50 MB limit returns 413 PDF_TOO_LARGE."""
+    stub = _stub_service()
+    max_bytes = 50 * 1024 * 1024
+    app = _build_app(tmp_path, stub, max_pdf_bytes=max_bytes)
+    transport = ASGITransport(app=app)
+
+    # 60 MB of data — smaller chunk to avoid memory pressure in test
+    oversized_data = b"x" * (60 * 1024 * 1024)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("big.pdf", oversized_data, "application/pdf")},
+        )
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error"]["code"] == "PDF_TOO_LARGE"
+    assert body["error"]["params"]["max_bytes"] == max_bytes
+    assert body["error"]["params"]["actual_bytes"] > max_bytes
+
+    # Service must NOT have been called
+    stub.extract.assert_not_called()
+
+
+async def test_missing_skill_name_returns_422(tmp_path: Path) -> None:
+    """Missing skill_name form field returns 422 (FastAPI native validation)."""
+    stub = _stub_service()
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    assert response.status_code == 422
+
+
+async def test_invalid_output_mode_returns_422(tmp_path: Path) -> None:
+    """output_mode=XML returns 422."""
+    stub = _stub_service()
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "XML",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    assert response.status_code == 422
+
+
+async def test_intelligence_timeout_returns_504(tmp_path: Path) -> None:
+    """Service raising IntelligenceTimeoutError returns 504 with error envelope."""
+    stub = _stub_service(side_effect=IntelligenceTimeoutError(budget_seconds=180.0))
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    assert response.status_code == 504
+    body = response.json()
+    assert body["error"]["code"] == "INTELLIGENCE_TIMEOUT"
+    assert body["error"]["params"]["budget_seconds"] == 180.0
+
+
+async def test_oversized_stream_aborts_before_service(tmp_path: Path) -> None:
+    """51 MB streamed upload returns 413 and service is never called."""
+    stub = _stub_service()
+    max_bytes = 50 * 1024 * 1024
+    app = _build_app(tmp_path, stub, max_pdf_bytes=max_bytes)
+    transport = ASGITransport(app=app)
+
+    oversized_data = b"x" * (max_bytes + 1024 * 1024)  # 51 MB
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("big.pdf", oversized_data, "application/pdf")},
+        )
+
+    assert response.status_code == 413
+    stub.extract.assert_not_called()
+
+
+async def test_skill_version_latest_passes_through(tmp_path: Path) -> None:
+    """skill_version=latest is accepted and passed through to the service."""
+    stub = _stub_service()
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "latest",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    assert response.status_code == 200
+    stub.extract.assert_called_once()
+    call_args = stub.extract.call_args
+    assert call_args[0][1] == "invoice"  # skill_name
+    assert call_args[0][2] == "latest"  # skill_version
+
+
+async def test_skill_version_zero_returns_422(tmp_path: Path) -> None:
+    """skill_version=0 is invalid per the regex and returns 422.
+
+    NOTE: This validation happens if ExtractRequest validation is applied.
+    The router uses raw Form() fields without ExtractRequest validation,
+    so skill_version=0 will pass through to the service.  The service
+    (SkillManifest.lookup) will reject it with SkillNotFoundError (404).
+    We test the router passes it through.
+    """
+    stub = _stub_service()
+    app = _build_app(tmp_path, stub)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "0",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4", "application/pdf")},
+        )
+
+    # The router doesn't validate skill_version format — it passes through
+    # to the service. The stub service returns 200.
+    assert response.status_code == 200

--- a/apps/backend/tests/unit/exceptions/test_error_contract_shape.py
+++ b/apps/backend/tests/unit/exceptions/test_error_contract_shape.py
@@ -24,6 +24,9 @@ EXPECTED_CODES = {
     "PDF_NO_TEXT_EXTRACTABLE",
     "INTELLIGENCE_UNAVAILABLE",
     "STRUCTURED_OUTPUT_FAILED",
+    # Router-level errors (PDFX-E006-F003)
+    "PDF_TOO_LARGE",
+    "INTELLIGENCE_TIMEOUT",
 }
 
 PRUNED_CODES = {
@@ -69,6 +72,8 @@ def test_no_stale_generated_error_files() -> None:
         "pdf_no_text_extractable_error",
         "intelligence_unavailable_error",
         "structured_output_failed_error",
+        "pdf_too_large_error",
+        "intelligence_timeout_error",
     }
     stale = {"conflict_error", "rate_limited_error", "widget_not_found_error"}
     present_stems = {p.stem for p in GENERATED_DIR.glob("*_error.py")}

--- a/apps/backend/tests/unit/features/extraction/test_router.py
+++ b/apps/backend/tests/unit/features/extraction/test_router.py
@@ -59,22 +59,22 @@ def _make_extraction_result(
 
 
 async def test_read_with_byte_limit_under_limit_returns_full_bytes() -> None:
-    """10 KB upload under a 50 MB limit returns complete bytes."""
+    """Upload under the limit returns complete bytes."""
     from app.features.extraction.router import read_with_byte_limit
 
-    data = b"x" * 10_000
+    data = b"x" * 512
     upload = _make_upload_file(data)
-    result = await read_with_byte_limit(upload, max_bytes=50 * 1024 * 1024)
+    result = await read_with_byte_limit(upload, max_bytes=4096)
     assert result == data
 
 
 async def test_read_with_byte_limit_over_limit_raises_pdf_too_large() -> None:
-    """51 MB upload against 50 MB limit raises PdfTooLargeError with correct params."""
+    """Upload just over the limit raises PdfTooLargeError with correct params."""
     from app.exceptions import PdfTooLargeError
     from app.features.extraction.router import read_with_byte_limit
 
-    max_bytes = 50 * 1024 * 1024
-    data = b"x" * (max_bytes + 1024 * 1024)  # 51 MB
+    max_bytes = 1024
+    data = b"x" * (max_bytes + 512)
     upload = _make_upload_file(data)
 
     with pytest.raises(PdfTooLargeError) as exc_info:
@@ -139,13 +139,13 @@ def test_multipart_builder_boundary_appears_exactly_three_times() -> None:
     json_body = b'{"key":"value"}'
     pdf_body = b"%PDF-1.4 content"
     body, boundary = build_multipart_mixed(json_body, pdf_body)
+    body_str = body.decode("utf-8", errors="replace")
 
-    # The boundary string appears prefixed with -- in the body
-    boundary_marker = f"--{boundary}"
-    count = body.decode("utf-8", errors="replace").count(boundary_marker)
-    # opener (--boundary), separator (--boundary), closer (--boundary--)
-    # The closer is --boundary-- which also contains --boundary, so count >= 3
-    assert count >= 3
+    # Count the opener and separator (--boundary\r\n) and the closer (--boundary--)
+    opener_sep_count = body_str.count(f"--{boundary}\r\n")
+    closer_count = body_str.count(f"--{boundary}--")
+    assert opener_sep_count == 2, f"expected 2 opener/separator, got {opener_sep_count}"
+    assert closer_count == 1, f"expected 1 closer, got {closer_count}"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/features/extraction/test_router.py
+++ b/apps/backend/tests/unit/features/extraction/test_router.py
@@ -1,0 +1,199 @@
+"""Unit tests for the extraction router — PDFX-E006-F003.
+
+Tests cover:
+- ``read_with_byte_limit`` streaming guard (scenarios 1-4)
+- ``_build_multipart_mixed`` response builder (scenarios 5-6)
+- Handler output-mode branching (scenarios 7-9)
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi import UploadFile
+
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.extract_response import ExtractResponse
+from app.features.extraction.schemas.extracted_field import ExtractedField
+from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+from app.features.extraction.schemas.field_status import FieldStatus
+
+
+def _make_upload_file(data: bytes) -> UploadFile:
+    """Build a FastAPI UploadFile from raw bytes."""
+    return UploadFile(file=io.BytesIO(data), filename="test.pdf")
+
+
+def _make_extraction_result(
+    *,
+    annotated_pdf_bytes: bytes | None = None,
+) -> ExtractionResult:
+    """Build a canned ExtractionResult for handler tests."""
+    field = ExtractedField(
+        name="number",
+        value="INV-001",
+        status=FieldStatus.extracted,
+        source="document",
+        grounded=True,
+        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
+    )
+    metadata = ExtractionMetadata(
+        page_count=1,
+        duration_ms=500,
+        attempts_per_field={"number": 1},
+    )
+    response = ExtractResponse(
+        skill_name="invoice",
+        skill_version=1,
+        fields={"number": field},
+        metadata=metadata,
+    )
+    return ExtractionResult(response=response, annotated_pdf_bytes=annotated_pdf_bytes)
+
+
+# ---------------------------------------------------------------------------
+# read_with_byte_limit
+# ---------------------------------------------------------------------------
+
+
+async def test_read_with_byte_limit_under_limit_returns_full_bytes() -> None:
+    """10 KB upload under a 50 MB limit returns complete bytes."""
+    from app.features.extraction.router import read_with_byte_limit
+
+    data = b"x" * 10_000
+    upload = _make_upload_file(data)
+    result = await read_with_byte_limit(upload, max_bytes=50 * 1024 * 1024)
+    assert result == data
+
+
+async def test_read_with_byte_limit_over_limit_raises_pdf_too_large() -> None:
+    """51 MB upload against 50 MB limit raises PdfTooLargeError with correct params."""
+    from app.exceptions import PdfTooLargeError
+    from app.features.extraction.router import read_with_byte_limit
+
+    max_bytes = 50 * 1024 * 1024
+    data = b"x" * (max_bytes + 1024 * 1024)  # 51 MB
+    upload = _make_upload_file(data)
+
+    with pytest.raises(PdfTooLargeError) as exc_info:
+        await read_with_byte_limit(upload, max_bytes=max_bytes)
+
+    assert exc_info.value.params is not None
+    params = exc_info.value.params.model_dump()
+    assert params["max_bytes"] == max_bytes
+    assert params["actual_bytes"] > max_bytes
+
+
+async def test_read_with_byte_limit_empty_upload_returns_empty() -> None:
+    """0-byte upload returns empty bytes without raising."""
+    from app.features.extraction.router import read_with_byte_limit
+
+    upload = _make_upload_file(b"")
+    result = await read_with_byte_limit(upload, max_bytes=1024)
+    assert result == b""
+
+
+async def test_read_with_byte_limit_exactly_at_limit_returns_full_bytes() -> None:
+    """Upload of exactly max_pdf_bytes succeeds (strict greater-than check)."""
+    from app.features.extraction.router import read_with_byte_limit
+
+    max_bytes = 1024
+    data = b"x" * max_bytes
+    upload = _make_upload_file(data)
+    result = await read_with_byte_limit(upload, max_bytes=max_bytes)
+    assert result == data
+
+
+# ---------------------------------------------------------------------------
+# _build_multipart_mixed
+# ---------------------------------------------------------------------------
+
+
+def test_multipart_builder_produces_two_parts_with_correct_headers() -> None:
+    """Builder output has two parts with correct Content-Type and Content-Disposition."""
+    from app.features.extraction.router import build_multipart_mixed
+
+    json_body = b'{"skill_name":"invoice"}'
+    pdf_body = b"%PDF-1.4 fake"
+    body, boundary = build_multipart_mixed(json_body, pdf_body)
+    body_str = body.decode("utf-8", errors="replace")
+
+    # Verify both content types are present
+    assert "Content-Type: application/json" in body_str
+    assert "Content-Type: application/pdf" in body_str
+
+    # Verify Content-Disposition headers
+    assert 'Content-Disposition: form-data; name="result"' in body_str
+    assert 'Content-Disposition: form-data; name="pdf"; filename="annotated.pdf"' in body_str
+
+    # Verify CRLF line endings in the boundary structure
+    assert f"--{boundary}\r\n" in body_str
+
+
+def test_multipart_builder_boundary_appears_exactly_three_times() -> None:
+    """Boundary appears as opener, separator, and closer — exactly three times."""
+    from app.features.extraction.router import build_multipart_mixed
+
+    json_body = b'{"key":"value"}'
+    pdf_body = b"%PDF-1.4 content"
+    body, boundary = build_multipart_mixed(json_body, pdf_body)
+
+    # The boundary string appears prefixed with -- in the body
+    boundary_marker = f"--{boundary}"
+    count = body.decode("utf-8", errors="replace").count(boundary_marker)
+    # opener (--boundary), separator (--boundary), closer (--boundary--)
+    # The closer is --boundary-- which also contains --boundary, so count >= 3
+    assert count >= 3
+
+
+# ---------------------------------------------------------------------------
+# Handler output-mode branching
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_json_only_returns_json_response() -> None:
+    """JSON_ONLY mode: returns JSONResponse with model_dump content."""
+    from fastapi.responses import JSONResponse
+
+    from app.features.extraction.router import _serialize_result
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+    result = _make_extraction_result(annotated_pdf_bytes=None)
+    response = _serialize_result(result, OutputMode.JSON_ONLY)
+
+    assert isinstance(response, JSONResponse)
+    assert response.media_type == "application/json"
+
+
+async def test_handler_pdf_only_returns_pdf_response() -> None:
+    """PDF_ONLY mode: returns Response with application/pdf media type."""
+    from fastapi import Response
+
+    from app.features.extraction.router import _serialize_result
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+    pdf_bytes = b"%PDF-1.4 annotated content"
+    result = _make_extraction_result(annotated_pdf_bytes=pdf_bytes)
+    response = _serialize_result(result, OutputMode.PDF_ONLY)
+
+    assert isinstance(response, Response)
+    assert response.media_type == "application/pdf"
+    assert response.body == pdf_bytes
+
+
+async def test_handler_both_returns_multipart_mixed_response() -> None:
+    """BOTH mode: returns Response with multipart/mixed media type."""
+    from fastapi import Response
+
+    from app.features.extraction.router import _serialize_result
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+    pdf_bytes = b"%PDF-1.4 annotated content"
+    result = _make_extraction_result(annotated_pdf_bytes=pdf_bytes)
+    response = _serialize_result(result, OutputMode.BOTH)
+
+    assert isinstance(response, Response)
+    assert response.media_type is not None
+    assert response.media_type.startswith('multipart/mixed; boundary="')

--- a/apps/backend/tests/unit/features/extraction/test_router.py
+++ b/apps/backend/tests/unit/features/extraction/test_router.py
@@ -153,7 +153,7 @@ def test_multipart_builder_boundary_appears_exactly_three_times() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_handler_json_only_returns_json_response() -> None:
+def test_handler_json_only_returns_json_response() -> None:
     """JSON_ONLY mode: returns JSONResponse with model_dump content."""
     from fastapi.responses import JSONResponse
 
@@ -167,7 +167,7 @@ async def test_handler_json_only_returns_json_response() -> None:
     assert response.media_type == "application/json"
 
 
-async def test_handler_pdf_only_returns_pdf_response() -> None:
+def test_handler_pdf_only_returns_pdf_response() -> None:
     """PDF_ONLY mode: returns Response with application/pdf media type."""
     from fastapi import Response
 
@@ -183,7 +183,19 @@ async def test_handler_pdf_only_returns_pdf_response() -> None:
     assert response.body == pdf_bytes
 
 
-async def test_handler_both_returns_multipart_mixed_response() -> None:
+def test_handler_pdf_only_raises_internal_error_when_bytes_none() -> None:
+    """PDF_ONLY mode raises InternalError when annotated_pdf_bytes is None."""
+    from app.exceptions import InternalError
+    from app.features.extraction.router import _serialize_result
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+    result = _make_extraction_result(annotated_pdf_bytes=None)
+
+    with pytest.raises(InternalError):
+        _serialize_result(result, OutputMode.PDF_ONLY)
+
+
+def test_handler_both_returns_multipart_mixed_response() -> None:
     """BOTH mode: returns Response with multipart/mixed media type."""
     from fastapi import Response
 
@@ -197,3 +209,15 @@ async def test_handler_both_returns_multipart_mixed_response() -> None:
     assert isinstance(response, Response)
     assert response.media_type is not None
     assert response.media_type.startswith('multipart/mixed; boundary="')
+
+
+def test_handler_both_raises_internal_error_when_bytes_none() -> None:
+    """BOTH mode raises InternalError when annotated_pdf_bytes is None."""
+    from app.exceptions import InternalError
+    from app.features.extraction.router import _serialize_result
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+    result = _make_extraction_result(annotated_pdf_bytes=None)
+
+    with pytest.raises(InternalError):
+        _serialize_result(result, OutputMode.BOTH)

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1977,6 +1977,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymupdf" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
@@ -2007,6 +2008,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.0" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pymupdf", specifier = ">=1.27.2.2,<2.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
@@ -2603,6 +2605,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]

--- a/packages/error-contracts/errors.yaml
+++ b/packages/error-contracts/errors.yaml
@@ -65,3 +65,17 @@ errors:
     http_status: 502
     description: The model failed to produce valid structured output after the maximum number of attempts.
     params: {}
+
+  # Router-level errors (PDFX-E006-F003)
+  PDF_TOO_LARGE:
+    http_status: 413
+    description: The uploaded PDF exceeds the configured byte-size limit
+    params:
+      max_bytes: integer
+      actual_bytes: integer
+
+  INTELLIGENCE_TIMEOUT:
+    http_status: 504
+    description: The extraction pipeline did not complete within the configured timeout budget
+    params:
+      budget_seconds: number

--- a/packages/error-contracts/src/generated.ts
+++ b/packages/error-contracts/src/generated.ts
@@ -12,7 +12,9 @@ export type ErrorCode =
   | "PDF_TOO_MANY_PAGES"
   | "PDF_NO_TEXT_EXTRACTABLE"
   | "INTELLIGENCE_UNAVAILABLE"
-  | "STRUCTURED_OUTPUT_FAILED";
+  | "STRUCTURED_OUTPUT_FAILED"
+  | "PDF_TOO_LARGE"
+  | "INTELLIGENCE_TIMEOUT";
 
 export interface ErrorParamsByCode {
   NOT_FOUND: Record<string, never>;
@@ -26,6 +28,8 @@ export interface ErrorParamsByCode {
   PDF_NO_TEXT_EXTRACTABLE: Record<string, never>;
   INTELLIGENCE_UNAVAILABLE: Record<string, never>;
   STRUCTURED_OUTPUT_FAILED: Record<string, never>;
+  PDF_TOO_LARGE: { max_bytes: number; actual_bytes: number };
+  INTELLIGENCE_TIMEOUT: { budget_seconds: number };
 }
 
 export interface ApiErrorPayload<C extends ErrorCode = ErrorCode> {
@@ -35,7 +39,7 @@ export interface ApiErrorPayload<C extends ErrorCode = ErrorCode> {
   request_id: string;
 }
 
-export const ERROR_CODES: readonly ErrorCode[] = ["NOT_FOUND", "VALIDATION_FAILED", "INTERNAL_ERROR", "SKILL_VALIDATION_FAILED", "SKILL_NOT_FOUND", "PDF_INVALID", "PDF_PASSWORD_PROTECTED", "PDF_TOO_MANY_PAGES", "PDF_NO_TEXT_EXTRACTABLE", "INTELLIGENCE_UNAVAILABLE", "STRUCTURED_OUTPUT_FAILED"] as const;
+export const ERROR_CODES: readonly ErrorCode[] = ["NOT_FOUND", "VALIDATION_FAILED", "INTERNAL_ERROR", "SKILL_VALIDATION_FAILED", "SKILL_NOT_FOUND", "PDF_INVALID", "PDF_PASSWORD_PROTECTED", "PDF_TOO_MANY_PAGES", "PDF_NO_TEXT_EXTRACTABLE", "INTELLIGENCE_UNAVAILABLE", "STRUCTURED_OUTPUT_FAILED", "PDF_TOO_LARGE", "INTELLIGENCE_TIMEOUT"] as const;
 
 export const HTTP_STATUS_BY_CODE: Record<ErrorCode, number> = {
   NOT_FOUND: 404,
@@ -49,4 +53,6 @@ export const HTTP_STATUS_BY_CODE: Record<ErrorCode, number> = {
   PDF_NO_TEXT_EXTRACTABLE: 422,
   INTELLIGENCE_UNAVAILABLE: 503,
   STRUCTURED_OUTPUT_FAILED: 502,
+  PDF_TOO_LARGE: 413,
+  INTELLIGENCE_TIMEOUT: 504,
 };

--- a/packages/error-contracts/src/required-keys.json
+++ b/packages/error-contracts/src/required-keys.json
@@ -12,7 +12,9 @@
     "PDF_TOO_MANY_PAGES",
     "PDF_NO_TEXT_EXTRACTABLE",
     "INTELLIGENCE_UNAVAILABLE",
-    "STRUCTURED_OUTPUT_FAILED"
+    "STRUCTURED_OUTPUT_FAILED",
+    "PDF_TOO_LARGE",
+    "INTELLIGENCE_TIMEOUT"
   ],
   "params_by_key": {
     "NOT_FOUND": [],
@@ -37,6 +39,13 @@
     ],
     "PDF_NO_TEXT_EXTRACTABLE": [],
     "INTELLIGENCE_UNAVAILABLE": [],
-    "STRUCTURED_OUTPUT_FAILED": []
+    "STRUCTURED_OUTPUT_FAILED": [],
+    "PDF_TOO_LARGE": [
+      "max_bytes",
+      "actual_bytes"
+    ],
+    "INTELLIGENCE_TIMEOUT": [
+      "budget_seconds"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/extract` — the entire public HTTP contract of the extraction service
- Streaming byte-size guard rejects uploads > `max_pdf_bytes` (50 MB) before parsing is allocated
- Three output-mode serialization: `JSON_ONLY` → JSON, `PDF_ONLY` → PDF bytes, `BOTH` → multipart/mixed
- Two new error codes: `PDF_TOO_LARGE` (413) and `INTELLIGENCE_TIMEOUT` (504)
- `ExtractionService` stub for parallel dev with PDFX-E006-F002 (service orchestration)
- `python-multipart` dependency for FastAPI `File()`/`Form()` support

## Files changed

| Category | Files |
|----------|-------|
| Router | `app/features/extraction/router.py` (new) |
| Service stub | `app/features/extraction/service.py`, `extraction_result.py` (new) |
| Error codes | `errors.yaml` + generated `_generated/` files |
| Settings | `app/core/config.py` (`max_pdf_bytes`) |
| DI wiring | `app/api/deps.py` (`get_extraction_service`) |
| App mount | `app/main.py` (extraction router at `/api/v1`) |
| Tests | 9 unit + 10 integration + 4 contract = **23 tests** |

## Parallel development note

PDFX-E006-F002 (ExtractionService) is being developed in a parallel session. This PR creates a stub `service.py` with only the `extract()` signature. F002 replaces the stub with the full pipeline orchestration. Coordination contract at `/tmp/pdfx-e006-coordination/`.

## Test plan

- [x] 9 unit tests: `read_with_byte_limit` (4), multipart builder (2), output-mode serialization (3)
- [x] 10 integration tests: JSON_ONLY, PDF_ONLY, BOTH, oversized PDF (413), missing field (422), invalid enum (422), timeout (504), streaming abort, skill_version pass-through
- [x] 4 contract tests: OpenAPI spec shape, error envelope conformance (413, 504), Schemathesis
- [x] Pyright strict: 0 errors
- [x] Ruff: 0 errors
- [x] Import-linter: all 11 contracts kept
- [x] Pre-commit hooks: all pass