### PR TITLE
chore(taskfile): include error-contracts tests in local task check

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,9 +52,10 @@ tasks:
       - task: test:contract
 
   check:errors:
-    desc: Fail on generated error contract drift vs errors.yaml
+    desc: Fail on generated error contract drift vs errors.yaml and run error-contracts tests
     cmds:
       - task: errors:check
+      - task: errors:test
 
   # ── Testing ──────────────────────────────────────────────────
   test:
@@ -160,6 +161,12 @@ tasks:
     cmds:
       - |
         uv run --with pyyaml python -c "from pathlib import Path; from scripts.generate import generate_python, generate_typescript, generate_required_keys; p = Path('errors.yaml'); generate_python(p, Path('../../apps/backend/app/exceptions/_generated')); generate_typescript(p, Path('src/generated.ts')); generate_required_keys(p, Path('src/required-keys.json')); print('Generated all error contract files')"
+
+  errors:test:
+    desc: Run error-contracts package tests (codegen + validator); CI parity with .github/workflows/ci.yml error-contracts job
+    dir: packages/error-contracts
+    cmds:
+      - uv run --with pytest --with pyyaml pytest tests/ -v
 
   # ── Docker ───────────────────────────────────────────────────
   docker:build:


### PR DESCRIPTION
## Summary

- Adds `errors:test` task that runs `uv run --with pytest --with pyyaml pytest tests/ -v` from `packages/error-contracts`, mirroring the `Codegen + validator tests` step in `.github/workflows/ci.yml` (the `error-contracts` job).
- Wires `errors:test` into `check:errors` so the aggregate `task check` now exercises the same 12 codegen + validator tests CI runs, closing the local/CI drift called out in #120.

Before this change, `task check` only asserted generated-artifact drift (`errors:check`), leaving the `error-contracts` package test suite uncovered locally — failures surfaced only in CI.

## Test plan

- [x] `task errors:test` runs and all 12 tests pass
- [x] `task check` completes green end-to-end (lint, types, skills, unit/integration/contract, errors:check, errors:test)
- [x] CI `error-contracts` job still green on this PR (no behavioral change to the CI path)

Closes #120.