### PR TITLE
fix(logging): suppress httpx/httpcore INFO noise

### DIFF
--- a/apps/backend/app/core/logging.py
+++ b/apps/backend/app/core/logging.py
@@ -77,5 +77,11 @@ def configure_logging(
     root_logger.setLevel(log_level.upper())
 
     # Silence noisy third-party loggers
-    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
-    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+    noisy_loggers = {
+        "uvicorn.access": logging.WARNING,
+        "sqlalchemy.engine": logging.WARNING,
+        "httpx": logging.WARNING,
+        "httpcore": logging.WARNING,
+    }
+    for logger_name, level in noisy_loggers.items():
+        logging.getLogger(logger_name).setLevel(level)

--- a/apps/backend/tests/unit/core/test_logging.py
+++ b/apps/backend/tests/unit/core/test_logging.py
@@ -1,5 +1,7 @@
 """Unit tests for the structlog configuration in app.core.logging."""
 
+import logging
+
 import structlog
 
 from app.core.log_redaction_filter import LogRedactionFilter
@@ -31,3 +33,15 @@ def test_redaction_filter_runs_after_merge_contextvars() -> None:
     )
     redact_idx = next(i for i, p in enumerate(processors) if isinstance(p, LogRedactionFilter))
     assert merge_idx < redact_idx
+
+
+def test_configure_logging_suppresses_httpx_to_warning() -> None:
+    """httpx emits INFO-level request logs that add noise; must be suppressed."""
+    configure_logging(log_level="info", json_output=False)
+    assert logging.getLogger("httpx").level == logging.WARNING
+
+
+def test_configure_logging_suppresses_httpcore_to_warning() -> None:
+    """httpcore is the transport layer under httpx; same suppression needed."""
+    configure_logging(log_level="info", json_output=False)
+    assert logging.getLogger("httpcore").level == logging.WARNING


### PR DESCRIPTION
## Summary
- Adds `httpx` and `httpcore` to the noisy-logger suppression dict in `configure_logging()`, setting both to `WARNING` level.
- Prevents Ollama HTTP call INFO-level request/response logs from polluting application output.
- Refactors the two existing `setLevel` calls into a single dict-driven loop for consistency.

Closes #66

## Test plan
- [x] `test_configure_logging_suppresses_httpx_to_warning` -- asserts `httpx` logger is set to WARNING after `configure_logging`
- [x] `test_configure_logging_suppresses_httpcore_to_warning` -- asserts `httpcore` logger is set to WARNING after `configure_logging`
- [x] All existing logging tests remain green
- [x] Full `task check` passes (lint, architecture, typecheck, unit, integration, contract)