### PR TITLE
fix(coordinates): SubBlockMatcher NFKC handles combining marks

### DIFF
--- a/apps/backend/app/features/extraction/coordinates/sub_block_matcher.py
+++ b/apps/backend/app/features/extraction/coordinates/sub_block_matcher.py
@@ -120,12 +120,12 @@ def _nfkc_with_map(text: str) -> tuple[str, list[int]]:
     expands into multiple normalized characters, all of those normalized
     characters map back to that same source index (leading edge).
 
-    Characters are grouped into "normalization segments": each segment is a base
-    character followed by zero or more combining marks (Unicode category "M").
+    Characters are grouped into "normalization segments": each segment is one
+    codepoint followed by any subsequent combining marks (Unicode category "M").
     Each segment is NFKC-normalized as a unit so that combining sequences like
-    ``e`` + U+0301 (combining acute) correctly compose into ``é``. All
-    normalized characters produced by a segment map back to the segment's
-    leading (first) original index.
+    ``e`` + U+0301 (combining acute) correctly compose into ``é``. Normalized
+    characters are mapped back to original indices with per-codepoint granularity
+    when the segment spans multiple source characters.
     """
     out_parts: list[str] = []
     mapping: list[int] = []
@@ -140,7 +140,8 @@ def _nfkc_with_map(text: str) -> tuple[str, list[int]]:
         segment = text[seg_start:i]
         normalized_seg = unicodedata.normalize("NFKC", segment)
         out_parts.append(normalized_seg)
-        mapping.extend([seg_start] * len(normalized_seg))
+        seg_len = i - seg_start
+        mapping.extend(seg_start + min(j, seg_len - 1) for j in range(len(normalized_seg)))
     return "".join(out_parts), mapping
 
 

--- a/apps/backend/app/features/extraction/coordinates/sub_block_matcher.py
+++ b/apps/backend/app/features/extraction/coordinates/sub_block_matcher.py
@@ -119,13 +119,28 @@ def _nfkc_with_map(text: str) -> tuple[str, list[int]]:
     character whose normalization contributed it. When one source character
     expands into multiple normalized characters, all of those normalized
     characters map back to that same source index (leading edge).
+
+    Characters are grouped into "normalization segments": each segment is a base
+    character followed by zero or more combining marks (Unicode category "M").
+    Each segment is NFKC-normalized as a unit so that combining sequences like
+    ``e`` + U+0301 (combining acute) correctly compose into ``é``. All
+    normalized characters produced by a segment map back to the segment's
+    leading (first) original index.
     """
     out_parts: list[str] = []
     mapping: list[int] = []
-    for i, ch in enumerate(text):
-        normalized_ch = unicodedata.normalize("NFKC", ch)
-        out_parts.append(normalized_ch)
-        mapping.extend([i] * len(normalized_ch))
+    n = len(text)
+    i = 0
+    while i < n:
+        seg_start = i
+        i += 1
+        # Extend the segment to include all following combining marks.
+        while i < n and unicodedata.category(text[i]).startswith("M"):
+            i += 1
+        segment = text[seg_start:i]
+        normalized_seg = unicodedata.normalize("NFKC", segment)
+        out_parts.append(normalized_seg)
+        mapping.extend([seg_start] * len(normalized_seg))
     return "".join(out_parts), mapping
 
 

--- a/apps/backend/tests/unit/features/extraction/coordinates/test_sub_block_matcher.py
+++ b/apps/backend/tests/unit/features/extraction/coordinates/test_sub_block_matcher.py
@@ -269,3 +269,23 @@ def test_mixed_drift_ligature_adjacent_to_two_spaces_returns_full_range() -> Non
     assert result is not None
     assert result.start == 0
     assert result.end == len(block_text)
+
+
+def test_combining_acute_matches_precomposed_e_acute_via_nfkc_step() -> None:
+    """Regression for #50: multi-codepoint composition (e + combining acute vs e-acute).
+
+    `"Cafe\\u0301 total"` contains `e` (U+0065) followed by a combining acute
+    accent (U+0301). The value `"Caf\\u00e9"` is the precomposed form. When the
+    NFKC step normalizes one character at a time the combining mark never merges
+    with its base, so the match fails. The fix normalizes whole substrings so
+    composition happens correctly.
+    """
+    matcher = SubBlockMatcher()
+    block_text = "Cafe\u0301 total"
+    value = "Caf\u00e9"
+
+    result = matcher.locate(block_text, value)
+
+    assert result is not None
+    assert result.start == 0
+    assert result.end == 5  # covers "Cafe\u0301" (5 code units in original)


### PR DESCRIPTION
## Summary
- Fix `_nfkc_with_map` to group base characters with their following combining marks (Unicode category "M") into segments before NFKC-normalizing, so multi-codepoint composition works correctly (e.g. `e` + U+0301 combining acute composes into precomposed `e-acute`).
- Add regression test `test_combining_acute_matches_precomposed_e_acute_via_nfkc_step` covering the exact scenario from issue #50.

Closes #50

## Test plan
- [x] New unit test verifies `SubBlockMatcher().locate("Cafe\u0301 total", "Caf\u00e9")` returns `CharRange(0, 5)` instead of `None` (decomposed block text vs precomposed value -- the actual bug scenario)
- [x] All 22 existing SubBlockMatcher tests still pass (no regressions)
- [x] `task check` passes (lint, pyright, unit, integration, contract, import-linter)