### PR TITLE
fix(config): validate ollama_base_url at startup

### DIFF
--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.core.docling_modes import OcrMode, TableMode
@@ -43,6 +43,19 @@ class Settings(BaseSettings):
 
     ollama_base_url: str = "http://host.docker.internal:11434"
     ollama_model: str = "gemma4:e2b"
+
+    @field_validator("ollama_base_url")
+    @classmethod
+    def _validate_ollama_base_url(cls, v: str) -> str:
+        url = v.strip().rstrip("/")
+        if not url:
+            msg = "ollama_base_url must not be empty"
+            raise ValueError(msg)
+        if not url.startswith(("http://", "https://")):
+            msg = "ollama_base_url must start with http:// or https://"
+            raise ValueError(msg)
+        return url
+
     ollama_timeout_seconds: Annotated[float, Field(gt=0)] = 30.0
     ollama_probe_ttl_seconds: Annotated[float, Field(ge=0)] = 10.0
     ollama_probe_timeout_seconds: Annotated[float, Field(gt=0)] = 5.0

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Annotated
+from urllib.parse import urlsplit
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -47,14 +48,24 @@ class Settings(BaseSettings):
     @field_validator("ollama_base_url")
     @classmethod
     def _validate_ollama_base_url(cls, v: str) -> str:
-        url = v.strip().rstrip("/")
-        if not url:
+        stripped = v.strip()
+        if not stripped:
             msg = "ollama_base_url must not be empty"
             raise ValueError(msg)
-        if not url.startswith(("http://", "https://")):
+        if not stripped.startswith(("http://", "https://")):
             msg = "ollama_base_url must start with http:// or https://"
             raise ValueError(msg)
-        return url
+        parsed = urlsplit(stripped)
+        if not parsed.netloc:
+            msg = "ollama_base_url must include a host (e.g. http://localhost:11434)"
+            raise ValueError(msg)
+        if parsed.path.rstrip("/").endswith("/api"):
+            msg = (
+                "ollama_base_url must not include a trailing /api path; "
+                "the client appends /api/generate and /api/tags automatically"
+            )
+            raise ValueError(msg)
+        return stripped.rstrip("/")
 
     ollama_timeout_seconds: Annotated[float, Field(gt=0)] = 30.0
     ollama_probe_ttl_seconds: Annotated[float, Field(ge=0)] = 10.0

--- a/apps/backend/tests/unit/core/test_config.py
+++ b/apps/backend/tests/unit/core/test_config.py
@@ -1,5 +1,8 @@
 """Tests for the application configuration."""
 
+import pytest
+from pydantic import ValidationError
+
 from app.core.config import Settings
 
 
@@ -53,3 +56,54 @@ def test_settings_ollama_probe_timeout_default() -> None:
     """ollama_probe_timeout_seconds defaults to 5.0."""
     s = Settings()
     assert s.ollama_probe_timeout_seconds == 5.0
+
+
+# -- ollama_base_url validation (issue #64) --------------------------------
+
+
+def test_settings_ollama_base_url_empty_string_rejected() -> None:
+    """An empty string for ollama_base_url must be rejected."""
+    with pytest.raises(ValidationError, match="ollama_base_url"):
+        Settings(ollama_base_url="")
+
+
+def test_settings_ollama_base_url_whitespace_only_rejected() -> None:
+    """A whitespace-only string for ollama_base_url must be rejected."""
+    with pytest.raises(ValidationError, match="ollama_base_url"):
+        Settings(ollama_base_url="   ")
+
+
+def test_settings_ollama_base_url_no_http_scheme_rejected() -> None:
+    """A URL without http:// or https:// scheme must be rejected."""
+    with pytest.raises(ValidationError, match="ollama_base_url"):
+        Settings(ollama_base_url="ftp://localhost:11434")
+
+
+def test_settings_ollama_base_url_bare_hostname_rejected() -> None:
+    """A bare hostname without scheme must be rejected."""
+    with pytest.raises(ValidationError, match="ollama_base_url"):
+        Settings(ollama_base_url="localhost:11434")
+
+
+def test_settings_ollama_base_url_valid_http_accepted() -> None:
+    """A valid http:// URL must be accepted."""
+    s = Settings(ollama_base_url="http://localhost:11434")
+    assert s.ollama_base_url == "http://localhost:11434"
+
+
+def test_settings_ollama_base_url_valid_https_accepted() -> None:
+    """A valid https:// URL must be accepted."""
+    s = Settings(ollama_base_url="https://ollama.example.com")
+    assert s.ollama_base_url == "https://ollama.example.com"
+
+
+def test_settings_ollama_base_url_trailing_slash_stripped() -> None:
+    """Trailing slashes must be stripped from ollama_base_url."""
+    s = Settings(ollama_base_url="http://localhost:11434/")
+    assert s.ollama_base_url == "http://localhost:11434"
+
+
+def test_settings_ollama_base_url_whitespace_stripped() -> None:
+    """Leading/trailing whitespace must be stripped before validation."""
+    s = Settings(ollama_base_url="  http://localhost:11434  ")
+    assert s.ollama_base_url == "http://localhost:11434"

--- a/apps/backend/tests/unit/core/test_config.py
+++ b/apps/backend/tests/unit/core/test_config.py
@@ -63,26 +63,38 @@ def test_settings_ollama_probe_timeout_default() -> None:
 
 def test_settings_ollama_base_url_empty_string_rejected() -> None:
     """An empty string for ollama_base_url must be rejected."""
-    with pytest.raises(ValidationError, match="ollama_base_url"):
+    with pytest.raises(ValidationError, match="must not be empty"):
         Settings(ollama_base_url="")
 
 
 def test_settings_ollama_base_url_whitespace_only_rejected() -> None:
     """A whitespace-only string for ollama_base_url must be rejected."""
-    with pytest.raises(ValidationError, match="ollama_base_url"):
+    with pytest.raises(ValidationError, match="must not be empty"):
         Settings(ollama_base_url="   ")
 
 
 def test_settings_ollama_base_url_no_http_scheme_rejected() -> None:
     """A URL without http:// or https:// scheme must be rejected."""
-    with pytest.raises(ValidationError, match="ollama_base_url"):
+    with pytest.raises(ValidationError, match="must start with"):
         Settings(ollama_base_url="ftp://localhost:11434")
 
 
 def test_settings_ollama_base_url_bare_hostname_rejected() -> None:
     """A bare hostname without scheme must be rejected."""
-    with pytest.raises(ValidationError, match="ollama_base_url"):
+    with pytest.raises(ValidationError, match="must start with"):
         Settings(ollama_base_url="localhost:11434")
+
+
+def test_settings_ollama_base_url_scheme_only_no_host_rejected() -> None:
+    """http:// with no host must be rejected."""
+    with pytest.raises(ValidationError, match="must include a host"):
+        Settings(ollama_base_url="http://")
+
+
+def test_settings_ollama_base_url_trailing_api_path_rejected() -> None:
+    """A URL ending with /api must be rejected to prevent double /api segments."""
+    with pytest.raises(ValidationError, match="must not include a trailing /api"):
+        Settings(ollama_base_url="http://localhost:11434/api")
 
 
 def test_settings_ollama_base_url_valid_http_accepted() -> None:


### PR DESCRIPTION
## Summary

- Adds a `@field_validator("ollama_base_url")` to `Settings` that strips whitespace and trailing slashes, then rejects empty strings and URLs without an `http://` or `https://` scheme.
- Prevents cryptic httpx errors downstream when `OLLAMA_BASE_URL` is set to an empty or malformed value.

Closes #64

## Test plan

- [x] `test_settings_ollama_base_url_empty_string_rejected` -- empty string raises `ValidationError`
- [x] `test_settings_ollama_base_url_whitespace_only_rejected` -- whitespace-only raises `ValidationError`
- [x] `test_settings_ollama_base_url_no_http_scheme_rejected` -- `ftp://` scheme rejected
- [x] `test_settings_ollama_base_url_bare_hostname_rejected` -- bare hostname rejected
- [x] `test_settings_ollama_base_url_valid_http_accepted` -- `http://` accepted
- [x] `test_settings_ollama_base_url_valid_https_accepted` -- `https://` accepted
- [x] `test_settings_ollama_base_url_trailing_slash_stripped` -- trailing `/` removed
- [x] `test_settings_ollama_base_url_whitespace_stripped` -- surrounding whitespace removed
- [x] `task check` passes (lint, format, pyright, unit, integration, contract, arch)