### PR TITLE
fix(intelligence): create fresh AsyncClient per infer() call

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -23,6 +23,15 @@ async HTTP path via `asyncio.run` inside `infer`. This is safe because
 If `infer` is ever called directly from an async context, `asyncio.run` raises
 `RuntimeError("This event loop is already running")` — the right outcome,
 because it surfaces the incorrect call site instead of deadlocking.
+
+Each ``infer()`` call creates a fresh ``httpx.AsyncClient`` inside the
+``asyncio.run`` scope rather than reusing the instance-level client (issue #47).
+``asyncio.run`` closes the event loop on return, and httpx binds its connection
+pool to the loop on first use; reusing the instance client across two
+``asyncio.run`` calls would raise ``RuntimeError: Event loop is closed`` on the
+second invocation. The instance-level ``http_client`` is still used by the
+``generate()`` and ``health_check()`` async paths, which run inside an
+already-running loop and do not have the loop-per-call problem.
 """
 
 from __future__ import annotations
@@ -118,10 +127,9 @@ class OllamaGemmaProvider(BaseLanguageModel):
         self._model = model_id or effective_settings.ollama_model
         self._generate_url = _build_generate_url(effective_settings.ollama_base_url)
         self._tags_url = build_tags_url(effective_settings.ollama_base_url)
+        self._timeout = httpx.Timeout(effective_settings.ollama_timeout_seconds)
         self._validator = effective_validator
-        self.http_client = http_client or httpx.AsyncClient(
-            timeout=httpx.Timeout(effective_settings.ollama_timeout_seconds),
-        )
+        self.http_client = http_client or httpx.AsyncClient(timeout=self._timeout)
 
     async def generate(
         self,
@@ -140,10 +148,16 @@ class OllamaGemmaProvider(BaseLanguageModel):
             original_prompt=prompt,
         )
 
-    async def _raw_generate(self, prompt: str) -> str:
+    async def _raw_generate(
+        self,
+        prompt: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> str:
+        http = client or self.http_client
         payload = _build_payload(self._model, prompt)
         try:
-            response = await self.http_client.post(self._generate_url, json=payload)
+            response = await http.post(self._generate_url, json=payload)
             response.raise_for_status()
         except httpx.ConnectError as exc:
             _logger.warning("intelligence_unavailable", cause="connect_error", error=str(exc))
@@ -196,20 +210,37 @@ class OllamaGemmaProvider(BaseLanguageModel):
         return response_text
 
     async def _validated_generate_batch(self, batch_prompts: Sequence[str]) -> list[str]:
-        # Every prompt runs inside the SAME event loop so the shared
-        # `httpx.AsyncClient` binds its connection pool to one loop only. If
-        # `infer` called `asyncio.run` per prompt, the second prompt would hit
-        # a client whose pool is bound to a closed loop. Each prompt routes
-        # through `self.generate`, which runs the `StructuredOutputValidator`
-        # fence-strip + JSON-parse + retry loop against the LangExtract
-        # wrapper schema — so the plugin entry path enforces the same
-        # CLAUDE.md-mandated "no bypass" invariant as the `generate()` path
-        # the `_ValidatingLangExtractAdapter` in `extraction_engine.py` uses.
-        outputs: list[str] = []
-        for prompt in batch_prompts:
-            result = await self.generate(prompt, LANGEXTRACT_WRAPPER_SCHEMA)
-            outputs.append(json.dumps(result.data))
-        return outputs
+        # A fresh ``AsyncClient`` is created per ``infer()`` call so that each
+        # ``asyncio.run`` scope gets its own loop+client pair. Reusing the
+        # instance-level ``self.http_client`` across separate ``asyncio.run``
+        # invocations causes ``RuntimeError: Event loop is closed`` on the
+        # second call because httpx binds its connection pool to the first
+        # loop, which ``asyncio.run`` closes on return (issue #47).
+        #
+        # Every prompt in the batch shares the same fresh client — and therefore
+        # the same event loop — so connection pooling still works within a
+        # single batch. Each prompt routes through ``self.generate``, which
+        # runs the ``StructuredOutputValidator`` fence-strip + JSON-parse +
+        # retry loop against the LangExtract wrapper schema, so the plugin
+        # entry path enforces the same CLAUDE.md-mandated "no bypass" invariant
+        # as the ``generate()`` path the ``_ValidatingLangExtractAdapter`` in
+        # ``extraction_engine.py`` uses.
+        async with httpx.AsyncClient(timeout=self._timeout) as batch_client:
+            outputs: list[str] = []
+            for prompt in batch_prompts:
+                raw_text = await self._raw_generate(prompt, client=batch_client)
+
+                async def _regenerate(correction_prompt: str) -> str:
+                    return await self._raw_generate(correction_prompt, client=batch_client)
+
+                result = await self._validator.validate_and_retry(
+                    raw_text,
+                    LANGEXTRACT_WRAPPER_SCHEMA,
+                    _regenerate,
+                    original_prompt=prompt,
+                )
+                outputs.append(json.dumps(result.data))
+            return outputs
 
     def infer(
         self,

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -136,14 +136,30 @@ class OllamaGemmaProvider(BaseLanguageModel):
         prompt: str,
         output_schema: dict[str, Any],
     ) -> GenerationResult:
-        raw_text = await self._raw_generate(prompt)
+        return await self._validated_generate(prompt, output_schema, client=self.http_client)
+
+    async def _validated_generate(
+        self,
+        prompt: str,
+        schema: dict[str, Any],
+        *,
+        client: httpx.AsyncClient,
+    ) -> GenerationResult:
+        """Shared validate-and-retry path for both ``generate()`` and ``infer()``.
+
+        Calls ``_raw_generate`` on the given *client*, then runs the
+        ``StructuredOutputValidator`` fence-strip + JSON-parse + retry loop
+        against *schema*. Retries also route through the same *client* so
+        connection-pool affinity is preserved within a single event loop.
+        """
+        raw_text = await self._raw_generate(prompt, client=client)
 
         async def _regenerate(correction_prompt: str) -> str:
-            return await self._raw_generate(correction_prompt)
+            return await self._raw_generate(correction_prompt, client=client)
 
         return await self._validator.validate_and_retry(
             raw_text,
-            output_schema,
+            schema,
             _regenerate,
             original_prompt=prompt,
         )
@@ -219,25 +235,20 @@ class OllamaGemmaProvider(BaseLanguageModel):
         #
         # Every prompt in the batch shares the same fresh client — and therefore
         # the same event loop — so connection pooling still works within a
-        # single batch. Each prompt routes through ``self.generate``, which
-        # runs the ``StructuredOutputValidator`` fence-strip + JSON-parse +
-        # retry loop against the LangExtract wrapper schema, so the plugin
-        # entry path enforces the same CLAUDE.md-mandated "no bypass" invariant
-        # as the ``generate()`` path the ``_ValidatingLangExtractAdapter`` in
-        # ``extraction_engine.py`` uses.
+        # single batch. Each prompt routes through ``_validated_generate``,
+        # the shared helper that both ``generate()`` and this batch path use,
+        # running the ``StructuredOutputValidator`` fence-strip + JSON-parse +
+        # retry loop against the LangExtract wrapper schema. This ensures the
+        # plugin entry path enforces the same CLAUDE.md-mandated "no bypass"
+        # invariant as the ``generate()`` path the
+        # ``_ValidatingLangExtractAdapter`` in ``extraction_engine.py`` uses.
         async with httpx.AsyncClient(timeout=self._timeout) as batch_client:
             outputs: list[str] = []
             for prompt in batch_prompts:
-                raw_text = await self._raw_generate(prompt, client=batch_client)
-
-                async def _regenerate(correction_prompt: str) -> str:
-                    return await self._raw_generate(correction_prompt, client=batch_client)
-
-                result = await self._validator.validate_and_retry(
-                    raw_text,
+                result = await self._validated_generate(
+                    prompt,
                     LANGEXTRACT_WRAPPER_SCHEMA,
-                    _regenerate,
-                    original_prompt=prompt,
+                    client=batch_client,
                 )
                 outputs.append(json.dumps(result.data))
             return outputs

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Self
 
 import httpx
 import pytest
@@ -106,6 +107,12 @@ class _FakeAsyncClient:
         self.aclose_calls += 1
         self.is_closed = True
 
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
+
 
 def _build_settings(
     *,
@@ -140,6 +147,22 @@ def _build_provider(
         validator=_build_validator(real_settings),
         http_client=fake_client,  # type: ignore[arg-type]  # test seam: FakeAsyncClient quacks like httpx.AsyncClient
     )
+
+
+def _patch_infer_client(
+    monkeypatch: pytest.MonkeyPatch,
+    post_outcomes: Sequence[_FakeResponse | BaseException],
+) -> _FakeAsyncClient:
+    """Patch ``httpx.AsyncClient`` in the provider module so ``infer()``'s
+    fresh-client construction returns a ``_FakeAsyncClient`` with the given
+    scripted responses. Returns the fake so callers can inspect ``post_calls``.
+    """
+    fake = _FakeAsyncClient(post_outcomes=post_outcomes)
+    monkeypatch.setattr(
+        "app.features.extraction.intelligence.ollama_gemma_provider.httpx.AsyncClient",
+        lambda **_kwargs: fake,
+    )
+    return fake
 
 
 def _http_status_error(status: int) -> httpx.HTTPStatusError:
@@ -450,14 +473,17 @@ def test_intelligence_unavailable_error_is_domain_error_subclass() -> None:
 # same failure mode documented in the provider's module docstring.
 
 
-def test_infer_yields_one_scored_output_per_prompt() -> None:
-    fake = _FakeAsyncClient(
+def test_infer_yields_one_scored_output_per_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _patch_infer_client(
+        monkeypatch,
         post_outcomes=[
             _FakeResponse(body={"response": '{"extractions":[{"a":1}]}'}),
             _FakeResponse(body={"response": '{"extractions":[{"b":2}]}'}),
         ],
     )
-    provider = _build_provider(fake_client=fake)
+    provider = _build_provider(fake_client=_FakeAsyncClient())
 
     results = list(provider.infer(["p1", "p2"]))
 
@@ -471,13 +497,18 @@ def test_infer_yields_one_scored_output_per_prompt() -> None:
     assert len(fake.post_calls) == 2
 
 
-def test_infer_routes_raw_text_through_structured_output_validator() -> None:
+def test_infer_routes_raw_text_through_structured_output_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # Fenced JSON must be cleaned by the validator's normalization step before
     # LangExtract's resolver sees it. If `infer` bypassed the validator, the
     # yielded output would still contain the ```json fence.
     fenced = '```json\n{"extractions":[]}\n```'
-    fake = _FakeAsyncClient(post_outcomes=[_FakeResponse(body={"response": fenced})])
-    provider = _build_provider(fake_client=fake)
+    _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[_FakeResponse(body={"response": fenced})],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
 
     results = list(provider.infer(["p1"]))
 
@@ -485,18 +516,21 @@ def test_infer_routes_raw_text_through_structured_output_validator() -> None:
     assert json.loads(results[0][0].output) == {"extractions": []}
 
 
-def test_infer_retries_on_wrapper_schema_violation_then_succeeds() -> None:
+def test_infer_retries_on_wrapper_schema_violation_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # First response is valid JSON but does NOT match the LangExtract wrapper
     # schema (`{"extractions": array}`). Validator retries; second response is
     # valid. Pins the contract that `infer` enforces the wrapper schema — not
     # just JSON parseability.
-    fake = _FakeAsyncClient(
+    fake = _patch_infer_client(
+        monkeypatch,
         post_outcomes=[
             _FakeResponse(body={"response": '{"wrong":"shape"}'}),
             _FakeResponse(body={"response": '{"extractions":[]}'}),
         ],
     )
-    provider = _build_provider(fake_client=fake)
+    provider = _build_provider(fake_client=_FakeAsyncClient())
 
     results = list(provider.infer(["p1"]))
 
@@ -504,11 +538,64 @@ def test_infer_retries_on_wrapper_schema_violation_then_succeeds() -> None:
     assert len(fake.post_calls) == 2
 
 
-def test_infer_propagates_intelligence_unavailable_error_on_connect_failure() -> None:
-    fake = _FakeAsyncClient(
+def test_infer_creates_fresh_http_client_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: issue #47 — ``infer()`` must create a fresh ``AsyncClient``
+    inside the ``asyncio.run`` scope, not reuse the instance-level one.
+
+    ``asyncio.run`` creates and then closes a fresh event loop each invocation.
+    If the ``httpx.AsyncClient`` stored on the instance is reused across two
+    ``asyncio.run`` calls, the second call finds the client's connection pool
+    bound to the now-closed first loop and raises ``RuntimeError: Event loop is
+    closed``. The fix is to create a fresh ``AsyncClient`` inside the
+    event-loop scope so each ``infer()`` gets its own matched loop+client pair.
+
+    This test pins the contract by intercepting ``httpx.AsyncClient``
+    construction during ``infer()`` and counting instantiations. Before the
+    fix, the count is zero (the instance-level client is reused). After the
+    fix, each ``infer()`` call creates exactly one fresh client.
+    """
+    wrapper_body = {"response": '{"extractions":[]}'}
+    construction_count = 0
+
+    def _fake_async_client_factory(**_kwargs: Any) -> _FakeAsyncClient:
+        nonlocal construction_count
+        construction_count += 1
+        return _FakeAsyncClient(  # type: ignore[return-value]  # test seam
+            post_outcomes=[_FakeResponse(body=wrapper_body)],
+        )
+
+    monkeypatch.setattr(
+        "app.features.extraction.intelligence.ollama_gemma_provider.httpx.AsyncClient",
+        _fake_async_client_factory,
+    )
+
+    # Provider's own http_client was built before the patch; it is used only
+    # by the `generate()`/`health_check()` async paths, not by `infer()`.
+    fake = _FakeAsyncClient(post_outcomes=[])
+    provider = _build_provider(fake_client=fake)
+
+    construction_count = 0
+    list(provider.infer(["p1"]))
+    first_call_count = construction_count
+
+    list(provider.infer(["p2"]))
+    second_call_count = construction_count - first_call_count
+
+    # Each infer() call must create exactly one fresh AsyncClient.
+    assert first_call_count == 1, f"first infer() should create 1 client, got {first_call_count}"
+    assert second_call_count == 1, f"second infer() should create 1 client, got {second_call_count}"
+
+
+def test_infer_propagates_intelligence_unavailable_error_on_connect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_infer_client(
+        monkeypatch,
         post_outcomes=[httpx.ConnectError("refused")],
     )
-    provider = _build_provider(fake_client=fake)
+    provider = _build_provider(fake_client=_FakeAsyncClient())
 
     with pytest.raises(IntelligenceUnavailableError):
         list(provider.infer(["p1"]))
@@ -524,6 +611,15 @@ def test_infer_uses_a_single_asyncio_run_for_the_whole_batch(
     # — pinned here by counting invocations.
     import asyncio as _asyncio
 
+    _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[
+            _FakeResponse(body={"response": '{"extractions":[]}'}),
+            _FakeResponse(body={"response": '{"extractions":[]}'}),
+            _FakeResponse(body={"response": '{"extractions":[]}'}),
+        ],
+    )
+
     call_count = 0
     real_run = _asyncio.run
 
@@ -537,14 +633,7 @@ def test_infer_uses_a_single_asyncio_run_for_the_whole_batch(
         counting_run,
     )
 
-    fake = _FakeAsyncClient(
-        post_outcomes=[
-            _FakeResponse(body={"response": '{"extractions":[]}'}),
-            _FakeResponse(body={"response": '{"extractions":[]}'}),
-            _FakeResponse(body={"response": '{"extractions":[]}'}),
-        ],
-    )
-    provider = _build_provider(fake_client=fake)
+    provider = _build_provider(fake_client=_FakeAsyncClient())
 
     results = list(provider.infer(["p1", "p2", "p3"]))
 


### PR DESCRIPTION
## Summary
- **Fixes #47**: `OllamaGemmaProvider.infer()` now creates a fresh `httpx.AsyncClient` inside the `asyncio.run` scope instead of reusing the instance-level client
- Each `infer()` call gets its own matched event-loop + client pair, preventing `RuntimeError: Event loop is closed` on the second invocation
- The instance-level `http_client` is still used by the `generate()` and `health_check()` async paths, which run inside an already-running loop

## Test plan
- [x] New regression test `test_infer_creates_fresh_http_client_per_call` pins the fresh-client-per-call contract
- [x] Existing `infer` tests updated to use `_patch_infer_client` helper for the new client-construction path
- [x] All 575 unit, 80 integration, 8 contract tests pass
- [x] Pyright strict: 0 errors
- [x] Architecture contracts: 11 kept, 0 broken
- [x] `task check` green