### PR TITLE
docs: fix test:e2e references to test:slow

### DIFF
--- a/docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-design.md
+++ b/docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-design.md
@@ -390,7 +390,7 @@ Schemathesis against the OpenAPI spec for `POST /api/v1/extract`.
 
 ### 9.4 E2E (optional, slow)
 
-- One golden-path test against a running Ollama + real Gemma 4 model with a single invoice PDF, asserting extraction produces the expected fields. Marked `slow`, excluded from the default `task check` run, runnable via `task test:e2e`.
+- One golden-path test against a running Ollama + real Gemma 4 model with a single invoice PDF, asserting extraction produces the expected fields. Marked `slow`, excluded from the default `task check` run, runnable via `task test:slow`.
 
 The rest of the test suite never touches a real LLM — determinism is required for CI.
 

--- a/docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-requirements.md
+++ b/docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-requirements.md
@@ -1268,7 +1268,7 @@ Measurement and enforcement of NFRs.
 | NFR Memory (NFR-008, NFR-009, NFR-010) | Manual | `ps` / `docker stats` spot check documented in runbook; regressions tracked visually |
 | NFR Security (NFR-018, NFR-019, NFR-020) | Unit + Integration | Monkey-patched file I/O and network calls; log record inspection |
 | NFR Maintainability (NFR-024 through NFR-030) | CI gates | `task check` runs pyright strict, ruff, tests, import-linter, error-contract validation |
-| Optional E2E (slow) | Realistic round-trip | One E2E test with a real Ollama + real Gemma 4 + a fixture skill + a fixture PDF, marked `slow`, excluded from default `task check`, runnable via `task test:e2e` |
+| Optional E2E (slow) | Realistic round-trip | One E2E test with a real Ollama + real Gemma 4 + a fixture skill + a fixture PDF, marked `slow`, excluded from default `task check`, runnable via `task test:slow` |
 
 ### Integration Testing Notes
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,7 +37,7 @@ Three levels, all mandatory for every feature. E2E is optional-slow.
 - **What:** End-to-end smoke test with a real Ollama + real Gemma 4 model
   against a fixture PDF.
 - **Tooling:** Pytest with `@pytest.mark.slow`, excluded from default
-  `task check`. Runnable via `task test:e2e` after the marker is added in
+  `task check`. Runnable via `task test:slow` after the marker is added in
   feature-dev.
 - **Scope:** One test only. Determinism is not required — the test catches
   catastrophic regressions in the Ollama integration.


### PR DESCRIPTION
## Summary

- Replaced `task test:e2e` with `task test:slow` in three doc files where the task name did not match the Taskfile definition, causing "task not found" errors for developers following the docs.
- Historical references in `bootstrap-decisions.md` and `reshape-plan.md` were left intact as they correctly document the pre-bootstrap template state.

Closes #62

## Test plan

- [ ] Verify `task test:slow` exists in `Taskfile.yml` (confirmed)
- [ ] Verify no active doc references `task test:e2e` (only historical records remain)
- [ ] `task check` passes (confirmed locally)