### PR TITLE
fix(validator): strip trailing code fence unconditionally

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/structured_output_validator.py
+++ b/apps/backend/app/features/extraction/intelligence/structured_output_validator.py
@@ -114,10 +114,10 @@ class StructuredOutputValidator:
 
 
 def _clean(raw_text: str) -> str:
-    # Three sequential, independent passes. Order matters — the opening-fence
-    # pass must run before the trailing-fence pass so the leading prefix is
-    # consumed first, but each pass is self-contained: whether the opening
-    # fence matched has no bearing on whether the trailing fence is stripped.
+    # Three sequential, independent passes. The opening-fence and trailing-fence
+    # passes are self-contained: one inspects the start of the string and the
+    # other inspects the end, so neither depends on whether the other matched.
+    # They are applied in this order simply as the cleanup flow.
     text = raw_text.strip()
     text = _strip_opening_fence(text)
     text = _strip_trailing_fence(text)

--- a/apps/backend/app/features/extraction/intelligence/structured_output_validator.py
+++ b/apps/backend/app/features/extraction/intelligence/structured_output_validator.py
@@ -114,14 +114,28 @@ class StructuredOutputValidator:
 
 
 def _clean(raw_text: str) -> str:
+    # Three sequential, independent passes. Order matters — the opening-fence
+    # pass must run before the trailing-fence pass so the leading prefix is
+    # consumed first, but each pass is self-contained: whether the opening
+    # fence matched has no bearing on whether the trailing fence is stripped.
     text = raw_text.strip()
+    text = _strip_opening_fence(text)
+    text = _strip_trailing_fence(text)
+    return text.strip()
+
+
+def _strip_opening_fence(text: str) -> str:
     for prefix in _FENCE_LANGUAGE_PREFIXES:
         if text.startswith(prefix):
-            text = text[len(prefix) :].lstrip("\n").lstrip()
-            if text.endswith("```"):
-                text = text[: -len("```")].rstrip()
-            break
-    return text.strip()
+            return text[len(prefix) :].lstrip("\n").lstrip()
+    return text
+
+
+def _strip_trailing_fence(text: str) -> str:
+    stripped = text.rstrip()
+    if stripped.endswith("```"):
+        return stripped[: -len("```")].rstrip()
+    return text
 
 
 def _try_parse(cleaned: str) -> tuple[dict[str, Any], None] | tuple[None, _FailurePair]:

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_structured_output_validator.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_structured_output_validator.py
@@ -24,6 +24,7 @@ from app.features.extraction.intelligence.correction_prompt_builder import (
 )
 from app.features.extraction.intelligence.structured_output_validator import (
     StructuredOutputValidator,
+    _clean,
 )
 
 _FOO_STRING_SCHEMA: dict[str, Any] = {
@@ -370,6 +371,50 @@ async def test_structured_output_failed_log_omits_raw_output_and_field_values() 
     # Schema-violation codes look like "schema_violation:<json_paths>" —
     # containing only the JSON paths, never user values.
     assert any("schema_violation" in c for c in failed["causes"])
+
+
+def test_clean_strips_trailing_fence_when_no_opening_fence_present() -> None:
+    """Regression: trailing ``` must be stripped even without an opening fence.
+
+    Before the fix, `_clean` only stripped a trailing fence inside the branch
+    that detected an opening fence, so output like `{...}\\n```` left the
+    closing backticks in the cleaned text. `raw_decode` happens to tolerate
+    the trailing noise today, but the contract of `_clean` is to hand JSON
+    parsing a fence-free string — relying on `raw_decode`'s leniency is
+    fragile and hides the intent.
+    """
+    raw = '{"foo": "bar"}\n```'
+
+    cleaned = _clean(raw)
+
+    assert cleaned == '{"foo": "bar"}'
+
+
+def test_clean_is_noop_when_no_fences_present() -> None:
+    """Regression guard: plain JSON must pass through `_clean` unchanged."""
+    raw = '{"foo": "bar"}'
+
+    cleaned = _clean(raw)
+
+    assert cleaned == '{"foo": "bar"}'
+
+
+def test_clean_strips_both_opening_and_trailing_fence() -> None:
+    """Regression guard: fully-fenced input keeps its previous behavior."""
+    raw = '```json\n{"foo": "bar"}\n```'
+
+    cleaned = _clean(raw)
+
+    assert cleaned == '{"foo": "bar"}'
+
+
+def test_clean_strips_trailing_fence_with_surrounding_whitespace() -> None:
+    """Trailing fence followed by whitespace must also be stripped."""
+    raw = '{"foo": "bar"}\n```\n   '
+
+    cleaned = _clean(raw)
+
+    assert cleaned == '{"foo": "bar"}'
 
 
 async def test_structured_output_retry_log_uses_sanitized_cause_field() -> None:

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_structured_output_validator.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_structured_output_validator.py
@@ -377,7 +377,7 @@ def test_clean_strips_trailing_fence_when_no_opening_fence_present() -> None:
     """Regression: trailing ``` must be stripped even without an opening fence.
 
     Before the fix, `_clean` only stripped a trailing fence inside the branch
-    that detected an opening fence, so output like `{...}\\n```` left the
+    that detected an opening fence, so output like `{...}\\n``` left the
     closing backticks in the cleaned text. `raw_decode` happens to tolerate
     the trailing noise today, but the contract of `_clean` is to hand JSON
     parsing a fence-free string — relying on `raw_decode`'s leniency is


### PR DESCRIPTION
## Summary
- `StructuredOutputValidator._clean` only stripped the trailing ``` inside the branch that detected an opening fence. LLM output with only a trailing fence (or one whose opener bypassed the prefix match) leaked backticks into the JSON parse step; `json.raw_decode`'s tolerance masked the defect without correcting the contract.
- Refactored `_clean` into three sequential, independent passes — strip opening fence, strip trailing fence, strip whitespace — so trailing-fence stripping no longer depends on opening-fence detection.
- Added three test cases: trailing-fence-only (failing before fix), no-fences passthrough (regression guard), both-fences roundtrip (regression guard), plus a whitespace variant.

Closes #149.

## Test plan
- [x] `pytest tests/unit/features/extraction/intelligence/test_structured_output_validator.py` — 23/23 pass
- [x] `task check` — 625 unit + 84 integration + 9 contract + 12 error-contract tests, all green; ruff, pyright strict, import-linter, skills:validate all pass