### PR TITLE
fix(skills): deep-freeze SkillExample.output (#52)

### DIFF
--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -54,6 +54,7 @@ from app.features.extraction.extraction.raw_extraction import RawExtraction
 from app.features.extraction.intelligence.langextract_wrapper_schema import (
     LANGEXTRACT_WRAPPER_SCHEMA,
 )
+from app.features.extraction.skills.deep_freeze import thaw
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -201,7 +202,10 @@ class ExtractionEngine:
             extractions = [
                 Extraction(
                     extraction_class=field_name,
-                    extraction_text=str(value),
+                    # Thaw frozen values (MappingProxyType -> dict, tuple ->
+                    # list) before str() so prompt serialization matches the
+                    # plain-dict/list representation skill authors expect.
+                    extraction_text=str(thaw(value)),
                 )
                 for field_name, value in example.output.items()
             ]

--- a/apps/backend/app/features/extraction/skills/deep_freeze.py
+++ b/apps/backend/app/features/extraction/skills/deep_freeze.py
@@ -1,0 +1,39 @@
+"""Deep-freeze and thaw helpers for immutable nested structures.
+
+Shared by `SkillExample` (freezes example outputs) and `Skill` (freezes
+`output_schema`). Extracted to a single module to avoid duplicating the
+recursion logic.
+"""
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any, cast
+
+
+def deep_freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Recursively wrap nested mappings in ``MappingProxyType`` and sequences in tuples."""
+    return MappingProxyType({str(k): _freeze_any(v) for k, v in value.items()})
+
+
+def _freeze_any(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return deep_freeze_mapping(cast("Mapping[str, Any]", value))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_any(item) for item in cast("list[Any] | tuple[Any, ...]", value))
+    return value
+
+
+def thaw(value: Any) -> Any:
+    """Recursively convert frozen structures back to plain dicts/lists.
+
+    ``SkillExample`` deep-freezes its ``output`` into ``MappingProxyType`` +
+    tuples. jsonschema's Draft7Validator does not accept ``MappingProxyType``
+    as ``"object"`` type, so we thaw just for validation.
+    """
+    if isinstance(value, Mapping):
+        mapping = cast("Mapping[str, Any]", value)
+        return {str(k): thaw(v) for k, v in mapping.items()}
+    if isinstance(value, (list, tuple)):
+        seq = cast("list[Any] | tuple[Any, ...]", value)
+        return [thaw(item) for item in seq]
+    return value

--- a/apps/backend/app/features/extraction/skills/skill.py
+++ b/apps/backend/app/features/extraction/skills/skill.py
@@ -9,9 +9,9 @@ defaults — the resulting `docling_config` is always a concrete
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 
+from app.features.extraction.skills.deep_freeze import deep_freeze_mapping
 from app.features.extraction.skills.skill_docling_config import SkillDoclingConfig
 from app.features.extraction.skills.skill_example import SkillExample
 from app.features.extraction.skills.skill_yaml_schema import SkillYamlSchema
@@ -64,19 +64,6 @@ class Skill:
             # Deep-freeze nested dicts/lists too — a shallow `MappingProxyType`
             # would leave `output_schema["properties"][...]` mutable, which
             # violates the "immutable runtime object" contract.
-            output_schema=_deep_freeze_mapping(schema.output_schema),
+            output_schema=deep_freeze_mapping(schema.output_schema),
             docling_config=merged,
         )
-
-
-def _deep_freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Recursively wrap nested mappings in `MappingProxyType` and lists in tuples."""
-    return MappingProxyType({str(k): _freeze_any(v) for k, v in value.items()})
-
-
-def _freeze_any(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return _deep_freeze_mapping(cast("Mapping[str, Any]", value))
-    if isinstance(value, list):
-        return tuple(_freeze_any(item) for item in cast("list[Any]", value))
-    return value

--- a/apps/backend/app/features/extraction/skills/skill_example.py
+++ b/apps/backend/app/features/extraction/skills/skill_example.py
@@ -1,6 +1,8 @@
 """Few-shot example embedded in a skill YAML file."""
 
-from typing import Any
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict
 
@@ -11,9 +13,34 @@ class SkillExample(BaseModel):
     `input` is the raw text the model should treat as the document body for
     this demonstration. `output` is the structured dict the model should
     produce — it must conform to the enclosing skill's `output_schema`.
+
+    The `output` dict is deep-frozen at construction time so that callers
+    cannot silently mutate example outputs and change extraction prompts.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     input: str
-    output: dict[str, Any]
+    output: Mapping[str, Any]
+
+    def model_post_init(self, _context: Any, /) -> None:
+        """Deep-freeze ``output`` after Pydantic validation finishes.
+
+        Pydantic's ``frozen=True`` prevents attribute reassignment on the
+        model, so we bypass it via ``object.__setattr__`` — the same
+        pattern Pydantic itself uses in ``model_post_init``.
+        """
+        object.__setattr__(self, "output", _deep_freeze_mapping(self.output))
+
+
+def _deep_freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Recursively wrap nested mappings in ``MappingProxyType`` and lists in tuples."""
+    return MappingProxyType({str(k): _freeze_any(v) for k, v in value.items()})
+
+
+def _freeze_any(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _deep_freeze_mapping(cast("Mapping[str, Any]", value))
+    if isinstance(value, list):
+        return tuple(_freeze_any(item) for item in cast("list[Any]", value))
+    return value

--- a/apps/backend/app/features/extraction/skills/skill_example.py
+++ b/apps/backend/app/features/extraction/skills/skill_example.py
@@ -1,10 +1,11 @@
 """Few-shot example embedded in a skill YAML file."""
 
 from collections.abc import Mapping
-from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
+
+from app.features.extraction.skills.deep_freeze import deep_freeze_mapping
 
 
 class SkillExample(BaseModel):
@@ -30,17 +31,4 @@ class SkillExample(BaseModel):
         model, so we bypass it via ``object.__setattr__`` — the same
         pattern Pydantic itself uses in ``model_post_init``.
         """
-        object.__setattr__(self, "output", _deep_freeze_mapping(self.output))
-
-
-def _deep_freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Recursively wrap nested mappings in ``MappingProxyType`` and lists in tuples."""
-    return MappingProxyType({str(k): _freeze_any(v) for k, v in value.items()})
-
-
-def _freeze_any(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return _deep_freeze_mapping(cast("Mapping[str, Any]", value))
-    if isinstance(value, list):
-        return tuple(_freeze_any(item) for item in cast("list[Any]", value))
-    return value
+        object.__setattr__(self, "output", deep_freeze_mapping(self.output))

--- a/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
+++ b/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
@@ -12,8 +12,9 @@ When multiple problems are present, they are aggregated into one
 `SkillValidationFailedError` so the skill author sees them all in one pass.
 """
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import yaml
 from jsonschema import Draft7Validator
@@ -67,7 +68,11 @@ class SkillYamlSchema(BaseModel):
             # binding the method locally lets us silence exactly that call
             # without hiding any behavior.
             iter_errors = validator.iter_errors  # type: ignore[reportUnknownMemberType]
-            errors = sorted(iter_errors(example.output), key=str)
+            # SkillExample deep-freezes `output` (MappingProxyType + tuples)
+            # at construction time.  jsonschema does not recognise
+            # MappingProxyType as an ``"object"`` type, so we thaw the
+            # frozen value back to plain dicts/lists for validation.
+            errors = sorted(iter_errors(_thaw(example.output)), key=str)
             for error in errors:
                 path_parts: list[str] = [str(p) for p in error.absolute_path]
                 path = "/" + "/".join(path_parts)
@@ -125,3 +130,19 @@ class SkillYamlSchema(BaseModel):
             raise SkillValidationFailedError(file=file_str, reason=msg)
 
         return instance
+
+
+def _thaw(value: Any) -> dict[str, Any] | list[Any] | Any:
+    """Recursively convert frozen structures back to plain dicts/lists.
+
+    ``SkillExample`` deep-freezes its ``output`` into ``MappingProxyType`` +
+    tuples. jsonschema's Draft7Validator does not accept ``MappingProxyType``
+    as ``"object"`` type, so we thaw just for validation.
+    """
+    if isinstance(value, Mapping):
+        mapping = cast("Mapping[str, Any]", value)
+        return {str(k): _thaw(v) for k, v in mapping.items()}
+    if isinstance(value, (list, tuple)):
+        seq = cast("list[Any] | tuple[Any, ...]", value)
+        return [_thaw(item) for item in seq]
+    return value

--- a/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
+++ b/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
@@ -12,9 +12,8 @@ When multiple problems are present, they are aggregated into one
 `SkillValidationFailedError` so the skill author sees them all in one pass.
 """
 
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Self, cast
+from typing import Any, Self
 
 import yaml
 from jsonschema import Draft7Validator
@@ -22,6 +21,7 @@ from jsonschema.exceptions import SchemaError
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.exceptions import SkillValidationFailedError
+from app.features.extraction.skills.deep_freeze import thaw
 from app.features.extraction.skills.skill_docling_config import SkillDoclingConfig
 from app.features.extraction.skills.skill_example import SkillExample
 
@@ -72,7 +72,7 @@ class SkillYamlSchema(BaseModel):
             # at construction time.  jsonschema does not recognise
             # MappingProxyType as an ``"object"`` type, so we thaw the
             # frozen value back to plain dicts/lists for validation.
-            errors = sorted(iter_errors(_thaw(example.output)), key=str)
+            errors = sorted(iter_errors(thaw(example.output)), key=str)
             for error in errors:
                 path_parts: list[str] = [str(p) for p in error.absolute_path]
                 path = "/" + "/".join(path_parts)
@@ -130,19 +130,3 @@ class SkillYamlSchema(BaseModel):
             raise SkillValidationFailedError(file=file_str, reason=msg)
 
         return instance
-
-
-def _thaw(value: Any) -> dict[str, Any] | list[Any] | Any:
-    """Recursively convert frozen structures back to plain dicts/lists.
-
-    ``SkillExample`` deep-freezes its ``output`` into ``MappingProxyType`` +
-    tuples. jsonschema's Draft7Validator does not accept ``MappingProxyType``
-    as ``"object"`` type, so we thaw just for validation.
-    """
-    if isinstance(value, Mapping):
-        mapping = cast("Mapping[str, Any]", value)
-        return {str(k): _thaw(v) for k, v in mapping.items()}
-    if isinstance(value, (list, tuple)):
-        seq = cast("list[Any] | tuple[Any, ...]", value)
-        return [_thaw(item) for item in seq]
-    return value

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill.py
@@ -86,6 +86,40 @@ def test_skill_output_schema_is_deeply_immutable() -> None:
         required.append("b")  # type: ignore[attr-defined]
 
 
+def test_skill_example_output_is_deeply_immutable() -> None:
+    """SkillExample.output must be deep-frozen so callers cannot silently
+    mutate example outputs and change extraction prompts.
+    """
+    example = SkillExample(
+        input="invoice text",
+        output={"vendor": "Acme", "items": [{"sku": "A1"}]},
+    )
+
+    # Top-level dict mutation must fail
+    with pytest.raises(TypeError):
+        example.output["injected"] = "hacked"  # type: ignore[index]
+
+    # Nested dict mutation must fail
+    with pytest.raises(TypeError):
+        example.output["items"][0]["sku"] = "B2"  # type: ignore[index]
+
+    # Nested list → tuple, so .append must fail
+    items = example.output["items"]
+    assert isinstance(items, tuple)
+    with pytest.raises((TypeError, AttributeError)):
+        items.append({"sku": "C3"})  # type: ignore[attr-defined]
+
+
+def test_skill_example_output_frozen_from_schema() -> None:
+    """SkillExample.output must remain frozen when accessed through Skill."""
+    schema = _valid_schema()
+    skill = Skill.from_schema(schema)
+    ex = skill.examples[0]
+
+    with pytest.raises(TypeError):
+        ex.output["a"] = "hacked"  # type: ignore[index]
+
+
 def test_docling_config_is_merged_not_raw_override() -> None:
     schema = _valid_schema(docling=SkillDoclingConfig(ocr="auto"))
     default = SkillDoclingConfig(ocr="off", table_mode="fast")


### PR DESCRIPTION
## Summary
- Deep-freeze `SkillExample.output` at construction time via `model_post_init`, preventing silent in-place mutation of example outputs that could change extraction prompts
- Add public `thaw()` helper in `deep_freeze.py` so jsonschema validation (which does not recognise `MappingProxyType`) continues to work against frozen example outputs; `SkillYamlSchema` calls `thaw()` before passing data to the validator
- Add two new tests: `test_skill_example_output_is_deeply_immutable` (direct construction) and `test_skill_example_output_frozen_from_schema` (through `Skill.from_schema`)

Closes #52

## Test plan
- [x] `test_skill_example_output_is_deeply_immutable` -- verifies top-level dict, nested dict, and nested list mutations all raise TypeError
- [x] `test_skill_example_output_frozen_from_schema` -- verifies freeze survives the full `SkillYamlSchema -> Skill.from_schema` pipeline
- [x] All 57 existing skill unit tests continue to pass
- [x] `task check` passes clean (lint, arch, format, types, unit, integration, contract, errors)