### PR TITLE
docs: clarify Python version policy as 3.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [`docs/superpowers/specs/`](docs/superpowers/specs/) for the full design and
 
 ## Tech Stack
 
-- **Runtime:** Python 3.13, FastAPI, Pydantic v2, pydantic-settings, structlog
+- **Runtime:** Python 3.13+, FastAPI, Pydantic v2, pydantic-settings, structlog
 - **Extraction:** Docling (PDF parsing + OCR), LangExtract (orchestration), Ollama + Gemma 4 smallest variant (local LLM), PyMuPDF (annotation)
 - **Testing:** pytest + pytest-asyncio, schemathesis (contract), import-linter (architecture)
 - **Tooling:** Taskfile, Ruff, Pyright, uv
@@ -17,7 +17,7 @@ Ollama runs on the host machine (outside the service container) and is reached v
 
 Prerequisites:
 
-- Python 3.13
+- Python 3.13+
 - `uv` (Astral)
 - Docker (optional — only if you want to run the service in a container)
 - Ollama installed on the host, with the smallest Gemma 4 variant pulled (`ollama pull <tag>`)


### PR DESCRIPTION
## Summary
- Updates README.md to say "Python 3.13+" instead of "Python 3.13" in both the Tech Stack and Prerequisites sections, aligning with `requires-python = ">=3.13"` in pyproject.toml.
- No code changes; the Dockerfile continues to target 3.13 as the production runtime image.

Closes #65

## Test plan
- [x] `task check` passes (lint, pyright, unit, integration, contract, architecture contracts, error generation)
- [ ] Verify README renders correctly on GitHub