### PR TITLE
fix(langextract): bound future.result with ollama_timeout_seconds

### DIFF
--- a/apps/backend/app/features/extraction/deps.py
+++ b/apps/backend/app/features/extraction/deps.py
@@ -48,7 +48,10 @@ def get_extraction_engine(request: Request) -> ExtractionEngine:
         with _dep_init_lock:
             engine = getattr(state, "extraction_engine", None)
             if engine is None:
-                engine = ExtractionEngine()
+                # Pass settings so the engine can bound the per-prompt
+                # `future.result()` blocking call inside
+                # `_ValidatingLangExtractAdapter.infer` (issue #152).
+                engine = ExtractionEngine(settings=state.settings)
                 state.extraction_engine = engine
     return engine
 

--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -142,21 +142,26 @@ class _ValidatingLangExtractAdapter(BaseLanguageModel):
                 # on the class would also catch an inner `TimeoutError`
                 # raised by the coroutine body, conflating a hung Ollama
                 # (this adapter's concern) with an inner-provider timeout
-                # (not our concern). We distinguish by `future.done()`:
-                # only a *pending* future means `future.result(timeout=)`
-                # itself timed out; a *done* future with a `TimeoutError`
-                # means the coroutine finished by raising — so we re-raise
-                # the original exception unchanged, preserving the cause.
+                # (not our concern). There is also a boundary race:
+                # `future.result(timeout=...)` may time out and THEN the
+                # future may settle before we inspect it. We distinguish
+                # by `future.done()`: a done future means the coroutine
+                # settled (success or exception) — call `future.result()`
+                # with no timeout so a just-completed success continues
+                # normally and a coroutine-raised `TimeoutError` still
+                # propagates unchanged. Only a still-pending future
+                # should be cancelled and remapped to our domain error.
                 if future.done():
-                    raise
-                # Best-effort cancel — a coroutine already blocked in a
-                # syscall on the main loop may still complete, but we stop
-                # caring about its result. Without this bound, a hung
-                # Ollama would pin this worker thread forever (issue #152).
-                future.cancel()
-                raise IntelligenceTimeoutError(
-                    budget_seconds=self._timeout_seconds,
-                ) from None
+                    result = future.result()
+                else:
+                    # Best-effort cancel — a coroutine already blocked in a
+                    # syscall on the main loop may still complete, but we stop
+                    # caring about its result. Without this bound, a hung
+                    # Ollama would pin this worker thread forever (issue #152).
+                    future.cancel()
+                    raise IntelligenceTimeoutError(
+                        budget_seconds=self._timeout_seconds,
+                    ) from None
             yield [ScoredOutput(score=1.0, output=json.dumps(result.data))]
 
 

--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -104,7 +104,12 @@ class _ValidatingLangExtractAdapter(BaseLanguageModel):
     result is discarded when this adapter's caller returns) and raise
     `IntelligenceTimeoutError`, which the global exception handler maps to
     504. The adapter does NOT own the main loop's executor, so there is
-    nothing to shut down here.
+    nothing to shut down here. Note: `concurrent.futures.TimeoutError` is
+    aliased to the builtin `TimeoutError` in CPython 3.11+, so the `except`
+    clause must distinguish an adapter timeout (future still pending) from
+    an inner `TimeoutError` raised by the coroutine (future already done)
+    via `future.done()` — otherwise inner failures would be silently
+    remapped to `IntelligenceTimeoutError` and lose their cause.
     """
 
     def __init__(
@@ -132,6 +137,18 @@ class _ValidatingLangExtractAdapter(BaseLanguageModel):
             try:
                 result = future.result(timeout=self._timeout_seconds)
             except concurrent.futures.TimeoutError:
+                # In CPython 3.11+, `concurrent.futures.TimeoutError is
+                # TimeoutError is asyncio.TimeoutError`. A bare `except`
+                # on the class would also catch an inner `TimeoutError`
+                # raised by the coroutine body, conflating a hung Ollama
+                # (this adapter's concern) with an inner-provider timeout
+                # (not our concern). We distinguish by `future.done()`:
+                # only a *pending* future means `future.result(timeout=)`
+                # itself timed out; a *done* future with a `TimeoutError`
+                # means the coroutine finished by raising — so we re-raise
+                # the original exception unchanged, preserving the cause.
+                if future.done():
+                    raise
                 # Best-effort cancel — a coroutine already blocked in a
                 # syscall on the main loop may still complete, but we stop
                 # caring about its result. Without this bound, a hung

--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -41,6 +41,7 @@ into field-level semantics.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
@@ -50,6 +51,8 @@ from langextract.core.base_model import BaseLanguageModel
 from langextract.core.data import AnnotatedDocument, ExampleData, Extraction
 from langextract.core.types import ScoredOutput
 
+from app.core.config import Settings
+from app.exceptions import IntelligenceTimeoutError
 from app.features.extraction.extraction.raw_extraction import RawExtraction
 from app.features.extraction.intelligence.langextract_wrapper_schema import (
     LANGEXTRACT_WRAPPER_SCHEMA,
@@ -89,16 +92,32 @@ class _ValidatingLangExtractAdapter(BaseLanguageModel):
     blocking on the returned `concurrent.futures.Future` from the
     worker thread — LangExtract's own orchestration is synchronous,
     so the blocking call is expected.
+
+    **Bounded blocking (issue #152).** The blocking `future.result()` call
+    is always bounded by `timeout_seconds` (sourced from
+    `Settings.ollama_timeout_seconds`). Without a timeout, an unresponsive
+    Ollama pins the worker thread indefinitely; sustained hangs exhaust
+    the thread pool, queue new requests, and degrade the service silently.
+    On `concurrent.futures.TimeoutError` we cancel the pending future
+    (best-effort — a coroutine that has already started awaiting a blocking
+    primitive may still run to completion on the main loop, but any pending
+    result is discarded when this adapter's caller returns) and raise
+    `IntelligenceTimeoutError`, which the global exception handler maps to
+    504. The adapter does NOT own the main loop's executor, so there is
+    nothing to shut down here.
     """
 
     def __init__(
         self,
         inner: IntelligenceProvider,
         main_loop: asyncio.AbstractEventLoop,
+        *,
+        timeout_seconds: float,
     ) -> None:
         super().__init__()
         self._inner = inner
         self._main_loop = main_loop
+        self._timeout_seconds = timeout_seconds
 
     def infer(
         self,
@@ -110,12 +129,43 @@ class _ValidatingLangExtractAdapter(BaseLanguageModel):
                 self._inner.generate(prompt, LANGEXTRACT_WRAPPER_SCHEMA),
                 self._main_loop,
             )
-            result = future.result()
+            try:
+                result = future.result(timeout=self._timeout_seconds)
+            except concurrent.futures.TimeoutError:
+                # Best-effort cancel — a coroutine already blocked in a
+                # syscall on the main loop may still complete, but we stop
+                # caring about its result. Without this bound, a hung
+                # Ollama would pin this worker thread forever (issue #152).
+                future.cancel()
+                raise IntelligenceTimeoutError(
+                    budget_seconds=self._timeout_seconds,
+                ) from None
             yield [ScoredOutput(score=1.0, output=json.dumps(result.data))]
 
 
 class ExtractionEngine:
-    """Constructs LangExtract call parameters from a Skill and invokes it."""
+    """Constructs LangExtract call parameters from a Skill and invokes it.
+
+    The engine's only configuration is the Ollama timeout budget that bounds
+    the `_ValidatingLangExtractAdapter.infer` blocking `future.result(...)`
+    per prompt (issue #152). When no `settings` argument is passed the
+    engine lazily materializes a `Settings()` from environment variables,
+    so callers that instantiated the engine with no argument before the
+    fix still work unchanged.
+    """
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self._settings = settings
+
+    def _ollama_timeout_seconds(self) -> float:
+        # Materialize Settings lazily so `ExtractionEngine()` call sites
+        # that predate the fix keep working. Pydantic-settings reads from
+        # env variables, matching the rest of the service.
+        settings = self._settings
+        if settings is None:
+            settings = Settings()  # type: ignore[call-arg]  # pydantic-settings fills from env
+            self._settings = settings
+        return settings.ollama_timeout_seconds
 
     async def extract(
         self,
@@ -158,7 +208,11 @@ class ExtractionEngine:
         # coroutines back onto THIS loop via `run_coroutine_threadsafe`.
         # That keeps the shared httpx client pool on its original loop.
         main_loop = asyncio.get_running_loop()
-        adapter = _ValidatingLangExtractAdapter(provider, main_loop)
+        adapter = _ValidatingLangExtractAdapter(
+            provider,
+            main_loop,
+            timeout_seconds=self._ollama_timeout_seconds(),
+        )
 
         result = await asyncio.to_thread(
             self._invoke_langextract,

--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -163,7 +163,7 @@ class ExtractionEngine:
         # env variables, matching the rest of the service.
         settings = self._settings
         if settings is None:
-            settings = Settings()  # type: ignore[call-arg]  # pydantic-settings fills from env
+            settings = Settings()  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
             self._settings = settings
         return settings.ollama_timeout_seconds
 

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -512,7 +512,7 @@ async def test_validating_adapter_infer_routes_through_provider_generate() -> No
 
     provider = _FakeProvider()
     main_loop = _asyncio.get_running_loop()
-    adapter = _ValidatingLangExtractAdapter(provider, main_loop)
+    adapter = _ValidatingLangExtractAdapter(provider, main_loop, timeout_seconds=30.0)
 
     def _run_infer() -> list[list[Any]]:
         return [list(batch) for batch in adapter.infer(["prompt-a", "prompt-b"])]
@@ -565,7 +565,11 @@ async def test_validating_adapter_routes_generate_back_to_main_event_loop() -> N
                 raw_output='{"ok": true}',
             )
 
-    adapter = _ValidatingLangExtractAdapter(_LoopCapturingProvider(), main_loop)
+    adapter = _ValidatingLangExtractAdapter(
+        _LoopCapturingProvider(),
+        main_loop,
+        timeout_seconds=30.0,
+    )
 
     def _run_infer() -> None:
         list(adapter.infer(["p1", "p2", "p3"]))
@@ -576,6 +580,111 @@ async def test_validating_adapter_routes_generate_back_to_main_event_loop() -> N
     assert all(lid == expected_loop_id for lid in captured_loops), (
         f"expected all prompts on main loop {expected_loop_id}, got {captured_loops}"
     )
+
+
+async def test_validating_adapter_infer_raises_intelligence_timeout_when_generate_hangs() -> None:
+    """If `provider.generate` hangs past `timeout_seconds`, the adapter must
+    raise `IntelligenceTimeoutError` (not block forever on `future.result()`
+    and not leak `concurrent.futures.TimeoutError`). Fix for issue #152:
+    unbounded `future.result()` was a thread-pool leak under sustained Ollama
+    hangs. We assert a hang is bounded by the configured timeout.
+    """
+    import asyncio as _asyncio
+
+    from app.exceptions import IntelligenceTimeoutError
+
+    hang_started = _asyncio.Event()
+
+    class _HangingProvider:
+        async def generate(
+            self,
+            prompt: str,
+            output_schema: dict[str, Any],
+        ) -> GenerationResult:
+            _ = prompt
+            _ = output_schema
+            hang_started.set()
+            # Simulate an unresponsive Ollama: hang effectively forever.
+            # The adapter's `future.result(timeout=...)` must wake us up.
+            await _asyncio.sleep(3600)
+            msg = "unreachable — adapter should have timed out"  # pragma: no cover
+            raise AssertionError(msg)  # pragma: no cover
+
+    main_loop = _asyncio.get_running_loop()
+    adapter = _ValidatingLangExtractAdapter(
+        _HangingProvider(),
+        main_loop,
+        timeout_seconds=0.2,
+    )
+
+    def _run_infer() -> None:
+        list(adapter.infer(["prompt-that-hangs"]))
+
+    # The overall await must return promptly with IntelligenceTimeoutError,
+    # not hang the caller. `asyncio.wait_for` as a belt-and-braces guard
+    # proves we were not rescued by the test harness killing the loop.
+    with pytest.raises(IntelligenceTimeoutError) as exc_info:
+        await _asyncio.wait_for(_asyncio.to_thread(_run_infer), timeout=5.0)
+    assert exc_info.value.code == "INTELLIGENCE_TIMEOUT"
+    # Sanity: the hanging coroutine actually started (so we really did hit
+    # the timeout path, not short-circuit somewhere earlier).
+    assert hang_started.is_set()
+
+
+async def test_validating_adapter_infer_returns_normally_when_generate_completes_in_time() -> None:
+    """Positive regression for the timeout fix: when `provider.generate` finishes
+    well within `timeout_seconds`, `infer` must yield the expected ScoredOutput
+    without surfacing any timeout error. Guards against the timeout guard
+    accidentally short-circuiting the fast path.
+    """
+    import asyncio as _asyncio
+
+    provider = _FakeProvider()
+    main_loop = _asyncio.get_running_loop()
+    adapter = _ValidatingLangExtractAdapter(
+        provider,
+        main_loop,
+        timeout_seconds=30.0,
+    )
+
+    def _run_infer() -> list[list[Any]]:
+        return [list(batch) for batch in adapter.infer(["quick-prompt"])]
+
+    results = await _asyncio.to_thread(_run_infer)
+
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert json.loads(results[0][0].output) == {"ok": True}
+
+
+async def test_extract_passes_ollama_timeout_from_settings_into_adapter(
+    patch_extract: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`ExtractionEngine.extract` must build the adapter with the
+    `ollama_timeout_seconds` value from `Settings`, so the timeout honoured
+    inside `future.result(timeout=...)` is the configured Ollama budget.
+    """
+    monkeypatch.setenv("OLLAMA_TIMEOUT_SECONDS", "7.5")
+
+    text = "Alice is 30."
+    skill = _build_skill(("name",))
+    patch_extract(
+        AnnotatedDocument(
+            extractions=[_extraction("name", "Alice", 0, 5)],
+            text=text,
+        ),
+    )
+
+    await ExtractionEngine().extract(text, skill, _FakeProvider())
+
+    call_kwargs = patch_extract.calls[0]  # type: ignore[attr-defined]
+    model = call_kwargs["model"]
+    assert isinstance(model, _ValidatingLangExtractAdapter)
+    # The adapter records the effective budget so downstream
+    # `future.result(timeout=...)` and IntelligenceTimeoutError payload
+    # both use the configured value.
+    assert model._timeout_seconds == 7.5  # noqa: SLF001 — asserting on private state is the point
 
 
 def test_extract_method_is_async() -> None:

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -691,6 +691,82 @@ async def test_validating_adapter_infer_propagates_inner_timeout_error_distinct_
     assert "provider's own timeout" in str(exc_info.value)
 
 
+async def test_validating_adapter_infer_returns_settled_result_on_boundary_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for Copilot review on PR #173: there is a boundary race
+    where `future.result(timeout=...)` raises `TimeoutError` AND the future
+    settles (successfully) just before we inspect `future.done()`. In that
+    case the adapter must return the settled result — NOT re-raise the
+    stale `TimeoutError` from the timed-out `.result(timeout=...)` call.
+
+    Before the fix, `if future.done(): raise` would leak the `TimeoutError`
+    past the adapter for a future that had actually completed successfully.
+    After the fix, a done future gets `.result()` called WITHOUT a timeout,
+    returning the settled value (or re-raising the coroutine's real error).
+    """
+    import asyncio as _asyncio
+    import concurrent.futures as _cf
+
+    from app.features.extraction.intelligence.generation_result import GenerationResult
+
+    settled_payload = GenerationResult(
+        data={"ok": True, "source": "settled-just-in-time"},
+        raw_output="{}",
+        attempts=1,
+    )
+
+    class _RacyFuture:
+        """Simulates the boundary race: first `.result(timeout=...)` raises
+        TimeoutError, but `.done()` returns True and `.result()` (no timeout)
+        returns the already-settled payload."""
+
+        def __init__(self, settled: GenerationResult) -> None:
+            self._settled = settled
+            self._timed_out_once = False
+
+        def result(self, timeout: float | None = None) -> GenerationResult:
+            if timeout is not None and not self._timed_out_once:
+                self._timed_out_once = True
+                raise _cf.TimeoutError
+            return self._settled
+
+        def done(self) -> bool:
+            return True
+
+        def cancel(self) -> bool:
+            return False
+
+    def _stub_run_coro_threadsafe(coro: Any, _loop: Any) -> _RacyFuture:
+        # Close the coroutine so we don't leak a "never awaited" warning.
+        coro.close()
+        return _RacyFuture(settled_payload)
+
+    monkeypatch.setattr(
+        "app.features.extraction.extraction.extraction_engine.asyncio.run_coroutine_threadsafe",
+        _stub_run_coro_threadsafe,
+    )
+
+    main_loop = _asyncio.get_running_loop()
+    adapter = _ValidatingLangExtractAdapter(
+        _FakeProvider(),
+        main_loop,
+        timeout_seconds=0.001,  # small; the stub controls behavior regardless
+    )
+
+    def _run_infer() -> list[list[Any]]:
+        return [list(batch) for batch in adapter.infer(["prompt"])]
+
+    results = await _asyncio.to_thread(_run_infer)
+
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert json.loads(results[0][0].output) == {
+        "ok": True,
+        "source": "settled-just-in-time",
+    }
+
+
 async def test_validating_adapter_infer_returns_normally_when_generate_completes_in_time() -> None:
     """Positive regression for the timeout fix: when `provider.generate` finishes
     well within `timeout_seconds`, `infer` must yield the expected ScoredOutput

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -629,8 +629,66 @@ async def test_validating_adapter_infer_raises_intelligence_timeout_when_generat
         await _asyncio.wait_for(_asyncio.to_thread(_run_infer), timeout=5.0)
     assert exc_info.value.code == "INTELLIGENCE_TIMEOUT"
     # Sanity: the hanging coroutine actually started (so we really did hit
-    # the timeout path, not short-circuit somewhere earlier).
-    assert hang_started.is_set()
+    # the timeout path, not short-circuit somewhere earlier). Because
+    # `future.cancel()` on a coroutine that has already been scheduled on
+    # the main loop is best-effort, the coroutine continues running for
+    # its `sleep(3)` duration even after the adapter raises — so we wait
+    # with our own timeout to absorb event-loop scheduling jitter rather
+    # than flaking when the timeout budget (0.2s) elapses before the
+    # scheduled `generate` gets CPU time.
+    await _asyncio.wait_for(hang_started.wait(), timeout=1.0)
+
+
+async def test_validating_adapter_infer_propagates_inner_timeout_error_distinct_from_adapter_timeout() -> (
+    None
+):
+    """If `provider.generate` itself raises `TimeoutError` (e.g. an inner
+    `asyncio.wait_for` inside a provider implementation expires), the adapter
+    must propagate that exception — NOT remap it to `IntelligenceTimeoutError`.
+
+    Regression for Copilot review on PR #173: in CPython 3.11+,
+    `concurrent.futures.TimeoutError is TimeoutError is asyncio.TimeoutError`.
+    A bare `except concurrent.futures.TimeoutError` would also catch inner
+    `TimeoutError` raised by the underlying coroutine, incorrectly converting
+    inner failures into `IntelligenceTimeoutError` and discarding the original
+    cause. The adapter distinguishes the two cases by checking
+    `future.done()` — only a pending future means `future.result(timeout=...)`
+    itself timed out; a done future with a `TimeoutError` result came from
+    the coroutine body.
+    """
+    import asyncio as _asyncio
+
+    from app.exceptions import IntelligenceTimeoutError
+
+    class _InnerTimeoutProvider:
+        async def generate(
+            self,
+            prompt: str,
+            output_schema: dict[str, Any],
+        ) -> GenerationResult:
+            _ = prompt
+            _ = output_schema
+            msg = "provider's own timeout — NOT adapter's future.result timeout"
+            raise TimeoutError(msg)
+
+    main_loop = _asyncio.get_running_loop()
+    adapter = _ValidatingLangExtractAdapter(
+        _InnerTimeoutProvider(),
+        main_loop,
+        timeout_seconds=30.0,
+    )
+
+    def _run_infer() -> None:
+        list(adapter.infer(["prompt"]))
+
+    # The inner TimeoutError must propagate — it is NOT an adapter timeout.
+    # We assert `not isinstance(..., IntelligenceTimeoutError)` defensively
+    # so a regression that re-maps inner timeouts is caught even if a
+    # future refactor makes IntelligenceTimeoutError extend TimeoutError.
+    with pytest.raises(TimeoutError) as exc_info:
+        await _asyncio.to_thread(_run_infer)
+    assert not isinstance(exc_info.value, IntelligenceTimeoutError)
+    assert "provider's own timeout" in str(exc_info.value)
 
 
 async def test_validating_adapter_infer_returns_normally_when_generate_completes_in_time() -> None:

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -622,21 +622,22 @@ async def test_validating_adapter_infer_raises_intelligence_timeout_when_generat
     def _run_infer() -> None:
         list(adapter.infer(["prompt-that-hangs"]))
 
+    # Start the blocking adapter call in the background, wait until the
+    # provider coroutine has definitely started, and only then assert that
+    # the adapter returns promptly with IntelligenceTimeoutError. Avoids a
+    # race where the adapter's 0.2s cancel could fire before the main loop
+    # has scheduled `generate` on slow/busy CI runners — in which case the
+    # old assertion (`hang_started.wait()` after the thread returned) would
+    # flake because `hang_started` never got set.
+    infer_task = _asyncio.create_task(_asyncio.to_thread(_run_infer))
+    await _asyncio.wait_for(hang_started.wait(), timeout=1.0)
+
     # The overall await must return promptly with IntelligenceTimeoutError,
     # not hang the caller. `asyncio.wait_for` as a belt-and-braces guard
     # proves we were not rescued by the test harness killing the loop.
     with pytest.raises(IntelligenceTimeoutError) as exc_info:
-        await _asyncio.wait_for(_asyncio.to_thread(_run_infer), timeout=5.0)
+        await _asyncio.wait_for(infer_task, timeout=5.0)
     assert exc_info.value.code == "INTELLIGENCE_TIMEOUT"
-    # Sanity: the hanging coroutine actually started (so we really did hit
-    # the timeout path, not short-circuit somewhere earlier). Because
-    # `future.cancel()` on a coroutine that has already been scheduled on
-    # the main loop is best-effort, the coroutine continues running for
-    # its `sleep(3)` duration even after the adapter raises — so we wait
-    # with our own timeout to absorb event-loop scheduling jitter rather
-    # than flaking when the timeout budget (0.2s) elapses before the
-    # scheduled `generate` gets CPU time.
-    await _asyncio.wait_for(hang_started.wait(), timeout=1.0)
 
 
 async def test_validating_adapter_infer_propagates_inner_timeout_error_distinct_from_adapter_timeout() -> (

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -604,9 +604,11 @@ async def test_validating_adapter_infer_raises_intelligence_timeout_when_generat
             _ = prompt
             _ = output_schema
             hang_started.set()
-            # Simulate an unresponsive Ollama: hang effectively forever.
-            # The adapter's `future.result(timeout=...)` must wake us up.
-            await _asyncio.sleep(3600)
+            # Simulate an unresponsive Ollama with a delay that exceeds the
+            # adapter timeout (0.2s) without stranding a non-daemon worker
+            # thread for an hour if timeout handling ever regresses. A few
+            # seconds is ample headroom vs the 0.2s budget below.
+            await _asyncio.sleep(3)
             msg = "unreachable — adapter should have timed out"  # pragma: no cover
             raise AssertionError(msg)  # pragma: no cover
 


### PR DESCRIPTION
## Summary
- `_ValidatingLangExtractAdapter.infer` now passes `timeout=settings.ollama_timeout_seconds` into `future.result(...)`, so a hung Ollama cannot pin a worker thread indefinitely (issue #152).
- On `concurrent.futures.TimeoutError`, the adapter cancels the pending future best-effort and raises `IntelligenceTimeoutError` (504), which maps cleanly at the boundary — no generic `TimeoutError` leaks out.
- `ExtractionEngine` now accepts an optional `settings=` arg (lazy-materialized to `Settings()` when omitted, preserving the pre-existing `ExtractionEngine()` no-arg call sites). `deps.py` wires `state.settings` through for production.
- No new error code needed — `INTELLIGENCE_TIMEOUT` already exists in `errors.yaml` with `budget_seconds: number`.

## Test plan
- [x] Failing unit test: `test_validating_adapter_infer_raises_intelligence_timeout_when_generate_hangs` exercises the hang path with a 0.2 s budget and `asyncio.wait_for` as belt-and-braces.
- [x] Positive regression: `test_validating_adapter_infer_returns_normally_when_generate_completes_in_time`.
- [x] Wiring check: `test_extract_passes_ollama_timeout_from_settings_into_adapter` asserts `Settings.ollama_timeout_seconds` flows into the adapter.
- [x] `task check` green end-to-end (lint, types, architecture, skills, unit, integration, contract, error-contracts codegen + tests).

Closes #152.