### PR TITLE
fix(ollama): map httpx.TimeoutException to IntelligenceTimeoutError

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -47,7 +47,7 @@ from langextract.core.types import ScoredOutput
 from langextract.providers.router import register
 
 from app.core.config import Settings
-from app.exceptions import IntelligenceUnavailableError
+from app.exceptions import IntelligenceTimeoutError, IntelligenceUnavailableError
 from app.features.extraction.intelligence.correction_prompt_builder import (
     CorrectionPromptBuilder,
 )
@@ -179,8 +179,18 @@ class OllamaGemmaProvider(BaseLanguageModel):
             _logger.warning("intelligence_unavailable", cause="connect_error", error=str(exc))
             raise IntelligenceUnavailableError from exc
         except httpx.TimeoutException as exc:
-            _logger.warning("intelligence_unavailable", cause="timeout", error=str(exc))
-            raise IntelligenceUnavailableError from exc
+            # Per-request deadline violation is a 504 timeout, not a 503
+            # availability failure. Reports the httpx-level budget the request
+            # was bounded by (``ollama_timeout_seconds``) — distinct from the
+            # end-to-end ``extraction_timeout_seconds`` surfaced by
+            # ``ExtractionService``. See issue #137.
+            budget = self._timeout.read or self._timeout.connect or 0.0
+            _logger.warning(
+                "intelligence_timeout",
+                budget_seconds=budget,
+                error=str(exc),
+            )
+            raise IntelligenceTimeoutError(budget_seconds=budget) from exc
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
             cause = (

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -127,7 +127,12 @@ class OllamaGemmaProvider(BaseLanguageModel):
         self._model = model_id or effective_settings.ollama_model
         self._generate_url = _build_generate_url(effective_settings.ollama_base_url)
         self._tags_url = build_tags_url(effective_settings.ollama_base_url)
-        self._timeout = httpx.Timeout(effective_settings.ollama_timeout_seconds)
+        # ``Settings`` enforces ``ollama_timeout_seconds > 0``; keep the float
+        # on the instance so the ``IntelligenceTimeoutError`` budget and the
+        # ``intelligence_timeout`` log event can reference an unambiguous source
+        # instead of reconstructing it from ``httpx.Timeout`` attributes.
+        self._timeout_seconds = effective_settings.ollama_timeout_seconds
+        self._timeout = httpx.Timeout(self._timeout_seconds)
         self._validator = effective_validator
         self.http_client = http_client or httpx.AsyncClient(timeout=self._timeout)
 
@@ -184,13 +189,12 @@ class OllamaGemmaProvider(BaseLanguageModel):
             # was bounded by (``ollama_timeout_seconds``) — distinct from the
             # end-to-end ``extraction_timeout_seconds`` surfaced by
             # ``ExtractionService``. See issue #137.
-            budget = self._timeout.read or self._timeout.connect or 0.0
             _logger.warning(
                 "intelligence_timeout",
-                budget_seconds=budget,
+                budget_seconds=self._timeout_seconds,
                 error=str(exc),
             )
-            raise IntelligenceTimeoutError(budget_seconds=budget) from exc
+            raise IntelligenceTimeoutError(budget_seconds=self._timeout_seconds) from exc
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
             cause = (

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -29,6 +29,7 @@ from structlog.testing import capture_logs
 
 from app.core.config import Settings
 from app.exceptions import IntelligenceTimeoutError, IntelligenceUnavailableError
+from app.exceptions._generated import IntelligenceTimeoutParams
 from app.features.extraction.intelligence.correction_prompt_builder import (
     CorrectionPromptBuilder,
 )
@@ -251,8 +252,8 @@ async def test_generate_timeout_raises_intelligence_timeout() -> None:
     with capture_logs() as logs, pytest.raises(IntelligenceTimeoutError) as excinfo:
         await provider.generate("hi", _NAME_STRING_SCHEMA)
     assert isinstance(excinfo.value.__cause__, httpx.TimeoutException)
-    assert excinfo.value.params is not None
-    assert excinfo.value.params.budget_seconds == 7.5  # type: ignore[attr-defined]  # IntelligenceTimeoutParams.budget_seconds
+    assert isinstance(excinfo.value.params, IntelligenceTimeoutParams)
+    assert excinfo.value.params.budget_seconds == 7.5
     event = next(e for e in logs if e.get("event") == "intelligence_timeout")
     assert event["budget_seconds"] == 7.5
 
@@ -693,8 +694,8 @@ def test_infer_propagates_intelligence_timeout_error_on_timeout(
 
     with pytest.raises(IntelligenceTimeoutError) as excinfo:
         list(provider.infer(["p1"]))
-    assert excinfo.value.params is not None
-    assert excinfo.value.params.budget_seconds == 9.25  # type: ignore[attr-defined]  # IntelligenceTimeoutParams.budget_seconds
+    assert isinstance(excinfo.value.params, IntelligenceTimeoutParams)
+    assert excinfo.value.params.budget_seconds == 9.25
 
 
 def test_infer_uses_a_single_asyncio_run_for_the_whole_batch(

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -28,7 +28,7 @@ import pytest
 from structlog.testing import capture_logs
 
 from app.core.config import Settings
-from app.exceptions import IntelligenceUnavailableError
+from app.exceptions import IntelligenceTimeoutError, IntelligenceUnavailableError
 from app.features.extraction.intelligence.correction_prompt_builder import (
     CorrectionPromptBuilder,
 )
@@ -234,17 +234,27 @@ async def test_generate_connect_error_raises_intelligence_unavailable() -> None:
     assert event["cause"] == "connect_error"
 
 
-async def test_generate_timeout_raises_intelligence_unavailable() -> None:
+async def test_generate_timeout_raises_intelligence_timeout() -> None:
+    """Regression guard for issue #137.
+
+    ``httpx.TimeoutException`` must map to ``IntelligenceTimeoutError`` (504),
+    not ``IntelligenceUnavailableError`` (503). An Ollama request that exceeds
+    the configured per-request timeout is a deadline violation — semantically
+    distinct from connection failures (which are availability problems).
+    """
+    settings = _build_settings(timeout_seconds=7.5)
     fake = _FakeAsyncClient(
         post_outcomes=[httpx.TimeoutException("deadline exceeded")],
     )
-    provider = _build_provider(fake_client=fake)
+    provider = _build_provider(settings=settings, fake_client=fake)
 
-    with capture_logs() as logs, pytest.raises(IntelligenceUnavailableError) as excinfo:
+    with capture_logs() as logs, pytest.raises(IntelligenceTimeoutError) as excinfo:
         await provider.generate("hi", _NAME_STRING_SCHEMA)
     assert isinstance(excinfo.value.__cause__, httpx.TimeoutException)
-    event = next(e for e in logs if e.get("event") == "intelligence_unavailable")
-    assert event["cause"] == "timeout"
+    assert excinfo.value.params is not None
+    assert excinfo.value.params.budget_seconds == 7.5  # type: ignore[attr-defined]  # IntelligenceTimeoutParams.budget_seconds
+    event = next(e for e in logs if e.get("event") == "intelligence_timeout")
+    assert event["budget_seconds"] == 7.5
 
 
 async def test_generate_http_500_raises_intelligence_unavailable() -> None:
@@ -663,6 +673,28 @@ def test_infer_propagates_intelligence_unavailable_error_on_connect_failure(
 
     with pytest.raises(IntelligenceUnavailableError):
         list(provider.infer(["p1"]))
+
+
+def test_infer_propagates_intelligence_timeout_error_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard for issue #137 — timeout path on the ``infer()`` seam.
+
+    ``infer()`` runs the fresh-client-per-asyncio.run path. A transport
+    ``TimeoutException`` there must surface as ``IntelligenceTimeoutError``
+    with the correct 504 budget, same as the ``generate()`` path.
+    """
+    _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[httpx.TimeoutException("deadline exceeded")],
+    )
+    settings = _build_settings(timeout_seconds=9.25)
+    provider = _build_provider(settings=settings, fake_client=_FakeAsyncClient())
+
+    with pytest.raises(IntelligenceTimeoutError) as excinfo:
+        list(provider.infer(["p1"]))
+    assert excinfo.value.params is not None
+    assert excinfo.value.params.budget_seconds == 9.25  # type: ignore[attr-defined]  # IntelligenceTimeoutParams.budget_seconds
 
 
 def test_infer_uses_a_single_asyncio_run_for_the_whole_batch(


### PR DESCRIPTION
## Summary

- The Ollama provider was mapping `httpx.TimeoutException` (including
  `ConnectTimeout`, `ReadTimeout`, `WriteTimeout`, `PoolTimeout`) to
  `IntelligenceUnavailableError` (503). That collapses a 504-timeout
  deadline violation into a 503-availability signal, losing the
  operational distinction between "Ollama is down" and "Ollama did not
  respond in time."
- Now maps to `IntelligenceTimeoutError(budget_seconds=...)` (504), with
  the httpx-level `ollama_timeout_seconds` budget carried through the
  error envelope. Distinct from the end-to-end
  `extraction_timeout_seconds` budget that `ExtractionService` surfaces
  when `asyncio.timeout` fires on the pipeline — operators can now tell
  *which* timer expired.
- New event name `intelligence_timeout` replaces the old
  `intelligence_unavailable cause=timeout` for cleaner telemetry.
- Other mappings preserved: `ConnectError` → `IntelligenceUnavailableError`,
  `HTTPStatusError` (4xx/5xx) → `IntelligenceUnavailableError`, and the
  widened `RequestError` catch-all from PR #86 (ReadError,
  RemoteProtocolError, etc.) → `IntelligenceUnavailableError`.
- `health_check()` untouched: `TimeoutException` is a `RequestError`
  subclass, so the existing `except (httpx.RequestError,
  httpx.HTTPStatusError)` handler already absorbs it to `return False`.
- `INTELLIGENCE_TIMEOUT` already existed in `errors.yaml` (PDFX-E006-F002)
  with `http_status: 504` and `budget_seconds: number` — no codegen change
  needed.

## Test plan

- [x] Red: failing test added asserting `IntelligenceTimeoutError` is
  raised on `TimeoutException` via `generate()` (with `budget_seconds`
  pinned to `ollama_timeout_seconds`) — confirmed red before the fix.
- [x] Red: failing test added for the `infer()` seam (LangExtract
  plugin path) asserting the same mapping — confirmed red before the fix.
- [x] Green: both new tests pass after the fix; full
  `test_ollama_gemma_provider.py` suite (34 tests) passes.
- [x] `task check` passes: ruff + pyright-strict + unit + integration +
  contract + import-linter + errors:generate/check/test — exit 0.

Closes #137.