### PR TITLE
fix(lifespan): degrade (not crash) on non-httpx probe exceptions

### DIFF
--- a/apps/backend/app/api/probe_cache.py
+++ b/apps/backend/app/api/probe_cache.py
@@ -16,13 +16,17 @@ transition (``True`` → ``False``) logs ``ollama_became_unreachable`` at
 WARNING so operators see the degradation at normal log levels.
 
 Exception handling during refresh: ``probe.check()`` is wrapped in a
-broad ``except Exception`` inside ``is_ready()`` so any non-httpx
-exception (bad config, wrapped-client attribute errors, unexpected
-``DomainError`` subclasses) is converted into cached-``False`` plus a
-``probe_check_failed_on_refresh`` WARNING. This mirrors the startup
-guard in ``app/main.py._lifespan`` (issue #144) and keeps ``/ready``
-on the documented 503 ``ollama_unreachable`` contract across the
-entire process lifetime rather than only within the primed TTL window.
+broad ``except Exception`` inside ``is_ready()`` so any unexpected
+``Exception`` subclass (bad config, wrapped-client attribute errors,
+unexpected ``DomainError`` subclasses) is converted into cached-``False``
+plus a ``probe_check_failed_on_refresh`` WARNING. ``BaseException``
+subclasses such as ``asyncio.CancelledError`` (a ``BaseException`` since
+Python 3.8), ``SystemExit``, and ``KeyboardInterrupt`` are intentionally
+not swallowed — request cancellations and shutdown signals still
+propagate. This mirrors the startup guard in ``app/main.py._lifespan``
+(issue #144) and keeps ``/ready`` on the documented 503
+``ollama_unreachable`` contract across the entire process lifetime
+rather than only within the primed TTL window.
 """
 
 from __future__ import annotations
@@ -89,16 +93,19 @@ class ProbeCache:
             had_previous = self._has_previous_result
             # ``probe.check()`` catches ``httpx.HTTPError`` and JSON decode
             # errors internally and returns ``False``, but any other
-            # exception (e.g. ``ValueError`` from a bad config, an
-            # ``AttributeError`` on a wrapped client, a ``DomainError``
-            # subclass raised deeper in the probe path) would escape and
-            # turn the ``/ready`` endpoint into a 500. The lifespan's
-            # startup guard (issue #144) only covers the startup probe;
-            # this mirror-guard on every TTL refresh keeps the ``/ready``
-            # contract stable (503 ``ollama_unreachable``) for the full
-            # lifetime of the process, not just the primed-TTL window.
-            # ``except Exception`` is deliberate here for the same reason
-            # as in ``app/main.py._lifespan``: degrade rather than crash.
+            # unexpected ``Exception`` subclass (e.g. ``ValueError`` from a
+            # bad config, an ``AttributeError`` on a wrapped client, a
+            # ``DomainError`` subclass raised deeper in the probe path)
+            # would escape and turn the ``/ready`` endpoint into a 500. The
+            # lifespan's startup guard (issue #144) only covers the startup
+            # probe; this mirror-guard on every TTL refresh keeps the
+            # ``/ready`` contract stable (503 ``ollama_unreachable``) for
+            # the full lifetime of the process, not just the primed-TTL
+            # window. ``except Exception`` is deliberate here for the same
+            # reason as in ``app/main.py._lifespan``: degrade rather than
+            # crash. Cancellations and shutdown signals propagate because
+            # ``asyncio.CancelledError`` inherits from ``BaseException`` on
+            # Python 3.8+, so ``except Exception`` does not match them.
             try:
                 refreshed = await self._probe.check()
             except Exception as exc:  # noqa: BLE001 - degrade-don't-crash is the contract

--- a/apps/backend/app/api/probe_cache.py
+++ b/apps/backend/app/api/probe_cache.py
@@ -14,6 +14,15 @@ state from ``False`` to ``True``, an ``ollama_reachable_recovered`` event
 is logged at INFO level (PDFX-E007-F002 self-healing).  The reverse
 transition (``True`` → ``False``) logs ``ollama_became_unreachable`` at
 WARNING so operators see the degradation at normal log levels.
+
+Exception handling during refresh: ``probe.check()`` is wrapped in a
+broad ``except Exception`` inside ``is_ready()`` so any non-httpx
+exception (bad config, wrapped-client attribute errors, unexpected
+``DomainError`` subclasses) is converted into cached-``False`` plus a
+``probe_check_failed_on_refresh`` WARNING. This mirrors the startup
+guard in ``app/main.py._lifespan`` (issue #144) and keeps ``/ready``
+on the documented 503 ``ollama_unreachable`` contract across the
+entire process lifetime rather than only within the primed TTL window.
 """
 
 from __future__ import annotations
@@ -78,7 +87,28 @@ class ProbeCache:
                 return self._last_result
             previous = self._last_result
             had_previous = self._has_previous_result
-            self._last_result = await self._probe.check()
+            # ``probe.check()`` catches ``httpx.HTTPError`` and JSON decode
+            # errors internally and returns ``False``, but any other
+            # exception (e.g. ``ValueError`` from a bad config, an
+            # ``AttributeError`` on a wrapped client, a ``DomainError``
+            # subclass raised deeper in the probe path) would escape and
+            # turn the ``/ready`` endpoint into a 500. The lifespan's
+            # startup guard (issue #144) only covers the startup probe;
+            # this mirror-guard on every TTL refresh keeps the ``/ready``
+            # contract stable (503 ``ollama_unreachable``) for the full
+            # lifetime of the process, not just the primed-TTL window.
+            # ``except Exception`` is deliberate here for the same reason
+            # as in ``app/main.py._lifespan``: degrade rather than crash.
+            try:
+                refreshed = await self._probe.check()
+            except Exception as exc:  # noqa: BLE001 - degrade-don't-crash is the contract
+                _logger.warning(
+                    "probe_check_failed_on_refresh",
+                    error_class=type(exc).__name__,
+                    exc_info=True,
+                )
+                refreshed = False
+            self._last_result = refreshed
             self._last_check_time = time.monotonic()
             self._has_previous_result = True
             if had_previous and not previous and self._last_result:

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -57,21 +57,25 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Ollama responded 200 but was missing the pinned model (issue #107).
     #
     # The probe's own ``check()`` catches ``httpx.HTTPError`` and JSON decode
-    # errors and returns ``False``, but any other exception (e.g.
-    # ``ValueError`` from a bad config, a ``DomainError`` raised deeper in
-    # the probe path, an ``AttributeError`` on a wrapped client) would
-    # escape and crash the ASGI boot, causing the container to crash-loop
-    # (issue #144). Degrading on startup is always preferable to dying on
-    # startup: ``/health`` stays green and the cache is primed ``False`` so
-    # the initial readiness state degrades cleanly instead of aborting app
-    # startup. Runtime TTL refreshes are guarded separately inside
-    # ``ProbeCache.is_ready()`` (same broad ``except Exception`` strategy),
-    # which keeps ``/ready`` on the documented 503 ``ollama_unreachable``
-    # contract across the full process lifetime even if the underlying
-    # fault is persistent, and the self-healing TTL refresh recovers once
-    # Ollama behaves. ``except Exception`` is deliberate here — this is
-    # one of the rare places where "catch everything and degrade" is the
-    # correct failure mode.
+    # errors and returns ``False``, but any other unexpected ``Exception``
+    # subclass (e.g. ``ValueError`` from a bad config, a ``DomainError``
+    # raised deeper in the probe path, an ``AttributeError`` on a wrapped
+    # client) would escape and crash the ASGI boot, causing the container
+    # to crash-loop (issue #144). Degrading on startup is always preferable
+    # to dying on startup: ``/health`` stays green and the cache is primed
+    # ``False`` so the initial readiness state degrades cleanly instead of
+    # aborting app startup. Runtime TTL refreshes are guarded separately
+    # inside ``ProbeCache.is_ready()`` with the same broad ``except
+    # Exception`` strategy, which keeps ``/ready`` on the documented 503
+    # ``ollama_unreachable`` contract across the full process lifetime even
+    # if the underlying fault is persistent, and the self-healing TTL
+    # refresh recovers once Ollama behaves. ``except Exception`` is
+    # deliberate here: it is one of the rare places where catching any
+    # unexpected non-``BaseException`` startup failure and degrading is the
+    # correct failure mode. ``BaseException`` subclasses such as
+    # ``asyncio.CancelledError`` (a ``BaseException`` since Python 3.8),
+    # ``SystemExit``, and ``KeyboardInterrupt`` are intentionally not
+    # swallowed so shutdown and termination signals still propagate.
     try:
         ready = await probe.check()
     except Exception as exc:  # noqa: BLE001 - degrade-don't-crash is the contract

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -55,7 +55,28 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # model tag is installed — so the startup log event reflects "ready"
     # rather than the older "reachable" wording which was misleading when
     # Ollama responded 200 but was missing the pinned model (issue #107).
-    ready = await probe.check()
+    #
+    # The probe's own ``check()`` catches ``httpx.HTTPError`` and JSON decode
+    # errors and returns ``False``, but any other exception (e.g.
+    # ``ValueError`` from a bad config, a ``DomainError`` raised deeper in
+    # the probe path, an ``AttributeError`` on a wrapped client) would
+    # escape and crash the ASGI boot, causing the container to crash-loop
+    # (issue #144). Degrading on startup is always preferable to dying on
+    # startup: ``/health`` stays green, ``/ready`` returns 503 with the
+    # existing ``ollama_unreachable`` contract, and the self-healing TTL
+    # refresh in ``ProbeCache`` recovers once Ollama behaves. ``except
+    # Exception`` is deliberate here — this is one of the rare places where
+    # "catch everything and degrade" is the correct failure mode.
+    try:
+        ready = await probe.check()
+    except Exception as exc:  # noqa: BLE001 - degrade-don't-crash is the contract
+        _logger.warning(
+            "probe_check_failed_at_startup",
+            error_class=type(exc).__name__,
+            exc_info=True,
+        )
+        ready = False
+
     cache.prime(result=ready)
 
     if ready:

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -62,11 +62,16 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # the probe path, an ``AttributeError`` on a wrapped client) would
     # escape and crash the ASGI boot, causing the container to crash-loop
     # (issue #144). Degrading on startup is always preferable to dying on
-    # startup: ``/health`` stays green, ``/ready`` returns 503 with the
-    # existing ``ollama_unreachable`` contract, and the self-healing TTL
-    # refresh in ``ProbeCache`` recovers once Ollama behaves. ``except
-    # Exception`` is deliberate here — this is one of the rare places where
-    # "catch everything and degrade" is the correct failure mode.
+    # startup: ``/health`` stays green and the cache is primed ``False`` so
+    # the initial readiness state degrades cleanly instead of aborting app
+    # startup. Runtime TTL refreshes are guarded separately inside
+    # ``ProbeCache.is_ready()`` (same broad ``except Exception`` strategy),
+    # which keeps ``/ready`` on the documented 503 ``ollama_unreachable``
+    # contract across the full process lifetime even if the underlying
+    # fault is persistent, and the self-healing TTL refresh recovers once
+    # Ollama behaves. ``except Exception`` is deliberate here — this is
+    # one of the rare places where "catch everything and degrade" is the
+    # correct failure mode.
     try:
         ready = await probe.check()
     except Exception as exc:  # noqa: BLE001 - degrade-don't-crash is the contract

--- a/apps/backend/tests/integration/test_degraded_startup.py
+++ b/apps/backend/tests/integration/test_degraded_startup.py
@@ -329,13 +329,15 @@ class _ExplodingProbe:
     """Probe stub whose ``check()`` raises a non-httpx exception once, then
     returns ``False`` for any subsequent TTL-triggered refresh.
 
-    Simulates the class of failure described in issue #144 — anything that
-    is not an ``httpx.HTTPError`` (e.g. ``ValueError`` from a bad config,
-    ``JSONDecodeError`` from a malformed payload upstream of the real
-    probe's internal catch, an attribute error on a wrapped client, a
-    ``DomainError`` subclass from the probe path). The previous lifespan
-    had no guard, so any such exception propagated out of ``_lifespan``
-    and crash-looped the container.
+    Simulates unexpected exceptions *escaping* ``probe.check()`` — the
+    failure mode described in issue #144. This is explicitly distinct from
+    the ``httpx`` and JSON-decode paths the real ``OllamaHealthProbe``
+    already catches internally. Realistic examples include ``ValueError``
+    from a bad config, ``OSError`` from a lower-level transport path, an
+    ``AttributeError`` on a wrapped client, or a ``DomainError`` subclass
+    raised from the probe path. The previous lifespan had no guard, so any
+    such exception propagated out of ``_lifespan`` and crash-looped the
+    container.
     """
 
     def __init__(self, *, error: Exception) -> None:

--- a/apps/backend/tests/integration/test_degraded_startup.py
+++ b/apps/backend/tests/integration/test_degraded_startup.py
@@ -318,3 +318,111 @@ async def test_stays_degraded_when_ollama_always_unreachable(tmp_path: Path) -> 
                 ready = await client.get("/ready")
                 assert ready.status_code == 503
                 assert ready.json()["status"] == "not_ready"
+
+
+# ---------------------------------------------------------------------------
+# Tests — non-httpx probe.check() exceptions must not crash startup (issue #144)
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingProbe:
+    """Probe stub whose ``check()`` raises a non-httpx exception once, then
+    returns ``False`` for any subsequent TTL-triggered refresh.
+
+    Simulates the class of failure described in issue #144 — anything that
+    is not an ``httpx.HTTPError`` (e.g. ``ValueError`` from a bad config,
+    ``JSONDecodeError`` from a malformed payload upstream of the real
+    probe's internal catch, an attribute error on a wrapped client, a
+    ``DomainError`` subclass from the probe path). The previous lifespan
+    had no guard, so any such exception propagated out of ``_lifespan``
+    and crash-looped the container.
+    """
+
+    def __init__(self, *, error: Exception) -> None:
+        self._error = error
+        self.call_count = 0
+
+    async def check(self) -> bool:
+        self.call_count += 1
+        if self.call_count == 1:
+            raise self._error
+        return False
+
+
+async def test_non_httpx_probe_exception_does_not_crash_startup(
+    tmp_path: Path,
+) -> None:
+    """probe.check() raising a non-httpx exception must not propagate out of _lifespan.
+
+    Before the fix, ``ValueError`` (or any non-httpx exception) escaped the
+    lifespan and killed the ASGI app boot, causing a container crash-loop
+    as soon as Ollama's behaviour deviated from the exact httpx error paths
+    the probe internals catch. After the fix, the exception is caught,
+    logged at WARNING, and the cache is primed as not-ready so the service
+    boots into degraded mode.
+    """
+    _write_valid_skill(tmp_path)
+    app = create_app(_degraded_settings(tmp_path))
+    app.state.ollama_health_probe = _ExplodingProbe(error=ValueError("simulated"))
+
+    # If the lifespan fails to guard against the exception, entering this
+    # context manager raises and the assertion below never runs.
+    async with _lifespan(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_non_httpx_probe_exception_logs_warning_with_event_name(
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Non-httpx probe failure emits a structured WARNING with the error class.
+
+    The event name is intentionally distinct from ``ollama_not_ready_at_startup``
+    so operators tailing logs can filter on "probe itself exploded" vs
+    "probe ran and reported not-ready". The error class name is included so
+    operators can triage the underlying cause without needing to inspect
+    the stack trace.
+    """
+    _write_valid_skill(tmp_path)
+    app = create_app(_degraded_settings(tmp_path))
+    app.state.ollama_health_probe = _ExplodingProbe(error=ValueError("simulated"))
+
+    async with _lifespan(app):
+        pass
+
+    captured = capfd.readouterr()
+    assert "probe_check_failed_at_startup" in captured.out
+    assert "warning" in captured.out.lower()
+    assert "ValueError" in captured.out
+
+
+async def test_non_httpx_probe_exception_ready_returns_503_ollama_unreachable(
+    tmp_path: Path,
+) -> None:
+    """After a non-httpx probe failure at boot, /ready mirrors the httpx path.
+
+    The readiness cache is primed as not-ready so ``/ready`` returns 503
+    with the existing ``ollama_unreachable`` reason — operators see the
+    same contract whether the probe returned ``False`` or blew up, because
+    from the outside both mean "Ollama is not usable right now."
+    """
+    _write_valid_skill(tmp_path)
+    app = create_app(_degraded_settings(tmp_path))
+    # First call (startup) raises; subsequent TTL-triggered refreshes
+    # return False so /ready stays 503 throughout the test.
+    app.state.ollama_health_probe = _ExplodingProbe(error=ValueError("simulated"))
+
+    async with _lifespan(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/ready")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "not_ready"
+    assert body["reason"] == "ollama_unreachable"

--- a/apps/backend/tests/integration/test_degraded_startup.py
+++ b/apps/backend/tests/integration/test_degraded_startup.py
@@ -426,3 +426,59 @@ async def test_non_httpx_probe_exception_ready_returns_503_ollama_unreachable(
     body = response.json()
     assert body["status"] == "not_ready"
     assert body["reason"] == "ollama_unreachable"
+
+
+class _PersistentlyExplodingProbe:
+    """Probe stub whose ``check()`` always raises a non-httpx exception.
+
+    Simulates the persistent-failure scenario: the underlying fault (bad
+    config, wrapped-client attribute error, unexpected ``DomainError``)
+    doesn't clear between calls, so every TTL-triggered refresh from the
+    ``ProbeCache`` re-hits the exception path. The ``/ready`` contract
+    must still return 503 ``ollama_unreachable`` — not 500 — for the
+    full process lifetime.
+    """
+
+    def __init__(self, *, error: Exception) -> None:
+        self._error = error
+        self.call_count = 0
+
+    async def check(self) -> bool:
+        self.call_count += 1
+        raise self._error
+
+
+async def test_persistent_probe_exception_keeps_ready_on_503_after_ttl(
+    tmp_path: Path,
+) -> None:
+    """Persistent non-httpx probe failures keep /ready returning 503, not 500.
+
+    Defends the ``ollama_unreachable`` contract beyond the primed-TTL
+    window: once startup is over, the cache's own TTL refresh path must
+    also catch the exception and treat it as cached-``False``, otherwise
+    a persistent bad-config scenario would turn /ready from 503 into 500
+    the moment the TTL ticks over.
+    """
+    _write_valid_skill(tmp_path)
+    app = create_app(_degraded_settings(tmp_path))
+    app.state.ollama_health_probe = _PersistentlyExplodingProbe(
+        error=ValueError("simulated persistent fault"),
+    )
+
+    async with _lifespan(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Primed-TTL window: served from cache primed False by lifespan.
+            first = await client.get("/ready")
+            assert first.status_code == 503
+            assert first.json()["reason"] == "ollama_unreachable"
+
+            # TTL expires → ProbeCache refreshes → probe raises again.
+            # Without the mirror guard in is_ready(), this becomes a 500.
+            await asyncio.sleep(0.06)
+            second = await client.get("/ready")
+
+    assert second.status_code == 503
+    second_body = second.json()
+    assert second_body["status"] == "not_ready"
+    assert second_body["reason"] == "ollama_unreachable"

--- a/apps/backend/tests/unit/api/test_probe_cache.py
+++ b/apps/backend/tests/unit/api/test_probe_cache.py
@@ -13,12 +13,15 @@ from tests.conftest import FakeProbe
 class _ExplodingProbe:
     """Probe stub whose ``check()`` raises a configured exception every call.
 
-    Simulates the class of failure described in issue #144 — any exception
-    that is not an ``httpx.HTTPError`` the real probe already catches (e.g.
-    ``ValueError`` from a bad config, ``AttributeError`` on a wrapped
-    client, a ``DomainError`` subclass from the probe path). The cache
-    must convert this into cached-``False`` so ``/ready`` keeps returning
-    503 ``ollama_unreachable`` instead of 500.
+    Simulates unexpected exceptions *escaping* ``probe.check()`` — the
+    failure mode described in issue #144. This is explicitly distinct from
+    the ``httpx`` and JSON-decode paths the real ``OllamaHealthProbe``
+    already catches internally and converts to ``False``. Examples here
+    include ``ValueError`` from a bad config, ``AttributeError`` on a
+    wrapped client, ``OSError`` from a lower-level transport layer, or a
+    ``DomainError`` subclass from the probe path. The cache must convert
+    these escaped exceptions into cached-``False`` so ``/ready`` keeps
+    returning 503 ``ollama_unreachable`` instead of 500.
     """
 
     def __init__(self, *, error: Exception) -> None:

--- a/apps/backend/tests/unit/api/test_probe_cache.py
+++ b/apps/backend/tests/unit/api/test_probe_cache.py
@@ -4,8 +4,31 @@ from __future__ import annotations
 
 import asyncio
 
+from structlog.testing import capture_logs
+
 from app.api.probe_cache import ProbeCache
 from tests.conftest import FakeProbe
+
+
+class _ExplodingProbe:
+    """Probe stub whose ``check()`` raises a configured exception every call.
+
+    Simulates the class of failure described in issue #144 — any exception
+    that is not an ``httpx.HTTPError`` the real probe already catches (e.g.
+    ``ValueError`` from a bad config, ``AttributeError`` on a wrapped
+    client, a ``DomainError`` subclass from the probe path). The cache
+    must convert this into cached-``False`` so ``/ready`` keeps returning
+    503 ``ollama_unreachable`` instead of 500.
+    """
+
+    def __init__(self, *, error: Exception) -> None:
+        self._error = error
+        self.call_count = 0
+
+    async def check(self) -> bool:
+        self.call_count += 1
+        raise self._error
+
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -99,3 +122,143 @@ async def test_zero_ttl_always_reprobes() -> None:
     await cache.is_ready()
 
     assert probe.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests — non-httpx exceptions from probe.check() must not escape the cache
+# ---------------------------------------------------------------------------
+#
+# The lifespan guard for issue #144 keeps startup alive, but once the primed
+# TTL window expires ``/ready`` triggers a fresh ``probe.check()`` through
+# ``ProbeCache.is_ready()``. If the underlying failure is persistent (bad
+# config, wrapped-client attribute error, ...), the refresh path must treat
+# the exception exactly like the startup path does: log WARNING, cache
+# ``False``, and return ``False`` so ``/ready`` stays on the documented
+# 503 ``ollama_unreachable`` contract rather than leaking a 500.
+
+
+async def test_probe_exception_on_first_call_returns_false() -> None:
+    """Unprimed cache + probe raises → is_ready() returns False, not exception."""
+    probe = _ExplodingProbe(error=ValueError("simulated"))
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=5.0,
+    )
+
+    result = await cache.is_ready()
+
+    assert result is False
+    assert probe.call_count == 1
+
+
+async def test_probe_exception_after_ttl_returns_false_not_raises() -> None:
+    """Primed True → TTL expires → probe raises → cache returns False, no raise."""
+    probe = _ExplodingProbe(error=ValueError("simulated"))
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=0.05,
+    )
+
+    cache.prime(result=True)
+    await asyncio.sleep(0.06)
+
+    result = await cache.is_ready()
+
+    assert result is False
+    assert probe.call_count == 1
+
+
+async def test_probe_exception_logs_warning_with_error_class() -> None:
+    """Probe exception emits ``probe_check_failed_on_refresh`` WARNING.
+
+    The event name is distinct from the lifespan's
+    ``probe_check_failed_at_startup`` so operators tailing logs can
+    separate "exploded during boot" from "exploded during runtime
+    refresh", and the error class name is included for triage.
+    """
+    probe = _ExplodingProbe(error=ValueError("simulated"))
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=5.0,
+    )
+
+    with capture_logs() as cap_logs:
+        await cache.is_ready()
+
+    events = [e for e in cap_logs if e["event"] == "probe_check_failed_on_refresh"]
+    assert len(events) == 1
+    assert events[0]["log_level"] == "warning"
+    assert events[0]["error_class"] == "ValueError"
+
+
+async def test_probe_exception_caches_false_within_ttl() -> None:
+    """After exception → result is cached as False within TTL (no re-probe)."""
+    probe = _ExplodingProbe(error=ValueError("simulated"))
+    cache = ProbeCache(
+        probe=probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=5.0,
+    )
+
+    first = await cache.is_ready()
+    second = await cache.is_ready()
+
+    assert first is False
+    assert second is False
+    # Second call must hit the TTL fast-path rather than re-probing,
+    # otherwise a persistent bad-config scenario turns into a thundering
+    # herd of exceptions on every /ready hit.
+    assert probe.call_count == 1
+
+
+async def test_probe_exception_to_success_logs_recovery() -> None:
+    """Primed True → probe raises (cached False) → probe returns True → recovery event.
+
+    Exercises the transition path: the exception-caught ``False`` must be
+    indistinguishable from a normal ``False`` result so the existing
+    self-heal logging still fires when the underlying fault clears.
+    """
+    # First post-prime refresh raises, second returns True.
+    recovering_probe = _TransientExplodingProbe(
+        error=ValueError("simulated"),
+        results=[True],
+    )
+    cache = ProbeCache(
+        probe=recovering_probe,  # type: ignore[arg-type]  # test seam
+        ttl_seconds=0.05,
+    )
+
+    cache.prime(result=True)
+    # Degrade path: primed True → TTL expires → probe raises → cache goes False.
+    await asyncio.sleep(0.06)
+    with capture_logs() as degrade_logs:
+        degraded = await cache.is_ready()
+    assert degraded is False
+    degradation_events = [e for e in degrade_logs if e["event"] == "ollama_became_unreachable"]
+    assert len(degradation_events) == 1
+
+    # Recovery path: TTL expires → probe returns True → recovery event fires.
+    await asyncio.sleep(0.06)
+    with capture_logs() as recover_logs:
+        recovered = await cache.is_ready()
+    assert recovered is True
+    recovery_events = [e for e in recover_logs if e["event"] == "ollama_reachable_recovered"]
+    assert len(recovery_events) == 1
+
+
+class _TransientExplodingProbe:
+    """Probe that raises once, then returns scripted results. Used for the
+    exception-to-success self-heal test.
+    """
+
+    def __init__(self, *, error: Exception, results: list[bool]) -> None:
+        self._error = error
+        self._results = list(results)
+        self.call_count = 0
+        self._raised = False
+
+    async def check(self) -> bool:
+        self.call_count += 1
+        if not self._raised:
+            self._raised = True
+            raise self._error
+        return self._results.pop(0)


### PR DESCRIPTION
## Summary

- `_lifespan` called `await probe.check()` with no guard. The probe's own `check()` catches `httpx.HTTPError` and JSON decode errors, but any other exception (e.g. `ValueError` from a bad config, a `DomainError` from a deeper rewrite, an `AttributeError` on a wrapped client) escaped `_lifespan` and crash-looped the container.
- Wrap the startup probe call in a bounded `except Exception` that logs a structured WARNING with a dedicated event name (`probe_check_failed_at_startup`) plus the error class, then primes the cache as not-ready so the boot flows through the existing degraded-mode path.
- Operators see the same `/ready` contract as the httpx failure path (503 + `ollama_unreachable`). Self-heal via `ProbeCache`'s TTL refresh is unchanged.

Closes #144.

## Test plan

- [x] TDD red: three new integration tests in `tests/integration/test_degraded_startup.py` under "non-httpx probe.check() exceptions must not crash startup" — confirmed failing before the fix (`ValueError: simulated` propagated out of `_lifespan`).
- [x] TDD green: same three tests pass after wrapping `probe.check()` in `except Exception` with structured-warning log and cache priming.
- [x] Full `task check` clean: lint, ruff format, pyright strict, skills:validate, unit, integration, contract, errors:generate drift check, error-contracts tests.
- [x] No change to the httpx success/failure event names — `ollama_ready_at_startup` and `ollama_not_ready_at_startup` preserved for operators already filtering on them.

Non-httpx failures emit a separate event name (`probe_check_failed_at_startup`) so operators can distinguish "probe ran and reported not-ready" from "probe itself blew up mid-flight" without needing to inspect the stack trace.

[Claude Code session](https://claude.ai/code)