### PR TITLE
feat(platform): /health liveness + /ready readiness with Ollama probe (PDFX-E007-F001)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 # OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=gemma4:e2b
 OLLAMA_TIMEOUT_SECONDS=30.0
+# Readiness probe TTL in seconds. The /ready endpoint caches probe results
+# for this duration before re-probing Ollama. 0 disables caching (every
+# /ready call probes). Defaults to 10.
+OLLAMA_PROBE_TTL_SECONDS=10.0
 
 # Extraction pipeline (PDFX-E006-F002)
 # End-to-end timeout for the full extraction pipeline in seconds.

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ OLLAMA_TIMEOUT_SECONDS=30.0
 # for this duration before re-probing Ollama. 0 disables caching (every
 # /ready call probes). Defaults to 10.
 OLLAMA_PROBE_TTL_SECONDS=10.0
+# HTTP timeout for the readiness probe against Ollama /api/tags.
+# Separate from OLLAMA_TIMEOUT_SECONDS (which covers /api/generate).
+OLLAMA_PROBE_TIMEOUT_SECONDS=5.0
 
 # Extraction pipeline (PDFX-E006-F002)
 # End-to-end timeout for the full extraction pipeline in seconds.

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -27,9 +27,7 @@ from functools import lru_cache
 
 from fastapi import Request
 
-from app.api.probe_cache import (
-    ProbeCache,  # placed after feature imports for visual grouping
-)
+from app.api.probe_cache import ProbeCache
 from app.core.config import Settings
 
 # Pipeline component imports — these are lightweight classes (no heavy
@@ -156,15 +154,26 @@ def get_extraction_service(request: Request) -> ExtractionService:
 
 
 def get_ollama_health_probe(request: Request) -> OllamaHealthProbe:
-    """Return (and lazily cache) the health probe bound to this app instance."""
+    """Return (and lazily cache) the health probe bound to this app instance.
+
+    The tags URL is built here (reusing ``build_tags_url`` from the
+    provider module) so the probe class does not duplicate the URL
+    construction logic.
+    """
+    from app.features.extraction.intelligence.ollama_gemma_provider import (
+        build_tags_url,
+    )
+
     state = request.app.state
     probe: OllamaHealthProbe | None = getattr(state, "ollama_health_probe", None)
     if probe is None:
         with _dep_init_lock:
             probe = getattr(state, "ollama_health_probe", None)
             if probe is None:
+                settings = get_settings(request)
                 probe = OllamaHealthProbe(
-                    base_url=get_settings(request).ollama_base_url,
+                    tags_url=build_tags_url(settings.ollama_base_url),
+                    timeout_seconds=settings.ollama_probe_timeout_seconds,
                 )
                 state.ollama_health_probe = probe
     return probe

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -43,6 +43,7 @@ from app.features.extraction.intelligence.correction_prompt_builder import (
 )
 from app.features.extraction.intelligence.ollama_gemma_provider import (
     OllamaGemmaProvider,
+    build_tags_url,
 )
 from app.features.extraction.intelligence.ollama_health_probe import (
     OllamaHealthProbe,
@@ -160,10 +161,6 @@ def get_ollama_health_probe(request: Request) -> OllamaHealthProbe:
     provider module) so the probe class does not duplicate the URL
     construction logic.
     """
-    from app.features.extraction.intelligence.ollama_gemma_provider import (
-        build_tags_url,
-    )
-
     state = request.app.state
     probe: OllamaHealthProbe | None = getattr(state, "ollama_health_probe", None)
     if probe is None:

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -27,6 +27,9 @@ from functools import lru_cache
 
 from fastapi import Request
 
+from app.api.probe_cache import (
+    ProbeCache,  # placed after feature imports for visual grouping
+)
 from app.core.config import Settings
 
 # Pipeline component imports — these are lightweight classes (no heavy
@@ -42,6 +45,9 @@ from app.features.extraction.intelligence.correction_prompt_builder import (
 )
 from app.features.extraction.intelligence.ollama_gemma_provider import (
     OllamaGemmaProvider,
+)
+from app.features.extraction.intelligence.ollama_health_probe import (
+    OllamaHealthProbe,
 )
 from app.features.extraction.intelligence.structured_output_validator import (
     StructuredOutputValidator,
@@ -147,3 +153,34 @@ def get_extraction_service(request: Request) -> ExtractionService:
                 )
                 state.extraction_service = service
     return service
+
+
+def get_ollama_health_probe(request: Request) -> OllamaHealthProbe:
+    """Return (and lazily cache) the health probe bound to this app instance."""
+    state = request.app.state
+    probe: OllamaHealthProbe | None = getattr(state, "ollama_health_probe", None)
+    if probe is None:
+        with _dep_init_lock:
+            probe = getattr(state, "ollama_health_probe", None)
+            if probe is None:
+                probe = OllamaHealthProbe(
+                    base_url=get_settings(request).ollama_base_url,
+                )
+                state.ollama_health_probe = probe
+    return probe
+
+
+def get_probe_cache(request: Request) -> ProbeCache:
+    """Return (and lazily cache) the readiness probe cache."""
+    state = request.app.state
+    cache: ProbeCache | None = getattr(state, "probe_cache", None)
+    if cache is None:
+        with _dep_init_lock:
+            cache = getattr(state, "probe_cache", None)
+            if cache is None:
+                cache = ProbeCache(
+                    probe=get_ollama_health_probe(request),
+                    ttl_seconds=get_settings(request).ollama_probe_ttl_seconds,
+                )
+                state.probe_cache = cache
+    return cache

--- a/apps/backend/app/api/health_router.py
+++ b/apps/backend/app/api/health_router.py
@@ -19,7 +19,27 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@router.get("/ready")
+@router.get(
+    "/ready",
+    responses={
+        200: {
+            "description": "Ollama is reachable and the service is ready.",
+            "content": {
+                "application/json": {
+                    "example": {"status": "ready"},
+                },
+            },
+        },
+        503: {
+            "description": "Ollama is unreachable; service is not ready.",
+            "content": {
+                "application/json": {
+                    "example": {"status": "not_ready", "reason": "ollama_unreachable"},
+                },
+            },
+        },
+    },
+)
 async def ready(
     probe_cache: Annotated[ProbeCache, Depends(get_probe_cache)],
 ) -> JSONResponse:

--- a/apps/backend/app/api/health_router.py
+++ b/apps/backend/app/api/health_router.py
@@ -1,6 +1,14 @@
 """Health and readiness endpoints — mounted at root, outside /api/v1/."""
 
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from app.api.deps import get_probe_cache
+from app.api.probe_cache import (
+    ProbeCache,  # runtime: FastAPI resolves Annotated[..., Depends()]
+)
 
 router = APIRouter(tags=["health"])
 
@@ -12,12 +20,17 @@ async def health() -> dict[str, str]:
 
 
 @router.get("/ready")
-async def ready() -> dict[str, str]:
-    """Readiness probe.
+async def ready(
+    probe_cache: Annotated[ProbeCache, Depends(get_probe_cache)],
+) -> JSONResponse:
+    """Readiness probe gated on Ollama reachability.
 
-    v1 minimal stub: returns 200 unconditionally. The feature-dev for
-    PDFX-E007-F001 replaces this with an Ollama-probe-gated readiness
-    check that returns 503 when the configured Ollama base URL is
-    unreachable within a short TTL.
+    Returns 200 if the last Ollama probe succeeded within the TTL window,
+    otherwise 503 with a structured JSON body.
     """
-    return {"status": "ready"}
+    if await probe_cache.is_ready():
+        return JSONResponse(status_code=200, content={"status": "ready"})
+    return JSONResponse(
+        status_code=503,
+        content={"status": "not_ready", "reason": "ollama_unreachable"},
+    )

--- a/apps/backend/app/api/health_router.py
+++ b/apps/backend/app/api/health_router.py
@@ -1,9 +1,10 @@
 """Health and readiness endpoints — mounted at root, outside /api/v1/."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from app.api.deps import get_probe_cache
 from app.api.probe_cache import (
@@ -11,6 +12,15 @@ from app.api.probe_cache import (
 )
 
 router = APIRouter(tags=["health"])
+
+
+class _ReadyResponse(BaseModel):
+    status: Literal["ready"]
+
+
+class _NotReadyResponse(BaseModel):
+    status: Literal["not_ready"]
+    reason: Literal["ollama_unreachable"]
 
 
 @router.get("/health")
@@ -24,19 +34,11 @@ async def health() -> dict[str, str]:
     responses={
         200: {
             "description": "Ollama is reachable and the service is ready.",
-            "content": {
-                "application/json": {
-                    "example": {"status": "ready"},
-                },
-            },
+            "model": _ReadyResponse,
         },
         503: {
             "description": "Ollama is unreachable; service is not ready.",
-            "content": {
-                "application/json": {
-                    "example": {"status": "not_ready", "reason": "ollama_unreachable"},
-                },
-            },
+            "model": _NotReadyResponse,
         },
     },
 )

--- a/apps/backend/app/api/probe_cache.py
+++ b/apps/backend/app/api/probe_cache.py
@@ -34,6 +34,9 @@ class ProbeCache:
         self._ttl = ttl_seconds
         self._last_check_time: float = 0.0
         self._last_result: bool = False
+        # asyncio.Lock() is loop-free at construction since Python 3.10;
+        # it binds to the running loop on first ``await``. Safe to create
+        # here even though the DI factory (``get_probe_cache``) is sync.
         self._lock = asyncio.Lock()
 
     async def is_ready(self) -> bool:

--- a/apps/backend/app/api/probe_cache.py
+++ b/apps/backend/app/api/probe_cache.py
@@ -4,10 +4,14 @@ Single-entry in-process cache. The ``/ready`` handler queries this; if the
 cached result is still within the TTL window it is returned immediately
 (O(1), no network call). Otherwise the underlying ``OllamaHealthProbe`` is
 called, the result is stored, and the timestamp is updated.
+
+An ``asyncio.Lock`` guards the refresh path so concurrent ``/ready`` calls
+at TTL expiry coalesce into a single probe instead of a thundering herd.
 """
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import TYPE_CHECKING
 
@@ -30,12 +34,19 @@ class ProbeCache:
         self._ttl = ttl_seconds
         self._last_check_time: float = 0.0
         self._last_result: bool = False
+        self._lock = asyncio.Lock()
 
     async def is_ready(self) -> bool:
         """Return cached probe result, refreshing if the TTL has expired."""
         now = time.monotonic()
         if self._last_check_time > 0 and (now - self._last_check_time) < self._ttl:
             return self._last_result
-        self._last_result = await self._probe.check()
-        self._last_check_time = time.monotonic()
-        return self._last_result
+        async with self._lock:
+            # Re-check inside the lock: another coroutine may have refreshed
+            # the cache while we were waiting for the lock.
+            now = time.monotonic()
+            if self._last_check_time > 0 and (now - self._last_check_time) < self._ttl:
+                return self._last_result
+            self._last_result = await self._probe.check()
+            self._last_check_time = time.monotonic()
+            return self._last_result

--- a/apps/backend/app/api/probe_cache.py
+++ b/apps/backend/app/api/probe_cache.py
@@ -1,0 +1,41 @@
+"""TTL-cached readiness probe result.
+
+Single-entry in-process cache. The ``/ready`` handler queries this; if the
+cached result is still within the TTL window it is returned immediately
+(O(1), no network call). Otherwise the underlying ``OllamaHealthProbe`` is
+called, the result is stored, and the timestamp is updated.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.features.extraction.intelligence.ollama_health_probe import (
+        OllamaHealthProbe,
+    )
+
+
+class ProbeCache:
+    """TTL-gated cache around an ``OllamaHealthProbe``."""
+
+    def __init__(
+        self,
+        *,
+        probe: OllamaHealthProbe,
+        ttl_seconds: float,
+    ) -> None:
+        self._probe = probe
+        self._ttl = ttl_seconds
+        self._last_check_time: float = 0.0
+        self._last_result: bool = False
+
+    async def is_ready(self) -> bool:
+        """Return cached probe result, refreshing if the TTL has expired."""
+        now = time.monotonic()
+        if self._last_check_time > 0 and (now - self._last_check_time) < self._ttl:
+            return self._last_result
+        self._last_result = await self._probe.check()
+        self._last_check_time = time.monotonic()
+        return self._last_result

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     ollama_model: str = "gemma4:e2b"
     ollama_timeout_seconds: Annotated[float, Field(gt=0)] = 30.0
     ollama_probe_ttl_seconds: Annotated[float, Field(ge=0)] = 10.0
+    ollama_probe_timeout_seconds: Annotated[float, Field(gt=0)] = 5.0
 
     # Extraction pipeline (PDFX-E006-F002)
     extraction_timeout_seconds: Annotated[float, Field(gt=0)] = 180.0

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     ollama_base_url: str = "http://host.docker.internal:11434"
     ollama_model: str = "gemma4:e2b"
     ollama_timeout_seconds: Annotated[float, Field(gt=0)] = 30.0
+    ollama_probe_ttl_seconds: Annotated[float, Field(ge=0)] = 10.0
 
     # Extraction pipeline (PDFX-E006-F002)
     extraction_timeout_seconds: Annotated[float, Field(gt=0)] = 180.0

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -9,11 +9,11 @@ model IDs. The same registered entry point is declared in `pyproject.toml` so
 that fresh LangExtract processes discover the provider via Python's
 `importlib.metadata` entry-points mechanism.
 
-Containment: this is the ONE file in `apps/backend/app/features/extraction/`
-that imports `httpx`. Every other piece of HTTP-to-Ollama knowledge — the URL
-shape `/api/generate`, the `/api/tags` health probe path, the request payload
-schema — lives here and nowhere else. Import-linter contracts land in
-PDFX-E007-F004; until then, two AST-scan unit tests enforce the invariant.
+Containment: this file and ``ollama_health_probe.py`` are the only files in
+``apps/backend/app/features/extraction/`` that import ``httpx`` — authorized
+by the C6 httpx-containment contract in ``import-linter-contracts.ini``.
+The URL builder ``build_tags_url`` lives here and is reused by the probe's
+DI factory so the URL shape is defined once.
 
 Sync/async bridge: LangExtract's orchestration is synchronous, and its
 `BaseLanguageModel.infer` is a sync generator. The provider bridges to our
@@ -68,7 +68,7 @@ def _build_generate_url(base_url: str) -> str:
     return f"{base_url.rstrip('/')}/api/generate"
 
 
-def _build_tags_url(base_url: str) -> str:
+def build_tags_url(base_url: str) -> str:
     return f"{base_url.rstrip('/')}/api/tags"
 
 
@@ -117,7 +117,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
         )
         self._model = model_id or effective_settings.ollama_model
         self._generate_url = _build_generate_url(effective_settings.ollama_base_url)
-        self._tags_url = _build_tags_url(effective_settings.ollama_base_url)
+        self._tags_url = build_tags_url(effective_settings.ollama_base_url)
         self._validator = effective_validator
         self.http_client = http_client or httpx.AsyncClient(
             timeout=httpx.Timeout(effective_settings.ollama_timeout_seconds),

--- a/apps/backend/app/features/extraction/intelligence/ollama_health_probe.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_health_probe.py
@@ -13,30 +13,28 @@ import structlog
 
 _logger = structlog.get_logger(__name__)
 
-_PROBE_TIMEOUT_SECONDS = 5.0
-
-
-def _build_tags_url(base_url: str) -> str:
-    return f"{base_url.rstrip('/')}/api/tags"
+_DEFAULT_PROBE_TIMEOUT_SECONDS = 5.0
 
 
 class OllamaHealthProbe:
     """Lightweight probe that checks Ollama reachability.
 
-    Constructed with a base URL and an optional pre-built ``httpx.AsyncClient``
-    (test seam). If no client is provided, one is created with a short timeout
-    so a hung Ollama does not back up the readiness check.
+    Constructed with the full tags URL (built by the caller in the DI
+    factory) and an optional pre-built ``httpx.AsyncClient`` (test seam).
+    If no client is provided, one is created with a short timeout so a
+    hung Ollama does not back up the readiness check.
     """
 
     def __init__(
         self,
         *,
-        base_url: str,
+        tags_url: str,
+        timeout_seconds: float = _DEFAULT_PROBE_TIMEOUT_SECONDS,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._tags_url = _build_tags_url(base_url)
+        self._tags_url = tags_url
         self._http_client = http_client or httpx.AsyncClient(
-            timeout=httpx.Timeout(_PROBE_TIMEOUT_SECONDS),
+            timeout=httpx.Timeout(timeout_seconds),
         )
 
     async def check(self) -> bool:
@@ -44,8 +42,8 @@ class OllamaHealthProbe:
         try:
             response = await self._http_client.get(self._tags_url)
             response.raise_for_status()
-        except (httpx.RequestError, httpx.HTTPStatusError):
-            _logger.debug("ollama_probe_failed", url=self._tags_url)
+        except httpx.HTTPError:
+            _logger.debug("ollama_probe_failed", url=self._tags_url, exc_info=True)
             return False
         return True
 

--- a/apps/backend/app/features/extraction/intelligence/ollama_health_probe.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_health_probe.py
@@ -44,7 +44,7 @@ class OllamaHealthProbe:
         try:
             response = await self._http_client.get(self._tags_url)
             response.raise_for_status()
-        except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
+        except (httpx.RequestError, httpx.HTTPStatusError):
             _logger.debug("ollama_probe_failed", url=self._tags_url)
             return False
         return True

--- a/apps/backend/app/features/extraction/intelligence/ollama_health_probe.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_health_probe.py
@@ -1,0 +1,54 @@
+"""Ollama readiness probe for the /ready endpoint.
+
+Pings Ollama's ``/api/tags`` endpoint and returns a boolean signal.
+This is the second file (alongside ``ollama_gemma_provider.py``) that is
+pre-authorized to import ``httpx`` within the extraction feature — see
+the C6 httpx-containment contract in ``import-linter-contracts.ini``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import structlog
+
+_logger = structlog.get_logger(__name__)
+
+_PROBE_TIMEOUT_SECONDS = 5.0
+
+
+def _build_tags_url(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/api/tags"
+
+
+class OllamaHealthProbe:
+    """Lightweight probe that checks Ollama reachability.
+
+    Constructed with a base URL and an optional pre-built ``httpx.AsyncClient``
+    (test seam). If no client is provided, one is created with a short timeout
+    so a hung Ollama does not back up the readiness check.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._tags_url = _build_tags_url(base_url)
+        self._http_client = http_client or httpx.AsyncClient(
+            timeout=httpx.Timeout(_PROBE_TIMEOUT_SECONDS),
+        )
+
+    async def check(self) -> bool:
+        """Ping ``/api/tags``. Return True on 200, False on any failure."""
+        try:
+            response = await self._http_client.get(self._tags_url)
+            response.raise_for_status()
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
+            _logger.debug("ollama_probe_failed", url=self._tags_url)
+            return False
+        return True
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._http_client.aclose()

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -32,6 +32,11 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         # builds and caches it on `app.state`, so presence of the attribute
         # is the signal — no need to instantiate an `httpx.AsyncClient` just
         # to close it immediately.
+        probe = getattr(app.state, "ollama_health_probe", None)
+        if probe is not None:
+            await probe.aclose()
+            del app.state.ollama_health_probe
+
         provider = getattr(app.state, "intelligence_provider", None)
         if provider is not None:
             await provider.aclose()

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -27,20 +27,24 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     try:
         yield
     finally:
-        # Only close the provider if something actually constructed one during
-        # the app's lifetime. The `get_intelligence_provider` dep lazily
-        # builds and caches it on `app.state`, so presence of the attribute
-        # is the signal — no need to instantiate an `httpx.AsyncClient` just
-        # to close it immediately.
-        probe = getattr(app.state, "ollama_health_probe", None)
-        if probe is not None:
-            await probe.aclose()
-            del app.state.ollama_health_probe
-
-        provider = getattr(app.state, "intelligence_provider", None)
-        if provider is not None:
-            await provider.aclose()
-            del app.state.intelligence_provider
+        # Close each lazily-constructed resource independently. Each cleanup
+        # is wrapped in its own try/except so a failure in one does not
+        # prevent the others from running (e.g. probe.aclose() raising must
+        # not skip provider.aclose()).
+        #
+        # The probe_cache is also cleared because it holds a reference to the
+        # probe's (now-closed) httpx client. Without clearing it, a reused
+        # app instance would serve a stale cache backed by a closed client.
+        for attr in ("ollama_health_probe", "probe_cache", "intelligence_provider"):
+            obj = getattr(app.state, attr, None)
+            if obj is not None:
+                try:
+                    if hasattr(obj, "aclose"):
+                        await obj.aclose()
+                except (OSError, RuntimeError):
+                    _logger.warning("lifespan_cleanup_failed", attr=attr, exc_info=True)
+                finally:
+                    delattr(app.state, attr)
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -96,10 +100,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     application.state.skill_manifest = SkillManifest(loaded)
 
     application.include_router(health_router)
-    # ExtractionService is a stub until PDFX-E006-F002 merges.  Requests
-    # that reach the stub hit the catch-all handler and return 500
-    # INTERNAL_ERROR, which is correct "not implemented yet" behaviour.
-    # F002 MUST merge before (or together with) this branch.
     application.include_router(extraction_router, prefix="/api/v1")
 
     return application

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -41,7 +41,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 try:
                     if hasattr(obj, "aclose"):
                         await obj.aclose()
-                except (OSError, RuntimeError):
+                except Exception:  # noqa: BLE001 - cleanup must not prevent sibling resources from closing
                     _logger.warning("lifespan_cleanup_failed", attr=attr, exc_info=True)
                 finally:
                     delattr(app.state, attr)

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared test fixtures and fakes used across unit and integration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class FakeProbe:
+    """Controllable probe returning scripted boolean results.
+
+    Used by both unit tests (``test_probe_cache``) and integration tests
+    (``test_health``) to stub ``OllamaHealthProbe.check()`` without a
+    real Ollama instance.
+    """
+
+    def __init__(self, results: list[bool]) -> None:
+        self._results = list(results)
+        self.call_count = 0
+
+    async def check(self) -> bool:
+        if self.call_count >= len(self._results):
+            pytest.fail(
+                f"FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
+            )
+        result = self._results[self.call_count]
+        self.call_count += 1
+        return result

--- a/apps/backend/tests/integration/test_health.py
+++ b/apps/backend/tests/integration/test_health.py
@@ -1,9 +1,54 @@
-"""Integration tests for health, readiness, middleware, and CORS."""
+"""Integration tests for health, readiness, middleware, and CORS.
+
+The /ready endpoint is gated on a TTL-cached Ollama probe (PDFX-E007-F001).
+These tests override the ``get_probe_cache`` dependency to inject a
+controllable ``ProbeCache`` with a fake probe, so no real Ollama is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.api.deps import get_probe_cache
+from app.api.probe_cache import ProbeCache
 from app.main import app
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeProbe:
+    """Controllable probe returning scripted boolean results."""
+
+    def __init__(self, results: list[bool]) -> None:
+        self._results = list(results)
+        self.call_count = 0
+
+    async def check(self) -> bool:
+        self.call_count += 1
+        return self._results[self.call_count - 1]
+
+
+def _make_cache(
+    results: list[bool],
+    ttl: float = 60.0,
+) -> tuple[ProbeCache, _FakeProbe]:
+    probe = _FakeProbe(results=results)
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=ttl,
+    )
+    return cache, probe
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -14,6 +59,11 @@ async def client() -> AsyncClient:
         yield ac
 
 
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+
 async def test_health_returns_200(client: AsyncClient) -> None:
     """GET /health should return 200 with status ok."""
     response = await client.get("/health")
@@ -21,15 +71,114 @@ async def test_health_returns_200(client: AsyncClient) -> None:
     assert response.json() == {"status": "ok"}
 
 
-async def test_ready_returns_200(client: AsyncClient) -> None:
-    """GET /ready returns 200 in the minimal shell.
+# ---------------------------------------------------------------------------
+# /ready — probe returning True
+# ---------------------------------------------------------------------------
 
-    The Ollama-probe-aware readiness logic lands in feature-dev for PDFX-E007-F001;
-    at the post-bootstrap stage the endpoint is a simple stub.
-    """
-    response = await client.get("/ready")
+
+async def test_ready_returns_200_when_probe_ok(client: AsyncClient) -> None:
+    """GET /ready returns 200 when the Ollama probe succeeds."""
+    cache, _probe = _make_cache(results=[True])
+    app.dependency_overrides[get_probe_cache] = lambda: cache
+    try:
+        response = await client.get("/ready")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ready"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# /ready — probe returning False
+# ---------------------------------------------------------------------------
+
+
+async def test_ready_returns_503_when_probe_fails(client: AsyncClient) -> None:
+    """GET /ready returns 503 when the Ollama probe fails."""
+    cache, _probe = _make_cache(results=[False])
+    app.dependency_overrides[get_probe_cache] = lambda: cache
+    try:
+        response = await client.get("/ready")
+        assert response.status_code == 503
+        body: dict[str, Any] = response.json()
+        assert body["status"] == "not_ready"
+        assert body["reason"] == "ollama_unreachable"
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_ready_503_has_json_content_type(client: AsyncClient) -> None:
+    """The 503 response must be structured JSON, not a bare status code."""
+    cache, _probe = _make_cache(results=[False])
+    app.dependency_overrides[get_probe_cache] = lambda: cache
+    try:
+        response = await client.get("/ready")
+        assert response.status_code == 503
+        assert response.headers["content-type"] == "application/json"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# /ready — TTL caching
+# ---------------------------------------------------------------------------
+
+
+async def test_ready_caches_probe_within_ttl(client: AsyncClient) -> None:
+    """Two /ready calls within the TTL should trigger the probe only once."""
+    cache, probe = _make_cache(results=[True], ttl=60.0)
+    app.dependency_overrides[get_probe_cache] = lambda: cache
+    try:
+        await client.get("/ready")
+        await client.get("/ready")
+        assert probe.call_count == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_ready_ttl_flip_true_to_false(client: AsyncClient) -> None:
+    """Probe flips True→False: cached True is served until TTL expires."""
+    cache, probe = _make_cache(results=[True, False], ttl=0.05)
+    app.dependency_overrides[get_probe_cache] = lambda: cache
+    try:
+        # First call: probe returns True → 200
+        r1 = await client.get("/ready")
+        assert r1.status_code == 200
+
+        # Immediately after: still cached True → 200
+        r2 = await client.get("/ready")
+        assert r2.status_code == 200
+        assert probe.call_count == 1
+
+        # Wait for TTL expiry, then call again: probe returns False → 503
+        await asyncio.sleep(0.06)
+        r3 = await client.get("/ready")
+        assert r3.status_code == 503
+        assert probe.call_count == 2
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI
+# ---------------------------------------------------------------------------
+
+
+async def test_openapi_includes_health_and_ready(client: AsyncClient) -> None:
+    """OpenAPI doc must include both /health and /ready operations."""
+    response = await client.get("/openapi.json")
     assert response.status_code == 200
-    assert response.json() == {"status": "ready"}
+    spec: dict[str, Any] = response.json()
+    paths = spec.get("paths", {})
+    assert "/health" in paths, f"/health missing from OpenAPI paths: {list(paths)}"
+    assert "/ready" in paths, f"/ready missing from OpenAPI paths: {list(paths)}"
+    assert "get" in paths["/health"]
+    assert "get" in paths["/ready"]
+
+
+# ---------------------------------------------------------------------------
+# Middleware (preserved from original)
+# ---------------------------------------------------------------------------
 
 
 async def test_response_includes_x_request_id(client: AsyncClient) -> None:

--- a/apps/backend/tests/integration/test_health.py
+++ b/apps/backend/tests/integration/test_health.py
@@ -2,7 +2,7 @@
 
 The /ready endpoint is gated on a TTL-cached Ollama probe (PDFX-E007-F001).
 These tests override the ``get_probe_cache`` dependency to inject a
-controllable ``ProbeCache`` with a fake probe, so no real Ollama is needed.
+controllable ``ProbeCache`` with a ``FakeProbe``, so no real Ollama is needed.
 """
 
 from __future__ import annotations
@@ -16,34 +16,18 @@ from httpx import ASGITransport, AsyncClient
 from app.api.deps import get_probe_cache
 from app.api.probe_cache import ProbeCache
 from app.main import app
+from tests.conftest import FakeProbe
 
 # ---------------------------------------------------------------------------
-# Fakes
+# Helpers
 # ---------------------------------------------------------------------------
-
-
-class _FakeProbe:
-    """Controllable probe returning scripted boolean results."""
-
-    def __init__(self, results: list[bool]) -> None:
-        self._results = list(results)
-        self.call_count = 0
-
-    async def check(self) -> bool:
-        if self.call_count >= len(self._results):
-            pytest.fail(
-                f"_FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
-            )
-        result = self._results[self.call_count]
-        self.call_count += 1
-        return result
 
 
 def _make_cache(
     results: list[bool],
     ttl: float = 60.0,
-) -> tuple[ProbeCache, _FakeProbe]:
-    probe = _FakeProbe(results=results)
+) -> tuple[ProbeCache, FakeProbe]:
+    probe = FakeProbe(results=results)
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=ttl,
@@ -179,6 +163,16 @@ async def test_openapi_includes_health_and_ready(client: AsyncClient) -> None:
     assert "/ready" in paths, f"/ready missing from OpenAPI paths: {list(paths)}"
     assert "get" in paths["/health"]
     assert "get" in paths["/ready"]
+
+
+async def test_openapi_ready_documents_503(client: AsyncClient) -> None:
+    """OpenAPI spec must declare the 503 response for /ready."""
+    response = await client.get("/openapi.json")
+    spec: dict[str, Any] = response.json()
+    ready_responses = spec["paths"]["/ready"]["get"]["responses"]
+    assert "503" in ready_responses, (
+        f"/ready missing 503 in OpenAPI responses: {list(ready_responses)}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/integration/test_health.py
+++ b/apps/backend/tests/integration/test_health.py
@@ -30,8 +30,13 @@ class _FakeProbe:
         self.call_count = 0
 
     async def check(self) -> bool:
+        if self.call_count >= len(self._results):
+            pytest.fail(
+                f"_FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
+            )
+        result = self._results[self.call_count]
         self.call_count += 1
-        return self._results[self.call_count - 1]
+        return result
 
 
 def _make_cache(

--- a/apps/backend/tests/integration/test_skill_manifest_startup.py
+++ b/apps/backend/tests/integration/test_skill_manifest_startup.py
@@ -7,6 +7,8 @@ import pytest
 import yaml
 from httpx import ASGITransport, AsyncClient
 
+from app.api.deps import get_probe_cache
+from app.api.probe_cache import ProbeCache
 from app.core.config import Settings
 from app.exceptions import SkillValidationFailedError
 from app.features.extraction.skills import SkillManifest
@@ -58,10 +60,20 @@ async def test_ready_still_returns_200_after_manifest_wiring(tmp_path: Path) -> 
     _write_skill(tmp_path, dir_name="invoice", file_name="1.yaml", version=1)
     app = create_app(_settings_with_skills(tmp_path))
 
+    # /ready is now gated on an Ollama probe (PDFX-E007-F001).  Override the
+    # probe-cache dependency so this test stays isolated from real Ollama.
+    class _AlwaysReady:
+        async def check(self) -> bool:
+            return True
+
+    cache = ProbeCache(probe=_AlwaysReady(), ttl_seconds=60.0)  # type: ignore[arg-type]  # test seam
+    app.dependency_overrides[get_probe_cache] = lambda: cache
+
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/ready")
 
+    app.dependency_overrides.clear()
     assert response.status_code == 200
 
 

--- a/apps/backend/tests/integration/test_skill_manifest_startup.py
+++ b/apps/backend/tests/integration/test_skill_manifest_startup.py
@@ -13,6 +13,7 @@ from app.core.config import Settings
 from app.exceptions import SkillValidationFailedError
 from app.features.extraction.skills import SkillManifest
 from app.main import create_app
+from tests.conftest import FakeProbe
 
 
 def _write_skill(base: Path, *, dir_name: str, **overrides: Any) -> Path:
@@ -62,11 +63,7 @@ async def test_ready_still_returns_200_after_manifest_wiring(tmp_path: Path) -> 
 
     # /ready is now gated on an Ollama probe (PDFX-E007-F001).  Override the
     # probe-cache dependency so this test stays isolated from real Ollama.
-    class _AlwaysReady:
-        async def check(self) -> bool:
-            return True
-
-    cache = ProbeCache(probe=_AlwaysReady(), ttl_seconds=60.0)  # type: ignore[arg-type]  # test seam
+    cache = ProbeCache(probe=FakeProbe(results=[True]), ttl_seconds=60.0)  # type: ignore[arg-type]  # test seam
     app.dependency_overrides[get_probe_cache] = lambda: cache
 
     transport = ASGITransport(app=app)

--- a/apps/backend/tests/unit/api/test_health_router.py
+++ b/apps/backend/tests/unit/api/test_health_router.py
@@ -1,0 +1,58 @@
+"""Unit tests for health_router handler logic.
+
+These test the handler return values directly, without the HTTP stack.
+Integration tests (in tests/integration/test_health.py) cover the full
+ASGI round-trip.
+"""
+
+from __future__ import annotations
+
+from app.api.health_router import health, ready
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeProbeCache:
+    """Minimal ProbeCache stub returning a fixed ``is_ready`` result."""
+
+    def __init__(self, *, ready: bool) -> None:
+        self._ready = ready
+
+    async def is_ready(self) -> bool:
+        return self._ready
+
+
+# ---------------------------------------------------------------------------
+# /health tests
+# ---------------------------------------------------------------------------
+
+
+async def test_health_returns_ok() -> None:
+    result = await health()
+    assert result == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# /ready tests
+# ---------------------------------------------------------------------------
+
+
+async def test_ready_returns_200_when_probe_cache_ready() -> None:
+    cache = _FakeProbeCache(ready=True)
+    response = await ready(
+        probe_cache=cache,  # type: ignore[arg-type]  # test seam
+    )
+    assert response.status_code == 200
+    assert response.body == b'{"status":"ready"}'
+
+
+async def test_ready_returns_503_when_probe_cache_not_ready() -> None:
+    cache = _FakeProbeCache(ready=False)
+    response = await ready(
+        probe_cache=cache,  # type: ignore[arg-type]  # test seam
+    )
+    assert response.status_code == 503
+    assert b'"not_ready"' in response.body
+    assert b'"ollama_unreachable"' in response.body

--- a/apps/backend/tests/unit/api/test_probe_cache.py
+++ b/apps/backend/tests/unit/api/test_probe_cache.py
@@ -1,0 +1,126 @@
+"""Unit tests for ProbeCache — TTL-cached readiness probe result."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.api.probe_cache import ProbeCache
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeProbe:
+    """Records ``check()`` calls and returns scripted results."""
+
+    def __init__(self, results: list[bool]) -> None:
+        self._results = list(results)
+        self.call_count = 0
+
+    async def check(self) -> bool:
+        self.call_count += 1
+        return self._results[self.call_count - 1]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_first_call_triggers_probe() -> None:
+    probe = _FakeProbe(results=[True])
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=5.0,
+    )
+
+    result = await cache.is_ready()
+
+    assert result is True
+    assert probe.call_count == 1
+
+
+async def test_second_call_within_ttl_returns_cached() -> None:
+    probe = _FakeProbe(results=[True])
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=5.0,
+    )
+
+    await cache.is_ready()
+    result = await cache.is_ready()
+
+    assert result is True
+    assert probe.call_count == 1
+
+
+async def test_call_after_ttl_expiry_reprobes() -> None:
+    probe = _FakeProbe(results=[True, False])
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=0.05,
+    )
+
+    first = await cache.is_ready()
+    await asyncio.sleep(0.06)
+    second = await cache.is_ready()
+
+    assert first is True
+    assert second is False
+    assert probe.call_count == 2
+
+
+async def test_stale_true_served_within_ttl_after_probe_flips() -> None:
+    probe = _FakeProbe(results=[True, False])
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=5.0,
+    )
+
+    first = await cache.is_ready()
+    # Probe would now return False, but TTL hasn't expired
+    second = await cache.is_ready()
+
+    assert first is True
+    assert second is True  # stale cached result
+    assert probe.call_count == 1
+
+
+async def test_stale_flips_after_ttl_expires() -> None:
+    probe = _FakeProbe(results=[True, False])
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=0.05,
+    )
+
+    first = await cache.is_ready()
+    assert first is True
+
+    await asyncio.sleep(0.06)
+    second = await cache.is_ready()
+
+    assert second is False
+    assert probe.call_count == 2
+
+
+async def test_zero_ttl_always_reprobes() -> None:
+    probe = _FakeProbe(results=[True, True])
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=0.0,
+    )
+
+    await cache.is_ready()
+    await cache.is_ready()
+
+    assert probe.call_count == 2
+
+
+async def test_settings_default_ttl() -> None:
+    from app.core.config import Settings
+
+    settings = Settings(
+        skills_dir="/tmp/fake",  # noqa: S108 - test fixture path
+    )
+    assert settings.ollama_probe_ttl_seconds == 10.0

--- a/apps/backend/tests/unit/api/test_probe_cache.py
+++ b/apps/backend/tests/unit/api/test_probe_cache.py
@@ -4,31 +4,8 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from app.api.probe_cache import ProbeCache
-
-# ---------------------------------------------------------------------------
-# Fakes
-# ---------------------------------------------------------------------------
-
-
-class _FakeProbe:
-    """Records ``check()`` calls and returns scripted results."""
-
-    def __init__(self, results: list[bool]) -> None:
-        self._results = list(results)
-        self.call_count = 0
-
-    async def check(self) -> bool:
-        if self.call_count >= len(self._results):
-            pytest.fail(
-                f"_FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
-            )
-        result = self._results[self.call_count]
-        self.call_count += 1
-        return result
-
+from tests.conftest import FakeProbe
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -36,7 +13,7 @@ class _FakeProbe:
 
 
 async def test_first_call_triggers_probe() -> None:
-    probe = _FakeProbe(results=[True])
+    probe = FakeProbe(results=[True])
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=5.0,
@@ -49,7 +26,7 @@ async def test_first_call_triggers_probe() -> None:
 
 
 async def test_second_call_within_ttl_returns_cached() -> None:
-    probe = _FakeProbe(results=[True])
+    probe = FakeProbe(results=[True])
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=5.0,
@@ -63,7 +40,7 @@ async def test_second_call_within_ttl_returns_cached() -> None:
 
 
 async def test_call_after_ttl_expiry_reprobes() -> None:
-    probe = _FakeProbe(results=[True, False])
+    probe = FakeProbe(results=[True, False])
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=0.05,
@@ -79,7 +56,7 @@ async def test_call_after_ttl_expiry_reprobes() -> None:
 
 
 async def test_stale_true_served_within_ttl_after_probe_flips() -> None:
-    probe = _FakeProbe(results=[True, False])
+    probe = FakeProbe(results=[True, False])
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=5.0,
@@ -95,7 +72,7 @@ async def test_stale_true_served_within_ttl_after_probe_flips() -> None:
 
 
 async def test_stale_flips_after_ttl_expires() -> None:
-    probe = _FakeProbe(results=[True, False])
+    probe = FakeProbe(results=[True, False])
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=0.05,
@@ -112,7 +89,7 @@ async def test_stale_flips_after_ttl_expires() -> None:
 
 
 async def test_zero_ttl_always_reprobes() -> None:
-    probe = _FakeProbe(results=[True, True])
+    probe = FakeProbe(results=[True, True])
     cache = ProbeCache(
         probe=probe,  # type: ignore[arg-type]  # test seam
         ttl_seconds=0.0,
@@ -122,12 +99,3 @@ async def test_zero_ttl_always_reprobes() -> None:
     await cache.is_ready()
 
     assert probe.call_count == 2
-
-
-async def test_settings_default_ttl() -> None:
-    from app.core.config import Settings
-
-    settings = Settings(
-        skills_dir="/tmp/fake",  # noqa: S108 - test fixture path
-    )
-    assert settings.ollama_probe_ttl_seconds == 10.0

--- a/apps/backend/tests/unit/api/test_probe_cache.py
+++ b/apps/backend/tests/unit/api/test_probe_cache.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from app.api.probe_cache import ProbeCache
 
 # ---------------------------------------------------------------------------
@@ -19,8 +21,13 @@ class _FakeProbe:
         self.call_count = 0
 
     async def check(self) -> bool:
+        if self.call_count >= len(self._results):
+            pytest.fail(
+                f"_FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
+            )
+        result = self._results[self.call_count]
         self.call_count += 1
-        return self._results[self.call_count - 1]
+        return result
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/core/test_config.py
+++ b/apps/backend/tests/unit/core/test_config.py
@@ -41,3 +41,15 @@ def test_settings_redaction_overrides() -> None:
     s = Settings(log_max_value_length=42, log_redacted_keys=["secret", "token"])
     assert s.log_max_value_length == 42
     assert s.log_redacted_keys == ["secret", "token"]
+
+
+def test_settings_ollama_probe_ttl_default() -> None:
+    """ollama_probe_ttl_seconds defaults to 10.0."""
+    s = Settings()
+    assert s.ollama_probe_ttl_seconds == 10.0
+
+
+def test_settings_ollama_probe_timeout_default() -> None:
+    """ollama_probe_timeout_seconds defaults to 5.0."""
+    s = Settings()
+    assert s.ollama_probe_timeout_seconds == 5.0

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_httpx_import_containment.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_httpx_import_containment.py
@@ -1,10 +1,11 @@
-"""Static AST scan: httpx imports must be contained to ollama_gemma_provider.py.
+"""Static AST scan: httpx imports must be contained to allowed files.
 
-The dual-interface provider is the ONE file in the extraction feature allowed
-to know about HTTP clients. PDFX-E007-F004 will later add an import-linter
-contract that enforces this mechanically; until then, this AST scan is the
-enforcement mechanism. Any new file under `app/features/extraction/` that
-imports `httpx` fails this test.
+Two files in the extraction feature are authorized to import httpx:
+  1. ``ollama_gemma_provider.py`` — the dual-interface Ollama provider.
+  2. ``ollama_health_probe.py`` — the readiness probe (PDFX-E007-F001).
+
+PDFX-E007-F004 adds an import-linter contract (C6) that enforces this
+mechanically; this AST scan is the complementary enforcement mechanism.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ _EXTRACTION_ROOT = Path(__file__).resolve().parents[5] / "app" / "features" / "e
 _ALLOWED_FILES = frozenset(
     {
         "ollama_gemma_provider.py",
+        "ollama_health_probe.py",
     },
 )
 

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_health_probe.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_health_probe.py
@@ -22,25 +22,20 @@ from app.features.extraction.intelligence.ollama_health_probe import (
 
 
 class _FakeResponse:
-    """Minimal response stub that supports ``raise_for_status``."""
+    """Minimal response stub — only ``raise_for_status`` is called by the probe."""
 
     def __init__(
         self,
         *,
         status_code: int = 200,
-        body: dict[str, Any] | None = None,
         status_error: httpx.HTTPStatusError | None = None,
     ) -> None:
         self.status_code = status_code
-        self._body = body or {}
         self._status_error = status_error
 
     def raise_for_status(self) -> None:
         if self._status_error is not None:
             raise self._status_error
-
-    def json(self) -> dict[str, Any]:
-        return self._body
 
 
 class _FakeAsyncClient:
@@ -78,10 +73,10 @@ def _http_status_error(status: int) -> httpx.HTTPStatusError:
 def _build_probe(
     fake_client: _FakeAsyncClient,
     *,
-    base_url: str = "http://host.docker.internal:11434",
+    tags_url: str = "http://host.docker.internal:11434/api/tags",
 ) -> OllamaHealthProbe:
     return OllamaHealthProbe(
-        base_url=base_url,
+        tags_url=tags_url,
         http_client=fake_client,  # type: ignore[arg-type]  # test seam: FakeAsyncClient quacks like httpx.AsyncClient
     )
 
@@ -92,7 +87,7 @@ def _build_probe(
 
 
 async def test_check_returns_true_on_200() -> None:
-    fake = _FakeAsyncClient(get_outcomes=[_FakeResponse(body={"models": []})])
+    fake = _FakeAsyncClient(get_outcomes=[_FakeResponse()])
     probe = _build_probe(fake)
 
     assert await probe.check() is True

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_health_probe.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_health_probe.py
@@ -1,0 +1,135 @@
+"""Unit tests for OllamaHealthProbe — the readiness probe for /ready.
+
+Hand-written fake client in the same style as test_ollama_gemma_provider.py:
+no unittest.mock, no pytest-mock. Each scripted response is a _FakeResponse
+instance or an exception to be raised when ``get`` is awaited.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from app.features.extraction.intelligence.ollama_health_probe import (
+    OllamaHealthProbe,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal response stub that supports ``raise_for_status``."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        body: dict[str, Any] | None = None,
+        status_error: httpx.HTTPStatusError | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+        self._status_error = status_error
+
+    def raise_for_status(self) -> None:
+        if self._status_error is not None:
+            raise self._status_error
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _FakeAsyncClient:
+    """Records ``get`` calls and replays scripted outcomes."""
+
+    def __init__(
+        self,
+        get_outcomes: list[_FakeResponse | BaseException],
+    ) -> None:
+        self._get_outcomes = list(get_outcomes)
+        self.get_calls: list[str] = []
+        self.aclose_calls = 0
+
+    async def get(self, url: str, **_kwargs: Any) -> _FakeResponse:
+        self.get_calls.append(url)
+        if not self._get_outcomes:
+            pytest.fail("_FakeAsyncClient.get called more times than scripted")
+        outcome = self._get_outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    return httpx.HTTPStatusError(
+        message=f"Server error {status}",
+        request=httpx.Request("GET", "http://test/api/tags"),
+        response=httpx.Response(status),
+    )
+
+
+def _build_probe(
+    fake_client: _FakeAsyncClient,
+    *,
+    base_url: str = "http://host.docker.internal:11434",
+) -> OllamaHealthProbe:
+    return OllamaHealthProbe(
+        base_url=base_url,
+        http_client=fake_client,  # type: ignore[arg-type]  # test seam: FakeAsyncClient quacks like httpx.AsyncClient
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_check_returns_true_on_200() -> None:
+    fake = _FakeAsyncClient(get_outcomes=[_FakeResponse(body={"models": []})])
+    probe = _build_probe(fake)
+
+    assert await probe.check() is True
+    assert fake.get_calls == ["http://host.docker.internal:11434/api/tags"]
+
+
+async def test_check_returns_false_on_connect_error() -> None:
+    fake = _FakeAsyncClient(get_outcomes=[httpx.ConnectError("refused")])
+    probe = _build_probe(fake)
+
+    assert await probe.check() is False
+
+
+async def test_check_returns_false_on_http_500() -> None:
+    fake = _FakeAsyncClient(
+        get_outcomes=[
+            _FakeResponse(status_code=500, status_error=_http_status_error(500)),
+        ],
+    )
+    probe = _build_probe(fake)
+
+    assert await probe.check() is False
+
+
+async def test_check_returns_false_on_timeout() -> None:
+    fake = _FakeAsyncClient(
+        get_outcomes=[httpx.TimeoutException("deadline exceeded")],
+    )
+    probe = _build_probe(fake)
+
+    assert await probe.check() is False
+
+
+async def test_aclose_closes_underlying_client() -> None:
+    fake = _FakeAsyncClient(get_outcomes=[])
+    probe = _build_probe(fake)
+
+    await probe.aclose()
+
+    assert fake.aclose_calls == 1

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -43,9 +43,10 @@ The post-bootstrap shell ships three generic error codes (`NOT_FOUND`,
 feature-dev lands the corresponding features.
 
 **Health endpoints.** `/health` is a pure liveness probe returning
-`{"status":"ok"}`. `/ready` is a minimal stub returning `{"status":"ready"}`;
-during feature-dev PDFX-E007-F001 replaces it with an Ollama-probe-gated
-version.
+`{"status":"ok"}`. `/ready` is gated on a TTL-cached Ollama probe
+(PDFX-E007-F001): returns 200 when Ollama is reachable within the
+configured TTL, or 503 with `{"status":"not_ready","reason":"ollama_unreachable"}`
+otherwise.
 
 **Architecture enforcement.** `import-linter` is wired in `task lint` with one
 contract: `shared/` and `core/` cannot import from `features/`. The full

--- a/docs/bootstrap-decisions.md
+++ b/docs/bootstrap-decisions.md
@@ -63,7 +63,7 @@ Extraction Microservice (`PDFX`). The strip was driven by the graph tree at
 | All pre-commit / pre-push Python hooks | CLAUDE.md sacred |
 | Error contracts package (`errors.yaml`, codegen, tests) | Required for extraction features' error codes |
 | `import-linter` + `architecture/` directory | Required by PDFX-E007-F004 |
-| Health router (`/health` + `/ready`) | Required, rewritten stub until PDFX-E007-F001 |
+| Health router (`/health` + `/ready`) | Required; `/ready` now Ollama-probe-gated (PDFX-E007-F001) |
 | Exception handlers (`app/api/errors.py`) | Unchanged — feature-agnostic |
 | Error body schemas (`app/schemas/error_*.py`) | Unchanged — feature-agnostic |
 | Three generic error codes (`NOT_FOUND`, `VALIDATION_FAILED`, `INTERNAL_ERROR`) | Generic and needed by future features — `CONFLICT` pruned in PDFX-E001-F004 as a CRUD-era orphan |
@@ -77,7 +77,7 @@ Extraction Microservice (`PDFX`). The strip was driven by the graph tree at
 | 28 | `apps/backend/app/main.py` | Removed database lifespan, removed widget router mount. Simplified app factory. |
 | 29 | `apps/backend/app/core/config.py` | Removed `database_url` and the postgres validator. Kept `app_env`, `log_level`, `cors_origins`. |
 | 30 | `apps/backend/app/api/middleware.py` | Removed `SecurityHeadersMiddleware`. Kept request-id, access log, CORS. |
-| 31 | `apps/backend/app/api/health_router.py` | Removed DB probe from `/ready`; now a minimal stub to be replaced by PDFX-E007-F001. |
+| 31 | `apps/backend/app/api/health_router.py` | Removed DB probe from `/ready`; now Ollama-probe-gated readiness (PDFX-E007-F001). |
 | 32 | `apps/backend/app/exceptions/__init__.py` | Removed widget + rate-limited re-exports. |
 | 33 | `apps/backend/app/exceptions/_generated/` | Removed widget_* + rate_limited_* files; regenerated cleanly via `task errors:generate`. |
 | 34 | `apps/backend/architecture/import-linter-contracts.ini` | Removed 4 widget-specific contracts; kept the `shared-no-features` contract. Full extraction-feature contracts land in PDFX-E007-F004. |

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,8 +36,9 @@ allowed — adjust for stricter production needs.
 
 ### Health & Readiness Endpoints ([app/api/health_router.py](../apps/backend/app/api/health_router.py))
 `GET /health` is a pure liveness probe returning `{"status":"ok"}`. `GET /ready`
-is a minimal stub returning `{"status":"ready"}` for the post-bootstrap shell;
-PDFX-E007-F001 replaces it with an Ollama-probe-gated version during feature-dev.
+is gated on a TTL-cached Ollama probe (PDFX-E007-F001): returns
+`{"status":"ready"}` (200) when Ollama is reachable within the TTL window,
+or `{"status":"not_ready","reason":"ollama_unreachable"}` (503) otherwise.
 
 ## Backend — Error System
 

--- a/docs/graphs/PDFX/PDFX-E007-F001.md
+++ b/docs/graphs/PDFX/PDFX-E007-F001.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E007-F001
 parent: PDFX-E007
 title: /health liveness + /ready readiness with Ollama probe
-status: detailed
+status: implemented
 priority: 250
 dependencies: [PDFX-E004-F002, PDFX-E006-F002]
 ---
@@ -83,3 +83,39 @@ A service deployed in any reasonable environment (Docker, Kubernetes, Nomad, eve
 - `[UNRESOLVED]` Whether the probe TTL should be configurable per-environment (dev vs prod). Default: one global setting; operators tune via env var.
 - `[UNRESOLVED]` Exact Ollama endpoint to probe. `/api/tags` lists installed models — fast and lightweight. Default: `/api/tags`.
 - `[UNRESOLVED]` Whether the `/ready` 503 response should include a hint at how long the probe has been failing. Default: no — `/ready` is a binary signal; operators read structlog for the temporal context.
+
+## Unit test scenarios
+
+- Given a mock `httpx.AsyncClient` whose `get("/api/tags")` returns HTTP 200, when `OllamaHealthProbe.check()` is awaited, then it returns `True`.
+- Given a mock `httpx.AsyncClient` whose `get("/api/tags")` raises `httpx.ConnectError`, when `OllamaHealthProbe.check()` is awaited, then it returns `False` (never raises — the probe is boolean).
+- Given a mock `httpx.AsyncClient` whose `get("/api/tags")` returns HTTP 500 (`.raise_for_status()` raises `httpx.HTTPStatusError`), when `OllamaHealthProbe.check()` is awaited, then it returns `False`.
+- Given a mock `httpx.AsyncClient` whose `get("/api/tags")` raises `httpx.TimeoutException`, when `OllamaHealthProbe.check()` is awaited, then it returns `False` (a hung Ollama is the same as an unreachable one for readiness purposes).
+- Given a `ProbeCache` constructed with `ttl_seconds=5.0` and a mock probe whose `check()` returns `True`, when `probe_cache.is_ready()` is called for the first time (no cached result), then the mock probe's `check()` is invoked exactly once and the method returns `True`.
+- Given the same ProbeCache after a successful first call, when `is_ready()` is called again within 1 second (well within the 5 s TTL), then the mock probe's `check()` is NOT called again (total call count remains 1) and the method returns the cached `True`. (AC4)
+- Given the same ProbeCache, when `is_ready()` is called after 6 seconds have elapsed since the first call (past the 5 s TTL), then the mock probe's `check()` IS called a second time (total call count = 2) and the method returns the fresh result. (AC5)
+- Given a `ProbeCache` whose mock probe initially returns `True`, when the mock is reconfigured to return `False` and `is_ready()` is called immediately (within the TTL window), then the cached `True` is returned — the stale-but-within-TTL result is served. (AC6)
+- Given the same reconfigured ProbeCache (probe now returns `False`), when `is_ready()` is called after the TTL has expired, then the probe is called again, returns `False`, and `is_ready()` returns `False`.
+- Given a `ProbeCache` constructed with `ttl_seconds=0.0` (zero TTL), when `is_ready()` is called twice in rapid succession, then the probe is called twice — zero TTL means every call is a cache miss.
+- Given `Settings()` with no `OLLAMA_PROBE_TTL_SECONDS` env var set, when `settings.ollama_probe_ttl_seconds` is accessed, then it equals `10.0` (the documented default).
+- Given the `/health` route handler called directly (no HTTP stack), when it returns, then the result is `{"status": "ok"}` — no probe, no cache, no dependencies.
+- Given the `/ready` route handler with a `ProbeCache` dependency whose `is_ready()` returns `True`, when the handler is invoked, then it returns status code 200 with body `{"status": "ready"}`. (AC2)
+- Given the `/ready` route handler with a `ProbeCache` dependency whose `is_ready()` returns `False`, when the handler is invoked, then it returns status code 503 with body `{"status": "not_ready", "reason": "ollama_unreachable"}`. (AC3)
+
+## Integration test scenarios
+
+- Given the FastAPI ASGI app with the health router mounted, when `GET /health` is issued via `httpx.AsyncClient`, then the response is HTTP 200 with JSON body `{"status": "ok"}`. (AC1)
+- Given the FastAPI app with a `Depends` override that provides a `ProbeCache` whose underlying probe returns `True`, when `GET /ready` is issued, then the response is HTTP 200 with JSON body `{"status": "ready"}`. (AC2)
+- Given the FastAPI app with a `Depends` override that provides a `ProbeCache` whose underlying probe returns `False`, when `GET /ready` is issued, then the response is HTTP 503 with JSON body containing `"status": "not_ready"` and `"reason": "ollama_unreachable"`. (AC3)
+- Given the FastAPI app with a `ProbeCache` (TTL = 5 s) whose underlying mock probe returns `True`, when `GET /ready` is issued twice within 1 second, then the mock probe's `check()` was called exactly once across both requests — verifying the TTL cache works end-to-end through the HTTP stack. (AC4)
+- Given the FastAPI app with a `ProbeCache` whose mock probe initially returns `True` and is then reconfigured to return `False`, when `GET /ready` is called immediately after reconfiguration (within TTL), then the response is still HTTP 200 (cached True). When called again after the TTL expires, the response flips to HTTP 503. (AC6 end-to-end)
+- Given the FastAPI app running, when `GET /openapi.json` is fetched, then the document includes path entries for both `/health` and `/ready`, each with their `GET` operation and response schemas. (AC7)
+- Given the FastAPI app with the `/ready` route returning 503 (probe returning False), when the response is inspected, then the `Content-Type` header is `application/json` — the 503 is a structured JSON response, not a bare status code.
+
+## E2E test scenarios
+
+Not applicable. These endpoints are infrastructure probes with no user-facing flow beyond what integration tests cover. A real-Ollama E2E test (process boots → Ollama reachable → `/ready` returns 200 within 10 s) would be `@pytest.mark.slow` and belongs to the optional slow suite in PDFX-E007, not to this feature's mandatory test set.
+
+## Contract test scenarios
+
+- Given the OpenAPI spec generated by the FastAPI app, when Schemathesis exercises `GET /health`, then every generated response conforms to the declared 200 response schema (`{"status": "ok"}`).
+- Given the OpenAPI spec, when Schemathesis exercises `GET /ready`, then every generated response conforms to either the declared 200 response schema (`{"status": "ready"}`) or the 503 response schema (`{"status": "not_ready", "reason": "ollama_unreachable"}`) — both shapes are valid per the spec, and the actual shape depends on runtime probe state.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -67,9 +67,9 @@ task docker:down
 ## Health Checks
 
 - **Liveness**: `GET /health` → `{"status": "ok"}`
-- **Readiness**: `GET /ready` → `{"status": "ready"}` (post-bootstrap stub;
-  during feature-dev PDFX-E007-F001 replaces this with an Ollama-probe-gated
-  version that returns 503 when Ollama is unreachable)
+- **Readiness**: `GET /ready` → `{"status": "ready"}` (200) when Ollama is
+  reachable within the probe TTL (`OLLAMA_PROBE_TTL_SECONDS`, default 10 s),
+  or `{"status": "not_ready", "reason": "ollama_unreachable"}` (503) otherwise
 
 ## Ollama
 


### PR DESCRIPTION
## Summary

- Replace the stub `/ready` endpoint with an Ollama-probe-gated readiness check returning 200/503 based on TTL-cached probe against `/api/tags`
- Add `OllamaHealthProbe` (own `httpx.AsyncClient`, contained per C6 contract) and `ProbeCache` (single-entry TTL cache) wired via `Depends()` factories
- Add `Settings.ollama_probe_ttl_seconds` (default 10s) and matching `.env.example` entry
- Update lifespan to close probe client on shutdown; update httpx containment allowlist

## Test plan

- [x] 5 unit tests for `OllamaHealthProbe` (200→True, ConnectError→False, HTTP 500→False, Timeout→False, aclose)
- [x] 7 unit tests for `ProbeCache` (first call, cached within TTL, expiry re-probe, stale-within-TTL, stale-after-expiry, zero TTL, Settings default)
- [x] 3 unit tests for health router handlers (health ok, ready 200, ready 503)
- [x] 1 unit test for httpx import containment (probe file now in allowlist)
- [x] 10 integration tests (health 200, ready 200/503, JSON content-type, TTL caching, TTL flip, OpenAPI, middleware, CORS)
- [x] Updated `test_skill_manifest_startup` to override probe cache dependency
- [x] `task check` passes: lint, format, pyright strict (0 errors), import-linter, all unit/integration/contract tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)