### PR TITLE
fix(logging): case-insensitive denylist and bytes-aware truncation in redaction filter

### DIFF
--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -24,13 +24,20 @@ class LogRedactionFilter:
 
     Walks the event dict recursively so a forbidden key nested inside a dict
     value (e.g. ``log.info("evt", context={"extracted_value": "..."})``) is
-    still stripped. Long string values under non-denylisted keys are truncated
-    to ``max_value_length`` characters with a ``... [truncated]`` suffix so
-    operators see something without the full payload landing in logs.
+    still stripped. Denylist matching is case-insensitive (``Raw_Output`` and
+    ``RAW_OUTPUT`` are redacted just like ``raw_output``) because callers may
+    construct log keys from external identifiers whose casing cannot be
+    guaranteed. Long string values under non-denylisted keys are truncated to
+    ``max_value_length`` characters with a ``... [truncated]`` suffix; long
+    ``bytes`` values are replaced with a length-summary placeholder so
+    operators see the size without the full payload landing in logs.
     """
 
     def __init__(self, *, redacted_keys: list[str], max_value_length: int) -> None:
-        self._redacted_keys: frozenset[str] = frozenset(redacted_keys)
+        # Store the denylist in case-folded form so matching ignores casing.
+        # ``str.casefold`` is preferred over ``str.lower`` for Unicode keys, but
+        # in practice keys are ASCII; casefold is the safe default either way.
+        self._redacted_keys: frozenset[str] = frozenset(key.casefold() for key in redacted_keys)
         self._max_value_length: int = max_value_length
 
     def __call__(
@@ -52,10 +59,16 @@ class LogRedactionFilter:
             # 'event' is sacrosanct: it holds the log message body and is never
             # dropped, even if a misconfigured denylist contains it.
             is_event = top_level and key == _EVENT_KEY
-            if not is_event and key in self._redacted_keys:
+            if not is_event and self._is_redacted_key(key):
                 continue
             result[key] = self._scrub_value(value, preserve_length=is_event)
         return result
+
+    def _is_redacted_key(self, key: Any) -> bool:
+        # Non-string keys cannot be case-folded and are not in the denylist.
+        if not isinstance(key, str):
+            return False
+        return key.casefold() in self._redacted_keys
 
     def _scrub_value(self, value: Any, *, preserve_length: bool) -> Any:
         if isinstance(value, Mapping):
@@ -69,6 +82,17 @@ class LogRedactionFilter:
                 self._scrub_value(item, preserve_length=False)
                 for item in cast("tuple[Any, ...]", value)
             )
-        if not preserve_length and isinstance(value, str) and len(value) > self._max_value_length:
+        if preserve_length:
+            return value
+        return self._truncate_if_oversize(value)
+
+    def _truncate_if_oversize(self, value: Any) -> Any:
+        if isinstance(value, str) and len(value) > self._max_value_length:
             return value[: self._max_value_length] + _TRUNCATION_SUFFIX
+        if isinstance(value, bytes) and len(value) > self._max_value_length:
+            # Replace oversize bytes payloads with a length-summary placeholder
+            # rather than a truncated prefix: binary data is rarely human-
+            # readable and a byte-count tells operators what they need without
+            # risking a partial leak of document content.
+            return f"<bytes len={len(value)} truncated>"
         return value

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -143,3 +143,35 @@ def test_list_values_are_walked_for_nested_dicts() -> None:
 def test_long_string_inside_nested_dict_is_truncated() -> None:
     out = _call(_filter(), event="test", ctx={"msg": "y" * 600})
     assert out["ctx"]["msg"] == "y" * 500 + "... [truncated]"
+
+
+@pytest.mark.parametrize("key", ["Raw_Output", "RAW_OUTPUT", "PDF_Bytes", "Prompt"])
+def test_denylisted_key_is_redacted_case_insensitively(key: str) -> None:
+    """Denylist matching must be case-insensitive — ``Raw_Output`` bypasses redaction otherwise."""
+    out = _call(_filter(), event="test", **{key: "sensitive content"})
+    assert key not in out
+    assert all("sensitive content" not in str(v) for v in out.values())
+
+
+def test_long_bytes_value_under_non_denylisted_key_is_truncated() -> None:
+    """Large ``bytes`` payloads must not pass through untruncated — they get a length-summary placeholder."""
+    payload = b"x" * 1000
+    out = _call(_filter(), event="test", blob=payload)
+    # Raw 1000-byte payload must not appear verbatim in the output.
+    assert out["blob"] != payload
+    # The original byte length is surfaced so operators can tell something was truncated.
+    assert "1000" in str(out["blob"])
+
+
+def test_short_bytes_value_passes_through_unchanged() -> None:
+    """Bytes values at or below the limit must pass through unchanged."""
+    payload = b"y" * 500
+    out = _call(_filter(), event="test", blob=payload)
+    assert out["blob"] == payload
+
+
+def test_long_bytes_inside_nested_dict_is_truncated() -> None:
+    """Nested bytes payloads over the limit are also summarized."""
+    out = _call(_filter(), event="test", ctx={"blob": b"z" * 600})
+    assert out["ctx"]["blob"] != b"z" * 600
+    assert "600" in str(out["ctx"]["blob"])


### PR DESCRIPTION
## Summary

Closes #118. The redaction filter had two bypasses that allowed sensitive
content to reach logs:

- Denylist keys matched **case-sensitively**, so `Raw_Output` or
  `RAW_OUTPUT` slipped past a denylist containing `raw_output`.
- Truncation only applied to `str` values, so large `bytes` payloads
  (e.g. a whole PDF accidentally logged as context) passed through at
  full size.

## Changes

- `LogRedactionFilter.__init__` now case-folds every configured denylist
  key. A new private helper `_is_redacted_key` case-folds the incoming
  key at match time and short-circuits non-string keys.
- Truncation path extended to `bytes`: oversize `bytes` values are
  replaced with a `<bytes len=N truncated>` placeholder rather than a
  byte prefix. Binary data is rarely human-readable and a length summary
  avoids partial leaks of document content.
- Six new unit tests cover the case-insensitive denylist match (`Raw_Output`,
  `RAW_OUTPUT`, `PDF_Bytes`, `Prompt`), oversize bytes truncation,
  short-bytes pass-through, and oversize bytes inside nested dicts.

## Test plan

- [x] New tests fail against `main`, pass after the fix (TDD).
- [x] All 34 `test_log_redaction_filter.py` unit tests pass.
- [x] `task check` green end to end (lint, format, pyright, import-linter,
  unit, integration, contract, errors:check).