### PR TITLE
docs(extraction): clarify value is always str

### DIFF
--- a/apps/backend/app/features/extraction/extraction/raw_extraction.py
+++ b/apps/backend/app/features/extraction/extraction/raw_extraction.py
@@ -15,10 +15,11 @@ class RawExtraction:
     """One field extracted by LangExtract, translated into feature-owned shape.
 
     `field_name` mirrors the key declared in the skill's `output_schema`.
-    `value` is always ``str | None`` at runtime — it comes from
-    LangExtract's ``Extraction.extraction_text``, which is document text.
-    The ``Any`` annotation is kept for forward compatibility, but callers
-    should treat non-``None`` values as strings.  ``None`` means either:
+    `value` is always ``str | None`` at runtime — the string LangExtract
+    produced (``Extraction.extraction_text``), which may or may not be a
+    verbatim document span. The ``Any`` annotation is kept for forward
+    compatibility, but callers should treat non-``None`` values as strings.
+    ``None`` means either:
       (a) the engine emitted a placeholder for a declared field that
           LangExtract did not return (the "every declared field always
           present" API-stability invariant), or

--- a/apps/backend/app/features/extraction/extraction/raw_extraction.py
+++ b/apps/backend/app/features/extraction/extraction/raw_extraction.py
@@ -15,7 +15,10 @@ class RawExtraction:
     """One field extracted by LangExtract, translated into feature-owned shape.
 
     `field_name` mirrors the key declared in the skill's `output_schema`.
-    `value` is the extracted value, or `None` when either:
+    `value` is always ``str | None`` at runtime — it comes from
+    LangExtract's ``Extraction.extraction_text``, which is document text.
+    The ``Any`` annotation is kept for forward compatibility, but callers
+    should treat non-``None`` values as strings.  ``None`` means either:
       (a) the engine emitted a placeholder for a declared field that
           LangExtract did not return (the "every declared field always
           present" API-stability invariant), or

--- a/apps/backend/app/features/extraction/schemas/extracted_field.py
+++ b/apps/backend/app/features/extraction/schemas/extracted_field.py
@@ -11,10 +11,17 @@ from app.features.extraction.schemas.field_status import FieldStatus
 class ExtractedField(BaseModel):
     """One field of a skill's declared output as produced by the pipeline.
 
-    ``value`` is typed as ``Any | None`` because each field's concrete type is
-    determined by the skill's ``output_schema`` (string, number, date, list,
-    object, etc.); the schema layer deliberately does not constrain it. The
-    per-field response invariant — every declared field is always present —
+    ``value`` is always ``str | None`` at runtime. LangExtract's
+    ``Extraction.extraction_text`` is the sole data source, so the value is
+    always the document text that the LLM identified for this field —
+    regardless of what the skill's ``output_schema`` declares as the field's
+    semantic type. The ``Any`` annotation is kept for forward compatibility
+    (a future version may coerce values to their declared schema type), but
+    callers should treat ``value`` as a plain string today.
+    ``None`` indicates a declared field that the pipeline could not extract
+    (status will be ``failed``).
+
+    The per-field response invariant — every declared field is always present —
     is enforced upstream in the service, not here.
     """
 

--- a/apps/backend/app/features/extraction/schemas/extracted_field.py
+++ b/apps/backend/app/features/extraction/schemas/extracted_field.py
@@ -11,13 +11,12 @@ from app.features.extraction.schemas.field_status import FieldStatus
 class ExtractedField(BaseModel):
     """One field of a skill's declared output as produced by the pipeline.
 
-    ``value`` is always ``str | None`` at runtime. LangExtract's
-    ``Extraction.extraction_text`` is the sole data source, so the value is
-    always the document text that the LLM identified for this field —
-    regardless of what the skill's ``output_schema`` declares as the field's
-    semantic type. The ``Any`` annotation is kept for forward compatibility
-    (a future version may coerce values to their declared schema type), but
-    callers should treat ``value`` as a plain string today.
+    ``value`` is always ``str | None`` at runtime — the raw string returned
+    by LangExtract (``Extraction.extraction_text``), which may be grounded
+    to document text when offsets are present, otherwise inferred. The
+    ``Any`` annotation is kept for forward compatibility (a future version
+    may coerce values to their declared schema type), but callers should
+    treat ``value`` as a plain string today.
     ``None`` indicates a declared field that the pipeline could not extract
     (status will be ``failed``).
 


### PR DESCRIPTION
## Summary

- Clarifies that `ExtractedField.value` and `RawExtraction.value` are always `str | None` at runtime, since LangExtract's `Extraction.extraction_text` is the sole data source
- Picks option 1 from issue #48: document current behavior as the spec rather than adding post-LangExtract validation against the skill schema
- Keeps the `Any` type annotation for forward compatibility but updates docstrings to set correct caller expectations

## Test plan

- [x] `task check` passes (lint, pyright, import-linter, unit, integration, contract)
- [x] No runtime behavior change -- docstring-only fix

Closes #48