### PR TITLE
fix(parsing): offload converter factory into asyncio.to_thread

### DIFF
--- a/apps/backend/app/features/extraction/parsing/docling_document_parser.py
+++ b/apps/backend/app/features/extraction/parsing/docling_document_parser.py
@@ -12,9 +12,10 @@ Design summary (load-bearing; do not re-architect without updating the spec):
 * The parser is a thin coordinator. It delegates PDF parsing to a Docling
   `DocumentConverter`, walks the resulting Docling document, and emits our own
   feature-owned value types (`ParsedDocument`, `TextBlock`, `BoundingBox`).
-* The Docling conversion step is synchronous and CPU-bound. `async parse`
-  offloads it via `asyncio.to_thread` so the FastAPI event loop is never
-  starved while a document is being parsed.
+* Both the converter factory (which lazy-imports Docling and constructs the
+  pipeline) and the conversion step are synchronous and CPU-bound. `async
+  parse` offloads them together in a single `asyncio.to_thread` call so the
+  FastAPI event loop is never starved during cold start or parsing.
 * The concrete Docling objects are obtained through a `converter_factory`
   callable injected via the constructor. The default factory performs a
   *lazy* import of Docling and builds a real `DocumentConverter`; unit tests
@@ -407,8 +408,11 @@ class DoclingDocumentParser:
                 actual=preflight_page_count,
             )
 
-        converter = self._converter_factory(docling_config)
-        document = await asyncio.to_thread(converter.convert, pdf_bytes)
+        def _build_and_convert() -> _DoclingDocumentLike:
+            converter = self._converter_factory(docling_config)
+            return converter.convert(pdf_bytes)
+
+        document = await asyncio.to_thread(_build_and_convert)
 
         parsed = self._to_parsed_document(document)
         if not parsed.blocks:

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -346,6 +346,55 @@ async def test_parse_does_not_block_event_loop_during_synchronous_convert() -> N
     assert ticks >= 5
 
 
+@pytest.mark.asyncio
+async def test_parse_does_not_block_event_loop_during_converter_factory() -> None:
+    """The converter factory (lazy Docling import + pipeline construction) is
+    CPU-bound on cold start. It must be offloaded to a worker thread alongside
+    the convert call so the event loop stays responsive.
+
+    This test isolates the factory path: the factory sleeps for 200ms (simulating
+    a heavy cold-start import), while convert() itself is instant. If the factory
+    runs on the event loop thread, the ticker cannot advance.
+    """
+
+    class _InstantConverter:
+        def __init__(self, document: _FakeDoclingDocument, *, config: DoclingConfig) -> None:
+            self.document = document
+            self.config = config
+
+        def convert(self, _pdf_bytes: bytes) -> _FakeDoclingDocument:
+            return self.document
+
+    def slow_factory(config: DoclingConfig) -> _InstantConverter:
+        time.sleep(0.2)  # simulates heavy lazy-import + pipeline construction
+        return _InstantConverter(_two_page_document(), config=config)
+
+    parser = DoclingDocumentParser(converter_factory=slow_factory, pdf_preflight=_noop_preflight)
+
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while ticks < 500:  # upper guard so the test can never run forever
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    ticker_task = asyncio.create_task(_ticker())
+    await parser.parse(b"%PDF-fake", DoclingConfig(ocr="auto", table_mode="fast"))
+    ticker_task.cancel()
+    with contextlib_suppress_cancelled():
+        await ticker_task
+
+    # 200ms of blocking factory offloaded to a thread should leave room for
+    # the ticker to fire at least ~10 times. We assert 5 as a generous floor
+    # to avoid flakes on slow CI while still catching a regression that
+    # would run the factory on the event loop (which would leave ticks == 0).
+    assert ticks >= 5, (
+        f"ticker did not advance enough (ticks={ticks}); "
+        "converter factory appears to block the event loop"
+    )
+
+
 def contextlib_suppress_cancelled() -> Any:
     import contextlib
 


### PR DESCRIPTION
## Summary
- Moves the `converter_factory()` call inside the same `asyncio.to_thread` as `converter.convert()` so the entire blocking Docling cold-start (lazy import + pipeline construction + conversion) runs off the event loop.
- Adds a dedicated unit test (`test_parse_does_not_block_event_loop_during_converter_factory`) using the concurrent-ticker pattern that isolates the factory path: the factory sleeps 200ms while `convert()` is instant, proving the factory is offloaded.

## Test plan
- [x] New test fails on the old code (factory on event loop: ticks=0) and passes after the fix (ticks>=5)
- [x] All 20 parser unit tests pass
- [x] Full `task check` green (lint, arch contracts, pyright, unit, integration, contract, error generation)

Closes #51