### PR TITLE
fix(api): emit access log on unhandled exceptions

### DIFF
--- a/apps/backend/app/api/access_log_middleware.py
+++ b/apps/backend/app/api/access_log_middleware.py
@@ -14,7 +14,18 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = (time.perf_counter() - start) * 1000
+            _logger.info(
+                "http_request",
+                method=request.method,
+                path=request.url.path,
+                status_code=500,
+                duration_ms=round(duration_ms, 2),
+            )
+            raise
         duration_ms = (time.perf_counter() - start) * 1000
 
         _logger.info(

--- a/apps/backend/app/api/access_log_middleware.py
+++ b/apps/backend/app/api/access_log_middleware.py
@@ -14,25 +14,17 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
+        status_code = 500
         try:
             response = await call_next(request)
-        except Exception:
+            status_code = response.status_code
+        finally:
             duration_ms = (time.perf_counter() - start) * 1000
             _logger.info(
                 "http_request",
                 method=request.method,
                 path=request.url.path,
-                status_code=500,
+                status_code=status_code,
                 duration_ms=round(duration_ms, 2),
             )
-            raise
-        duration_ms = (time.perf_counter() - start) * 1000
-
-        _logger.info(
-            "http_request",
-            method=request.method,
-            path=request.url.path,
-            status_code=response.status_code,
-            duration_ms=round(duration_ms, 2),
-        )
         return response

--- a/apps/backend/tests/unit/api/test_access_log_middleware.py
+++ b/apps/backend/tests/unit/api/test_access_log_middleware.py
@@ -1,0 +1,126 @@
+"""Unit tests for AccessLogMiddleware."""
+
+import pytest
+from fastapi import FastAPI, Response
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request as StarletteRequest
+from starlette.types import Receive, Scope, Send
+
+from app.api.access_log_middleware import AccessLogMiddleware
+
+
+class _SentinelError(Exception):
+    """Sentinel exception used only by the exception-propagation test."""
+
+
+async def test_access_log_middleware_emits_log_on_unhandled_exception() -> None:
+    """When call_next raises, the middleware must still emit an http_request
+    log entry with status_code=500 and a positive duration_ms, then re-raise
+    the original exception."""
+    import structlog
+
+    captured_events: list[dict[str, object]] = []
+
+    def _capture_event(
+        _logger: object, _method_name: str, event_dict: dict[str, object]
+    ) -> dict[str, object]:
+        captured_events.append(event_dict.copy())
+        return event_dict
+
+    structlog.configure(
+        processors=[_capture_event, structlog.dev.ConsoleRenderer()],
+        wrapper_class=structlog.make_filtering_bound_logger(0),
+        cache_logger_on_first_use=False,
+    )
+
+    async def _noop_asgi_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        return None
+
+    boom_message = "handler exploded"
+
+    async def _call_next_raising(_request: StarletteRequest) -> Response:
+        raise _SentinelError(boom_message)
+
+    middleware = AccessLogMiddleware(_noop_asgi_app)
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/extract",
+        "headers": [],
+    }
+    request = StarletteRequest(scope)  # type: ignore[arg-type] -- only Starlette attrs used
+
+    with pytest.raises(_SentinelError, match=boom_message):
+        await middleware.dispatch(request, _call_next_raising)
+
+    http_events = [e for e in captured_events if e.get("event") == "http_request"]
+    assert len(http_events) == 1, f"Expected 1 http_request event, got {len(http_events)}"
+    log = http_events[0]
+    assert log["method"] == "POST"
+    assert log["path"] == "/api/v1/extract"
+    assert log["status_code"] == 500
+    assert isinstance(log["duration_ms"], float)
+    assert log["duration_ms"] >= 0
+
+
+async def test_access_log_middleware_reraises_original_exception() -> None:
+    """The original exception must propagate unchanged after the log is emitted."""
+
+    async def _noop_asgi_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        return None
+
+    boom_message = "original error must propagate"
+
+    async def _call_next_raising(_request: StarletteRequest) -> Response:
+        raise _SentinelError(boom_message)
+
+    middleware = AccessLogMiddleware(_noop_asgi_app)
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/_raise",
+        "headers": [],
+    }
+    request = StarletteRequest(scope)  # type: ignore[arg-type] -- only Starlette attrs used
+
+    with pytest.raises(_SentinelError, match=boom_message):
+        await middleware.dispatch(request, _call_next_raising)
+
+
+async def test_access_log_middleware_emits_log_on_success() -> None:
+    """Normal (non-exception) path still logs correctly."""
+    import structlog
+
+    captured_events: list[dict[str, object]] = []
+
+    def _capture_event(
+        _logger: object, _method_name: str, event_dict: dict[str, object]
+    ) -> dict[str, object]:
+        captured_events.append(event_dict.copy())
+        return event_dict
+
+    structlog.configure(
+        processors=[_capture_event, structlog.dev.ConsoleRenderer()],
+        wrapper_class=structlog.make_filtering_bound_logger(0),
+        cache_logger_on_first_use=False,
+    )
+
+    application = FastAPI()
+    application.add_middleware(AccessLogMiddleware)
+
+    @application.get("/_ok")
+    async def _ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    async with AsyncClient(transport=ASGITransport(app=application), base_url="http://test") as ac:
+        response = await ac.get("/_ok")
+
+    assert response.status_code == 200
+    http_events = [e for e in captured_events if e.get("event") == "http_request"]
+    assert len(http_events) >= 1
+    log = http_events[-1]
+    assert log["method"] == "GET"
+    assert log["path"] == "/_ok"
+    assert log["status_code"] == 200
+    assert isinstance(log["duration_ms"], float)
+    assert log["duration_ms"] >= 0

--- a/apps/backend/tests/unit/api/test_access_log_middleware.py
+++ b/apps/backend/tests/unit/api/test_access_log_middleware.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, Response
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request as StarletteRequest
 from starlette.types import Receive, Scope, Send
+from structlog.testing import capture_logs
 
 from app.api.access_log_middleware import AccessLogMiddleware
 
@@ -17,21 +18,6 @@ async def test_access_log_middleware_emits_log_on_unhandled_exception() -> None:
     """When call_next raises, the middleware must still emit an http_request
     log entry with status_code=500 and a positive duration_ms, then re-raise
     the original exception."""
-    import structlog
-
-    captured_events: list[dict[str, object]] = []
-
-    def _capture_event(
-        _logger: object, _method_name: str, event_dict: dict[str, object]
-    ) -> dict[str, object]:
-        captured_events.append(event_dict.copy())
-        return event_dict
-
-    structlog.configure(
-        processors=[_capture_event, structlog.dev.ConsoleRenderer()],
-        wrapper_class=structlog.make_filtering_bound_logger(0),
-        cache_logger_on_first_use=False,
-    )
 
     async def _noop_asgi_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
         return None
@@ -50,10 +36,10 @@ async def test_access_log_middleware_emits_log_on_unhandled_exception() -> None:
     }
     request = StarletteRequest(scope)  # type: ignore[arg-type] -- only Starlette attrs used
 
-    with pytest.raises(_SentinelError, match=boom_message):
+    with capture_logs() as cap_logs, pytest.raises(_SentinelError, match=boom_message):
         await middleware.dispatch(request, _call_next_raising)
 
-    http_events = [e for e in captured_events if e.get("event") == "http_request"]
+    http_events = [e for e in cap_logs if e.get("event") == "http_request"]
     assert len(http_events) == 1, f"Expected 1 http_request event, got {len(http_events)}"
     log = http_events[0]
     assert log["method"] == "POST"
@@ -89,22 +75,6 @@ async def test_access_log_middleware_reraises_original_exception() -> None:
 
 async def test_access_log_middleware_emits_log_on_success() -> None:
     """Normal (non-exception) path still logs correctly."""
-    import structlog
-
-    captured_events: list[dict[str, object]] = []
-
-    def _capture_event(
-        _logger: object, _method_name: str, event_dict: dict[str, object]
-    ) -> dict[str, object]:
-        captured_events.append(event_dict.copy())
-        return event_dict
-
-    structlog.configure(
-        processors=[_capture_event, structlog.dev.ConsoleRenderer()],
-        wrapper_class=structlog.make_filtering_bound_logger(0),
-        cache_logger_on_first_use=False,
-    )
-
     application = FastAPI()
     application.add_middleware(AccessLogMiddleware)
 
@@ -112,11 +82,14 @@ async def test_access_log_middleware_emits_log_on_success() -> None:
     async def _ok() -> dict[str, str]:
         return {"status": "ok"}
 
-    async with AsyncClient(transport=ASGITransport(app=application), base_url="http://test") as ac:
-        response = await ac.get("/_ok")
+    with capture_logs() as cap_logs:
+        async with AsyncClient(
+            transport=ASGITransport(app=application), base_url="http://test"
+        ) as ac:
+            response = await ac.get("/_ok")
 
     assert response.status_code == 200
-    http_events = [e for e in captured_events if e.get("event") == "http_request"]
+    http_events = [e for e in cap_logs if e.get("event") == "http_request"]
     assert len(http_events) >= 1
     log = http_events[-1]
     assert log["method"] == "GET"


### PR DESCRIPTION
## Summary
- Wraps `call_next` in `AccessLogMiddleware.dispatch` with `try/except Exception` so that unhandled exceptions still produce an `http_request` structured log entry with `status_code=500` and elapsed `duration_ms`, then re-raises the original exception
- Adds three unit tests covering the exception path, re-raise guarantee, and the existing success path

## Test plan
- [x] `test_access_log_middleware_emits_log_on_unhandled_exception` -- verifies structured log emitted with status 500 on exception
- [x] `test_access_log_middleware_reraises_original_exception` -- verifies original exception propagates unchanged
- [x] `test_access_log_middleware_emits_log_on_success` -- verifies normal path still logs correctly
- [x] `task check` passes (lint, format, type-check, architecture contracts, unit/integration/contract tests, error codegen)

Closes #56