### PR TITLE
fix(config): validate Settings.log_level against stdlib-logging levels

### DIFF
--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -14,6 +14,13 @@ from app.core.docling_modes import OcrMode, TableMode
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent.parent
 _DEFAULT_SKILLS_DIR = _BACKEND_ROOT / "skills"
 
+# Canonical stdlib-logging level names. Mirrors ``logging._nameToLevel``
+# minus ``NOTSET`` and the ``WARN`` alias — operators should spell
+# ``WARNING`` in full so the error message is unambiguous.
+_VALID_LOG_LEVELS: frozenset[str] = frozenset(
+    {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"},
+)
+
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
@@ -45,6 +52,36 @@ class Settings(BaseSettings):
 
     ollama_base_url: str = "http://host.docker.internal:11434"
     ollama_model: str = "gemma4:e2b"
+
+    @field_validator("log_level", mode="after")
+    @classmethod
+    def _validate_log_level(cls, v: str) -> str:
+        """Normalize and validate ``log_level`` against stdlib-logging levels.
+
+        Without this validator, a typo like ``LOG_LEVEL=debg`` slipped
+        past ``Settings`` construction and only crashed later when
+        structlog / ``logging.Logger.setLevel`` tried to parse it —
+        *before* the FastAPI exception handlers install, producing an
+        opaque traceback on startup (issue #146).
+
+        The validator:
+
+        * accepts any case (``debug``, ``Debug``, ``DEBUG``);
+        * strips surrounding whitespace (common ``.env`` paper-cut);
+        * rejects the empty string, non-standard aliases (``warn``),
+          and typos, with a message that lists the valid options so
+          operators can self-correct.
+
+        ``mode="after"`` is safe because the field is typed ``str`` and
+        pydantic-settings coerces env vars to strings before this
+        validator runs.
+        """
+        normalized = v.strip().upper()
+        if normalized not in _VALID_LOG_LEVELS:
+            valid = ", ".join(sorted(_VALID_LOG_LEVELS))
+            msg = f"log_level must be one of {{{valid}}} (case-insensitive); got {v!r}"
+            raise ValueError(msg)
+        return normalized
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -14,9 +14,10 @@ from app.core.docling_modes import OcrMode, TableMode
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent.parent
 _DEFAULT_SKILLS_DIR = _BACKEND_ROOT / "skills"
 
-# Canonical stdlib-logging level names. Mirrors ``logging._nameToLevel``
-# minus ``NOTSET`` and the ``WARN`` alias — operators should spell
-# ``WARNING`` in full so the error message is unambiguous.
+# Canonical stdlib-logging level names accepted by this validator.
+# Aliases such as ``WARN`` and ``FATAL`` are intentionally excluded —
+# operators should spell ``WARNING`` in full so the error message is
+# unambiguous.
 _VALID_LOG_LEVELS: frozenset[str] = frozenset(
     {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"},
 )

--- a/apps/backend/tests/unit/core/test_config.py
+++ b/apps/backend/tests/unit/core/test_config.py
@@ -10,7 +10,8 @@ def test_settings_defaults() -> None:
     """Settings should construct with sensible defaults from environment or code."""
     s = Settings()
     assert s.app_env == "development"
-    assert s.log_level == "info"
+    # log_level is normalized to uppercase by the validator (issue #146).
+    assert s.log_level == "INFO"
     assert s.cors_origins == ["http://localhost:5173"]
 
 
@@ -22,7 +23,8 @@ def test_settings_accepts_overrides() -> None:
         cors_origins=["https://example.com"],
     )
     assert s.app_env == "production"
-    assert s.log_level == "warning"
+    # Validator normalizes lowercase inputs to canonical uppercase (issue #146).
+    assert s.log_level == "WARNING"
     assert s.cors_origins == ["https://example.com"]
 
 
@@ -173,3 +175,68 @@ def test_settings_cors_origins_empty_array_via_env(
     monkeypatch.setenv("CORS_ORIGINS", "[]")
     s = Settings(_env_file=None)  # type: ignore[call-arg]
     assert s.cors_origins == []
+
+
+# -- log_level validation (issue #146) --------------------------------------
+
+
+def test_settings_log_level_typo_rejected() -> None:
+    """A typo like ``debg`` must fail validation with a clear error.
+
+    Without this validator, the typo slipped past Settings construction
+    and only surfaced when structlog / the stdlib logger tried to parse
+    it — crashing the app *before* the FastAPI exception handlers install.
+    """
+    with pytest.raises(ValidationError, match="log_level"):
+        Settings(log_level="debg")
+
+
+def test_settings_log_level_empty_string_rejected() -> None:
+    """An empty string for log_level must be rejected."""
+    with pytest.raises(ValidationError, match="log_level"):
+        Settings(log_level="")
+
+
+def test_settings_log_level_nonstandard_alias_rejected() -> None:
+    """A non-standard alias like ``warn`` (vs. ``warning``) must be rejected."""
+    with pytest.raises(ValidationError, match="log_level"):
+        Settings(log_level="warn")
+
+
+def test_settings_log_level_lowercase_normalized_to_uppercase() -> None:
+    """Lowercase values (common in ``.env`` files) normalize to uppercase."""
+    s = Settings(log_level="debug")
+    assert s.log_level == "DEBUG"
+
+
+def test_settings_log_level_mixed_case_normalized_to_uppercase() -> None:
+    """Mixed-case input is normalized to the canonical uppercase form."""
+    s = Settings(log_level="Warning")
+    assert s.log_level == "WARNING"
+
+
+def test_settings_log_level_uppercase_accepted() -> None:
+    """Uppercase values pass through unchanged."""
+    s = Settings(log_level="ERROR")
+    assert s.log_level == "ERROR"
+
+
+def test_settings_log_level_whitespace_stripped() -> None:
+    """Leading/trailing whitespace must be stripped before validation."""
+    s = Settings(log_level="  info  ")
+    assert s.log_level == "INFO"
+
+
+def test_settings_log_level_default_normalized_to_uppercase() -> None:
+    """The default value is also normalized by the validator."""
+    s = Settings()
+    assert s.log_level == "INFO"
+
+
+def test_settings_log_level_error_lists_valid_options() -> None:
+    """Validation error must list the valid options so operators can self-correct."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(log_level="debg")
+    message = str(exc_info.value)
+    for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        assert level in message


### PR DESCRIPTION
## Summary

- Add a pydantic `@field_validator` on `Settings.log_level` that normalizes case, strips whitespace, and validates against the stdlib-logging canonical set `{DEBUG, INFO, WARNING, ERROR, CRITICAL}`.
- Invalid values (typos like `debg`, empty strings, non-standard aliases like `warn`) now raise a clear pydantic `ValidationError` at `Settings()` construction time — before logging setup runs, before the FastAPI exception handlers install — with the valid options listed in the error message so operators can self-correct.

## Why

Previously `Settings.log_level` was a raw `str`. A typo in `LOG_LEVEL=debg` slipped past Settings construction and crashed the app inside `logging.Logger.setLevel(...)` during `configure_logging`. That path runs on import / startup, before the exception handlers are installed, so the operator got an ugly traceback rather than a structured startup-config error.

## Approach

Validator over `Literal[...]` because operators routinely write `LOG_LEVEL=info` in `.env` (lowercase). The validator accepts any case, strips whitespace, and normalizes to uppercase — the canonical stdlib form, which is also what `logging.Logger.setLevel` consumes.

## Test plan

- [x] Unit: typo rejected, empty string rejected, non-standard alias (`warn`) rejected, lowercase normalized to uppercase, mixed case normalized, uppercase pass-through, whitespace stripped, default normalized, error message lists valid options.
- [x] Existing `test_settings_defaults` / `test_settings_accepts_overrides` updated to reflect the normalized uppercase form.
- [x] `task check` green (ruff, ruff-format, pyright strict, import-linter, 630 unit + 84 integration + 9 contract tests).

Closes #146.