### PR TITLE
fix(intelligence): widen httpx error boundary to catch all RequestError subclasses

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -160,6 +160,14 @@ class OllamaGemmaProvider(BaseLanguageModel):
             )
             _logger.warning("intelligence_unavailable", cause=cause, status=status)
             raise IntelligenceUnavailableError from exc
+        except httpx.RequestError as exc:
+            # Catch-all for transport-level failures that the specific handlers
+            # above do not cover: ReadError, RemoteProtocolError, WriteError,
+            # etc. Without this, those RequestError subclasses escape as raw
+            # exceptions and surface as HTTP 500 instead of 503.
+            # See: https://github.com/<owner>/<repo>/issues/49
+            _logger.warning("intelligence_unavailable", cause="request_error", error=str(exc))
+            raise IntelligenceUnavailableError from exc
 
         try:
             decoded: Any = response.json()
@@ -224,7 +232,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
         try:
             response = await self.http_client.get(self._tags_url)
             response.raise_for_status()
-        except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
+        except (httpx.RequestError, httpx.HTTPStatusError):
             return False
         return True
 

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -165,7 +165,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
             # above do not cover: ReadError, RemoteProtocolError, WriteError,
             # etc. Without this, those RequestError subclasses escape as raw
             # exceptions and surface as HTTP 500 instead of 503.
-            # See: https://github.com/<owner>/<repo>/issues/49
+            # See issue #49.
             _logger.warning("intelligence_unavailable", cause="request_error", error=str(exc))
             raise IntelligenceUnavailableError from exc
 

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -294,6 +294,44 @@ async def test_generate_http_503_logs_http_5xx_cause() -> None:
     assert event["status"] == 503
 
 
+async def test_generate_read_error_raises_intelligence_unavailable() -> None:
+    """httpx.ReadError (e.g. peer reset mid-stream) must not escape as HTTP 500.
+
+    Regression guard for GitHub issue #49: only ConnectError and TimeoutException
+    were caught, so broader RequestError subclasses like ReadError leaked through
+    the domain error boundary.
+    """
+    fake = _FakeAsyncClient(
+        post_outcomes=[
+            httpx.ReadError("peer closed connection without sending complete message body")
+        ],
+    )
+    provider = _build_provider(fake_client=fake)
+
+    with capture_logs() as logs, pytest.raises(IntelligenceUnavailableError) as excinfo:
+        await provider.generate("hi", _NAME_STRING_SCHEMA)
+    assert isinstance(excinfo.value.__cause__, httpx.ReadError)
+    event = next(e for e in logs if e.get("event") == "intelligence_unavailable")
+    assert event["cause"] == "request_error"
+
+
+async def test_generate_remote_protocol_error_raises_intelligence_unavailable() -> None:
+    """httpx.RemoteProtocolError (e.g. malformed HTTP response) must not escape.
+
+    Regression guard for GitHub issue #49.
+    """
+    fake = _FakeAsyncClient(
+        post_outcomes=[httpx.RemoteProtocolError("malformed HTTP message")],
+    )
+    provider = _build_provider(fake_client=fake)
+
+    with capture_logs() as logs, pytest.raises(IntelligenceUnavailableError) as excinfo:
+        await provider.generate("hi", _NAME_STRING_SCHEMA)
+    assert isinstance(excinfo.value.__cause__, httpx.RemoteProtocolError)
+    event = next(e for e in logs if e.get("event") == "intelligence_unavailable")
+    assert event["cause"] == "request_error"
+
+
 async def test_generate_raises_intelligence_unavailable_when_body_json_is_list() -> None:
     """Non-dict JSON bodies must not leak AttributeError.
 
@@ -423,6 +461,32 @@ async def test_health_check_returns_false_on_http_error() -> None:
         get_outcomes=[
             _FakeResponse(status_code=500, status_error=_http_status_error(500)),
         ],
+    )
+    provider = _build_provider(fake_client=fake)
+
+    assert await provider.health_check() is False
+
+
+async def test_health_check_returns_false_on_read_error() -> None:
+    """ReadError during health check must return False, not crash.
+
+    Regression guard for GitHub issue #49.
+    """
+    fake = _FakeAsyncClient(
+        get_outcomes=[httpx.ReadError("peer reset")],
+    )
+    provider = _build_provider(fake_client=fake)
+
+    assert await provider.health_check() is False
+
+
+async def test_health_check_returns_false_on_remote_protocol_error() -> None:
+    """RemoteProtocolError during health check must return False, not crash.
+
+    Regression guard for GitHub issue #49.
+    """
+    fake = _FakeAsyncClient(
+        get_outcomes=[httpx.RemoteProtocolError("malformed HTTP message")],
     )
     provider = _build_provider(fake_client=fake)
 


### PR DESCRIPTION
## Summary
- Adds a catch-all `httpx.RequestError` handler in `OllamaGemmaProvider._raw_generate()` after the existing specific handlers (`ConnectError`, `TimeoutException`, `HTTPStatusError`), translating previously-uncaught transport errors (`ReadError`, `RemoteProtocolError`, etc.) to `IntelligenceUnavailableError` (503) instead of leaking as raw HTTP 500.
- Widens the `health_check()` except clause from `(ConnectError, TimeoutException, HTTPStatusError)` to `(RequestError, HTTPStatusError)` for the same coverage.
- Adds four regression tests: `ReadError` and `RemoteProtocolError` for both `generate()` and `health_check()`.

Closes #49

## Test plan
- [x] `test_generate_read_error_raises_intelligence_unavailable` -- ReadError in `_raw_generate` maps to IntelligenceUnavailableError with `cause=request_error`
- [x] `test_generate_remote_protocol_error_raises_intelligence_unavailable` -- RemoteProtocolError in `_raw_generate` maps to IntelligenceUnavailableError
- [x] `test_health_check_returns_false_on_read_error` -- ReadError in `health_check` returns False
- [x] `test_health_check_returns_false_on_remote_protocol_error` -- RemoteProtocolError in `health_check` returns False
- [x] All 32 existing provider unit tests still pass
- [x] `task check` green (lint, format, type-check, import-linter, unit, integration, contract)