### PR TITLE
fix(env): sync .env.example with Settings fields

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,9 +2,10 @@
 APP_ENV=development
 LOG_LEVEL=info
 CORS_ORIGINS=["http://localhost:5173"]
-# Maximum string length for a single structlog value before redaction-filter
-# truncation. Applies to every rendered log key; protects against accidentally
-# logging huge payloads (PDF bytes, model responses). Defaults to 500.
+# Maximum string length for a single structlog *value* before the redaction
+# filter truncates it (the top-level `event` value is preserved; key names are
+# not affected). Protects against accidentally logging huge payloads (PDF
+# bytes, model responses). Defaults to 500.
 LOG_MAX_VALUE_LENGTH=500
 # JSON array of log-record keys that the redaction filter strips from the
 # event dict entirely (the key and its value are removed, not replaced with a

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,6 +2,14 @@
 APP_ENV=development
 LOG_LEVEL=info
 CORS_ORIGINS=["http://localhost:5173"]
+# Maximum string length for a single structlog value before redaction-filter
+# truncation. Applies to every rendered log key; protects against accidentally
+# logging huge payloads (PDF bytes, model responses). Defaults to 500.
+LOG_MAX_VALUE_LENGTH=500
+# JSON array of log-record keys whose values must be replaced with "[REDACTED]"
+# by the redaction filter. Guard sensitive fields (raw PDF bytes, extracted
+# user data, LLM prompts) from appearing in logs.
+LOG_REDACTED_KEYS=["pdf_bytes","raw_output","extracted_value","prompt","field_values"]
 STRUCTURED_OUTPUT_MAX_RETRIES=3
 # Relative to the process cwd; `task dev:backend` runs from apps/backend/
 SKILLS_DIR=skills

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -6,9 +6,11 @@ CORS_ORIGINS=["http://localhost:5173"]
 # truncation. Applies to every rendered log key; protects against accidentally
 # logging huge payloads (PDF bytes, model responses). Defaults to 500.
 LOG_MAX_VALUE_LENGTH=500
-# JSON array of log-record keys whose values must be replaced with "[REDACTED]"
-# by the redaction filter. Guard sensitive fields (raw PDF bytes, extracted
-# user data, LLM prompts) from appearing in logs.
+# JSON array of log-record keys that the redaction filter strips from the
+# event dict entirely (the key and its value are removed, not replaced with a
+# placeholder). Match is case-insensitive and applies at any depth inside
+# nested dicts/lists. Guards sensitive fields (raw PDF bytes, extracted user
+# data, LLM prompts) from appearing in logs.
 LOG_REDACTED_KEYS=["pdf_bytes","raw_output","extracted_value","prompt","field_values"]
 STRUCTURED_OUTPUT_MAX_RETRIES=3
 # Relative to the process cwd; `task dev:backend` runs from apps/backend/

--- a/apps/backend/tests/unit/core/test_env_example_parity.py
+++ b/apps/backend/tests/unit/core/test_env_example_parity.py
@@ -1,0 +1,65 @@
+"""Parity check between ``Settings`` fields and ``apps/backend/.env.example``.
+
+Guards the CLAUDE.md cross-cutting rule: "Never add an env var without adding
+to both ``Settings`` and ``apps/backend/.env.example``." Closes the drift
+vector that motivated issue #138 so future additions cannot silently regress.
+
+The test iterates every field on ``Settings``, converts each name to
+``UPPER_SNAKE_CASE`` (pydantic-settings' default env-var convention), and
+asserts that a matching ``KEY=`` line exists at the start of a line in
+``.env.example``. Any field that is intentionally not environment-configurable
+must be added to ``_WAIVED_FIELDS`` with a comment explaining why.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.core.config import Settings
+
+# Fields that intentionally do NOT appear in ``.env.example``. Empty today;
+# add entries with an inline comment explaining the waiver if the need ever
+# arises (e.g. fields derived from other env vars at runtime).
+_WAIVED_FIELDS: frozenset[str] = frozenset()
+
+# ``apps/backend/tests/unit/core/test_env_example_parity.py``
+#   parents[0] = ``apps/backend/tests/unit/core/``
+#   parents[1] = ``apps/backend/tests/unit/``
+#   parents[2] = ``apps/backend/tests/``
+#   parents[3] = ``apps/backend/``
+_BACKEND_ROOT = Path(__file__).resolve().parents[3]
+_ENV_EXAMPLE = _BACKEND_ROOT / ".env.example"
+
+
+def _declared_env_keys() -> frozenset[str]:
+    """Return the set of ``KEY=`` prefixes declared in ``.env.example``."""
+    pattern = re.compile(r"^([A-Z][A-Z0-9_]*)=", re.MULTILINE)
+    text = _ENV_EXAMPLE.read_text(encoding="utf-8")
+    return frozenset(pattern.findall(text))
+
+
+def test_env_example_covers_every_settings_field() -> None:
+    """Every ``Settings`` field maps to a ``KEY=`` line in ``.env.example``."""
+    declared = _declared_env_keys()
+    missing = sorted(
+        name.upper()
+        for name in Settings.model_fields
+        if name not in _WAIVED_FIELDS and name.upper() not in declared
+    )
+    assert missing == [], (
+        f"Settings fields missing from apps/backend/.env.example: {missing}. "
+        "Either add a `KEY=<example value>` line with a one-line comment, or "
+        "add the field to _WAIVED_FIELDS with a justification."
+    )
+
+
+def test_env_example_has_no_unknown_keys() -> None:
+    """Every key in ``.env.example`` corresponds to a ``Settings`` field."""
+    declared = _declared_env_keys()
+    known = {name.upper() for name in Settings.model_fields}
+    unknown = sorted(declared - known)
+    assert unknown == [], (
+        f".env.example declares keys not found on Settings: {unknown}. "
+        "Either remove the stale keys or add the matching field to Settings."
+    )


### PR DESCRIPTION
## Summary

- Adds `LOG_MAX_VALUE_LENGTH` and `LOG_REDACTED_KEYS` to `apps/backend/.env.example` — both were declared on `Settings` but absent from the template, violating the CLAUDE.md cross-cutting rule that mandates parity between the two (`OLLAMA_TIMEOUT_SECONDS` named in the issue was already present on `main`).
- Adds `tests/unit/core/test_env_example_parity.py` that iterates `Settings.model_fields` and asserts every field has a matching `KEY=` line in `.env.example`, plus a reverse check that no stale keys linger. Closes the drift vector programmatically so future regressions fail CI.

Closes #138.

## Test plan

- [x] `task check` passes (lint, types, skills, unit, integration, contract, error-contract)
- [x] Parity test fails before the `.env.example` edit, passes after
- [x] New keys carry one-line explanatory comments matching the existing style