### PR TITLE
fix(api): set X-Request-Id header on error responses

### DIFF
--- a/apps/backend/app/api/errors.py
+++ b/apps/backend/app/api/errors.py
@@ -26,6 +26,7 @@ def register_exception_handlers(app: FastAPI) -> None:
         request_id = _get_request_id(request)
         return JSONResponse(
             status_code=exc.http_status,
+            headers={"X-Request-Id": request_id},
             content={
                 "error": {
                     "code": exc.code,
@@ -53,6 +54,7 @@ def register_exception_handlers(app: FastAPI) -> None:
         first = details[0] if details else {"field": "unknown", "reason": "unknown"}
         return JSONResponse(
             status_code=422,
+            headers={"X-Request-Id": request_id},
             content={
                 "error": {
                     "code": "VALIDATION_FAILED",
@@ -76,6 +78,7 @@ def register_exception_handlers(app: FastAPI) -> None:
         )
         return JSONResponse(
             status_code=500,
+            headers={"X-Request-Id": request_id},
             content={
                 "error": {
                     "code": "INTERNAL_ERROR",

--- a/apps/backend/app/api/errors.py
+++ b/apps/backend/app/api/errors.py
@@ -13,8 +13,13 @@ logger = structlog.get_logger(__name__)
 
 
 def _get_request_id(request: Request) -> str:
-    """Extract request ID from request state, set by RequestIdMiddleware."""
-    return getattr(request.state, "request_id", uuid4().hex)
+    """Extract request ID from request state, set by RequestIdMiddleware.
+
+    Falls back to a fresh ``uuid4().hex`` when the middleware is absent so the
+    ``X-Request-Id`` header always contains a valid 32-char hex string.
+    """
+    rid: str | None = getattr(request.state, "request_id", None)
+    return rid or uuid4().hex
 
 
 def register_exception_handlers(app: FastAPI) -> None:

--- a/apps/backend/app/api/errors.py
+++ b/apps/backend/app/api/errors.py
@@ -1,5 +1,7 @@
 """Exception handlers — maps DomainError subclasses to HTTP error responses."""
 
+from uuid import uuid4
+
 import structlog
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
@@ -12,7 +14,7 @@ logger = structlog.get_logger(__name__)
 
 def _get_request_id(request: Request) -> str:
     """Extract request ID from request state, set by RequestIdMiddleware."""
-    return getattr(request.state, "request_id", "unknown")
+    return getattr(request.state, "request_id", uuid4().hex)
 
 
 def register_exception_handlers(app: FastAPI) -> None:

--- a/apps/backend/tests/unit/api/test_request_id_middleware.py
+++ b/apps/backend/tests/unit/api/test_request_id_middleware.py
@@ -76,6 +76,7 @@ async def test_x_request_id_present_on_domain_error_responses() -> None:
     assert response.status_code == 404
     assert "x-request-id" in response.headers
     assert HEX32.match(response.headers["x-request-id"])
+    assert response.headers["x-request-id"] == response.json()["error"]["request_id"]
 
 
 async def test_x_request_id_present_on_unhandled_500_responses() -> None:
@@ -101,6 +102,7 @@ async def test_x_request_id_present_on_unhandled_500_responses() -> None:
     assert response.status_code == 500
     assert "x-request-id" in response.headers
     assert HEX32.match(response.headers["x-request-id"])
+    assert response.headers["x-request-id"] == response.json()["error"]["request_id"]
 
 
 async def test_concurrent_requests_each_get_distinct_ids(app: FastAPI) -> None:

--- a/apps/backend/tests/unit/api/test_request_id_middleware.py
+++ b/apps/backend/tests/unit/api/test_request_id_middleware.py
@@ -78,6 +78,31 @@ async def test_x_request_id_present_on_domain_error_responses() -> None:
     assert HEX32.match(response.headers["x-request-id"])
 
 
+async def test_x_request_id_present_on_unhandled_500_responses() -> None:
+    """X-Request-Id must appear on 500 responses produced by the catch-all
+    ``handle_unhandled`` exception handler.  Before the fix, when ``call_next``
+    raised an exception that was later caught by the exception handler, the
+    middleware never got to set the header on the resulting response.
+    """
+    from app.api.errors import register_exception_handlers
+
+    application = FastAPI()
+    application.add_middleware(RequestIdMiddleware)
+    register_exception_handlers(application)
+
+    @application.get("/_unhandled")
+    async def _unhandled() -> dict[str, str]:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    transport = ASGITransport(app=application, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/_unhandled")
+    assert response.status_code == 500
+    assert "x-request-id" in response.headers
+    assert HEX32.match(response.headers["x-request-id"])
+
+
 async def test_concurrent_requests_each_get_distinct_ids(app: FastAPI) -> None:
     import asyncio
 


### PR DESCRIPTION
## Summary
- Fixes #55: Unhandled 500 responses now include the `X-Request-Id` response header.
- Root cause: Starlette hoists `@app.exception_handler(Exception)` to `ServerErrorMiddleware`, which sits **outside** all user middleware including `RequestIdMiddleware`. The 500 response was therefore created after the middleware, so the header was never set.
- Fix: all three exception handlers in `errors.py` now include `X-Request-Id` directly in the `JSONResponse` `headers` kwarg. For `DomainError` and `RequestValidationError` (handled inside `ExceptionMiddleware`), the middleware also sets the header, which is harmless (same value). For `Exception` (handled by `ServerErrorMiddleware`), the handler is the only path.

## Test plan
- [x] New unit test `test_x_request_id_present_on_unhandled_500_responses` raises `RuntimeError` through the full middleware+handler stack and asserts `X-Request-Id` is present with 32-char hex format.
- [x] All existing middleware tests pass (7/7).
- [x] All error handler tests pass (5/5).
- [x] `task check` green (lint, arch, typecheck, unit, integration, contract).