### PR TITLE
fix(logging): apply redaction filter to exception tracebacks

### DIFF
--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -40,8 +40,10 @@ _EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 # Long numeric sequences (4+ digits) that may be monetary amounts, identifiers,
 # or phone numbers. Matches optional thousands-separators and a decimal part so
 # "$1,847.50" and "1847.50" both collapse to the same placeholder. Line numbers
-# in traceback frames ("line 42") are only 1-3 digits and therefore untouched.
-_NUMERIC_PATTERN = re.compile(r"\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?|\d+\.\d+")
+# in traceback frames ("line 42"), version strings ("python3.13"), and short
+# decimals ("timeout=0.5") are only 1-3 digits and therefore untouched —
+# mangling them would destroy traceback readability without scrubbing PII.
+_NUMERIC_PATTERN = re.compile(r"\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?")
 
 
 class LogRedactionFilter:

--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -6,8 +6,16 @@ the event dict outright, and long string values under any other key are truncate
 so operators see something without the full payload landing in logs. Call sites
 should not include forbidden fields in the first place; this filter exists so
 that an accidental log statement cannot leak document content.
+
+For the 'exception' key produced by ``structlog.processors.format_exc_info``,
+the filter additionally regex-scrubs email addresses and long numeric sequences
+from the rendered traceback string. Exception messages (e.g. the ``args[0]`` of
+a ``ValueError``) pass through the rendering verbatim and would otherwise leak
+PII such as filenames, emails, and monetary amounts from the exception's string
+representation (issue #134).
 """
 
+import re
 from collections.abc import Mapping, MutableMapping
 from typing import Any, cast
 
@@ -16,7 +24,24 @@ from typing import Any, cast
 # filter refuses to drop it — losing the message body would silently destroy
 # operator visibility.
 _EVENT_KEY = "event"
+# The 'exception' key is produced by ``structlog.processors.format_exc_info``
+# when a log call carries ``exc_info``. Its value is a multi-line traceback
+# string that may embed the original exception message verbatim; PII inside
+# that message must be scrubbed before the event reaches the renderer.
+_EXCEPTION_KEY = "exception"
 _TRUNCATION_SUFFIX = "... [truncated]"
+_REDACTED_EMAIL = "[REDACTED_EMAIL]"
+_REDACTED_NUMBER = "[REDACTED_NUMBER]"
+
+# Standard RFC-5322-ish email pattern; intentionally conservative to avoid
+# matching Python identifiers, filenames with dots, or module paths in a
+# traceback's frame lines.
+_EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+# Long numeric sequences (4+ digits) that may be monetary amounts, identifiers,
+# or phone numbers. Matches optional thousands-separators and a decimal part so
+# "$1,847.50" and "1847.50" both collapse to the same placeholder. Line numbers
+# in traceback frames ("line 42") are only 1-3 digits and therefore untouched.
+_NUMERIC_PATTERN = re.compile(r"\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?|\d+\.\d+")
 
 
 class LogRedactionFilter:
@@ -59,10 +84,21 @@ class LogRedactionFilter:
             # 'event' is sacrosanct: it holds the log message body and is never
             # dropped, even if a misconfigured denylist contains it.
             is_event = top_level and key == _EVENT_KEY
+            is_exception = top_level and key == _EXCEPTION_KEY
             if not is_event and self._is_redacted_key(key):
+                continue
+            if is_exception and isinstance(value, str):
+                # Rendered tracebacks may embed exception messages containing
+                # PII from upstream ValueErrors; scrub patterns before the
+                # standard truncation pass runs (issue #134).
+                result[key] = self._truncate_if_oversize(self._scrub_exception_string(value))
                 continue
             result[key] = self._scrub_value(value, preserve_length=is_event)
         return result
+
+    def _scrub_exception_string(self, value: str) -> str:
+        scrubbed = _EMAIL_PATTERN.sub(_REDACTED_EMAIL, value)
+        return _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, scrubbed)
 
     def _is_redacted_key(self, key: Any) -> bool:
         # Non-string keys cannot be case-folded and are not in the denylist.

--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -8,10 +8,10 @@ should not include forbidden fields in the first place; this filter exists so
 that an accidental log statement cannot leak document content.
 
 For the 'exception' key produced by ``structlog.processors.format_exc_info``,
-the filter additionally regex-scrubs email addresses and long numeric sequences
-from the rendered traceback string. Exception messages (e.g. the ``args[0]`` of
-a ``ValueError``) pass through the rendering verbatim and would otherwise leak
-PII such as filenames, emails, and monetary amounts from the exception's string
+the filter additionally regex-scrubs email addresses and monetary amounts or
+other long numeric identifiers from the rendered traceback string. Exception
+messages (e.g. the ``args[0]`` of a ``ValueError``) pass through the rendering
+verbatim and would otherwise leak PII from the exception's string
 representation (issue #134).
 """
 
@@ -39,11 +39,16 @@ _REDACTED_NUMBER = "[REDACTED_NUMBER]"
 _EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 # Long numeric sequences (4+ digits) that may be monetary amounts, identifiers,
 # or phone numbers. Matches optional thousands-separators and a decimal part so
-# "$1,847.50" and "1847.50" both collapse to the same placeholder. Line numbers
-# in traceback frames ("line 42"), version strings ("python3.13"), and short
-# decimals ("timeout=0.5") are only 1-3 digits and therefore untouched —
-# mangling them would destroy traceback readability without scrubbing PII.
-_NUMERIC_PATTERN = re.compile(r"\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?")
+# "$1,847.50" and "1847.50" both collapse to the same placeholder. Version
+# strings like "python3.13" and short decimals like "timeout=0.5" are only 1-3
+# digits and therefore untouched. Traceback frame line references of the form
+# "line 42" or "line 1234" are preserved explicitly via a negative lookbehind
+# so file/line locators remain readable for incident debugging — large files
+# legitimately produce 4+ digit line numbers, and mangling them would destroy
+# traceback usefulness without scrubbing any PII.
+_NUMERIC_PATTERN = re.compile(
+    r"(?<!line )\b(?:\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?)\b"
+)
 
 
 class LogRedactionFilter:

--- a/apps/backend/app/core/logging.py
+++ b/apps/backend/app/core/logging.py
@@ -36,8 +36,17 @@ def configure_logging(
     # but before any processor that might enrich the dict with sensitive data.
     # Today no enrichment processor adds sensitive keys, but if one is added
     # later it must be placed before the redaction filter, not after.
+    #
+    # ``format_exc_info`` runs before the redaction filter so that any exc_info
+    # tuple attached by ``logger.exception(...)`` is rendered into the
+    # ``exception`` string key BEFORE the filter walks the event dict. That way
+    # the filter sees the full traceback text and can scrub PII out of the
+    # rendered message — rather than passing the untouched exc_info tuple down
+    # to stdlib's ``ProcessorFormatter`` where rendering would happen after the
+    # redaction pass has already finished (issue #134).
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
+        structlog.processors.format_exc_info,
         redaction_filter,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,

--- a/apps/backend/tests/integration/test_request_logging_redaction.py
+++ b/apps/backend/tests/integration/test_request_logging_redaction.py
@@ -26,7 +26,16 @@ HEX32 = re.compile(r"^[a-f0-9]{32}$")
 SENTINEL = "SENSITIVE_PAYLOAD_42"
 PDF_CANARY = "CANARY_BYTES_XYZ"
 
-_TEST_PATHS = {"/_t/log_safe", "/_t/log_sensitive", "/_t/log_pdf", "/_t/log_error"}
+_TEST_PATHS = {
+    "/_t/log_safe",
+    "/_t/log_sensitive",
+    "/_t/log_pdf",
+    "/_t/log_error",
+    "/_t/log_unhandled",
+}
+
+EMAIL_CANARY = "pii+canary@example.com"
+NUMBER_CANARY = "1847.50"
 
 
 @pytest.fixture
@@ -71,6 +80,12 @@ def test_app() -> Iterator[FastAPI]:
             prompt="ignore me",
         )
         return JSONResponse(status_code=400, content={"error": "bad"})
+
+    @app.get("/_t/log_unhandled")
+    async def _unhandled() -> JSONResponse:
+        # Mimics handle_unhandled: raise an exception whose message carries PII.
+        msg = f"{EMAIL_CANARY} paid ${NUMBER_CANARY}"
+        raise ValueError(msg)
 
     yield app
 
@@ -135,3 +150,37 @@ async def test_error_log_keeps_error_code_but_strips_sensitive_fields(
     assert "VALIDATION_FAILED" in captured  # allowlisted key survives
     assert SENTINEL not in captured  # extracted_value stripped
     assert "ignore me" not in captured  # prompt stripped
+
+
+async def test_unhandled_exception_traceback_pii_is_redacted(
+    test_app: FastAPI,
+) -> None:
+    """Issue #134: rendered exception tracebacks from handle_unhandled must not leak PII."""
+    # raise_app_exceptions=False lets the app's exception-handler chain catch
+    # the ValueError and fire ``handle_unhandled``'s ``logger.exception`` call,
+    # which is what we want to observe here. With the default True, httpx
+    # re-raises the endpoint exception out of the client and the log line is
+    # never emitted.
+    transport = ASGITransport(app=test_app, raise_app_exceptions=False)
+    # Redirect the production-configured handler's stream so the capture goes
+    # through the real ProcessorFormatter (which is what redacts exc_info).
+    # Adding a bare second handler would re-render ``record.exc_info`` via
+    # stdlib's default Formatter and bypass the structlog processor chain
+    # entirely — the capture would show a fake "leak" that production never
+    # produces because production has only one handler.
+    root = logging.getLogger()
+    prod_handler = root.handlers[0]
+    assert isinstance(prod_handler, logging.StreamHandler)
+    original_stream = prod_handler.stream
+    buf = io.StringIO()
+    prod_handler.setStream(buf)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/_t/log_unhandled")
+    finally:
+        prod_handler.setStream(original_stream)
+    captured = buf.getvalue()
+    assert response.status_code == 500
+    assert "unhandled_exception" in captured  # log line was emitted
+    assert EMAIL_CANARY not in captured  # email in ValueError message is redacted
+    assert NUMBER_CANARY not in captured  # numeric amount in message is redacted

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -260,3 +260,36 @@ def test_exception_key_redacts_thousands_separated_amount() -> None:
     out = _call(_filter(), event="unhandled_exception", exception=traceback)
     assert "1,847.50" not in out["exception"]
     assert "1,847" not in out["exception"]
+
+
+@pytest.mark.parametrize(
+    "line_number",
+    ["42", "1234", "9999", "12345"],
+)
+def test_exception_key_preserves_frame_line_numbers(line_number: str) -> None:
+    """Traceback frame line references (``line N``) must survive redaction.
+
+    Large files legitimately produce 4+ digit line numbers; mangling them to
+    ``[REDACTED_NUMBER]`` destroys the file/line locator that operators need
+    to pin incident root causes. The numeric pattern excludes ``line N``
+    specifically via a negative lookbehind.
+    """
+    traceback = (
+        "Traceback (most recent call last):\n"
+        f'  File "app/foo.py", line {line_number}, in handler\n'
+        "ValueError: boom"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert f"line {line_number}" in out["exception"]
+
+
+def test_exception_key_still_redacts_long_numbers_not_after_line_keyword() -> None:
+    """Lookbehind only spares ``line N``; bare long numerics are still scrubbed."""
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        "ValueError: account 987654321 has a balance of 4321.00"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert "987654321" not in out["exception"]
+    assert "4321" not in out["exception"]

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -175,3 +175,54 @@ def test_long_bytes_inside_nested_dict_is_truncated() -> None:
     out = _call(_filter(), event="test", ctx={"blob": b"z" * 600})
     assert out["ctx"]["blob"] != b"z" * 600
     assert "600" in str(out["ctx"]["blob"])
+
+
+def test_exception_key_email_is_redacted() -> None:
+    """Issue #134: rendered exception tracebacks must have email PII scrubbed."""
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        "ValueError: cosmin@example.com paid the fee"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert "cosmin@example.com" not in out["exception"]
+
+
+def test_exception_key_long_numeric_is_redacted() -> None:
+    """Issue #134: rendered exception tracebacks must have numeric PII scrubbed."""
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        "ValueError: invoice total was 1847.50 dollars"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert "1847.50" not in out["exception"]
+    assert "1847" not in out["exception"]
+
+
+def test_exception_key_preserves_traceback_structure() -> None:
+    """Redacted exception strings still retain the traceback header so operators see the shape."""
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        "ValueError: user@example.com did something"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert "Traceback" in out["exception"]
+    assert "ValueError" in out["exception"]
+
+
+def test_exception_key_oversize_string_is_truncated() -> None:
+    """An exception string exceeding max_value_length is still truncated."""
+    long_tb = "Traceback\n" + "x" * 1000
+    out = _call(_filter(), event="unhandled_exception", exception=long_tb)
+    assert out["exception"].endswith("... [truncated]")
+    assert len(out["exception"]) == 500 + len("... [truncated]")
+
+
+def test_non_exception_string_values_not_pattern_scrubbed() -> None:
+    """Regression guard: regex scrubbing must only apply to the 'exception' key."""
+    # A normal log field that happens to contain an email must pass through
+    # unchanged; redaction patterns are only applied to rendered tracebacks.
+    out = _call(_filter(), event="test", message="user@example.com signed in")
+    assert out["message"] == "user@example.com signed in"

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -226,3 +226,37 @@ def test_non_exception_string_values_not_pattern_scrubbed() -> None:
     # unchanged; redaction patterns are only applied to rendered tracebacks.
     out = _call(_filter(), event="test", message="user@example.com signed in")
     assert out["message"] == "user@example.com signed in"
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        'File "app/foo.py", line 1, in <module>',
+        "python3.13",
+        "timeout=0.5",
+        "v1.0.2",
+        "duration=1.25",
+    ],
+)
+def test_exception_key_preserves_short_decimals_and_versions(fragment: str) -> None:
+    """Short decimals (versions, floats, timeouts) in tracebacks must pass through.
+
+    The numeric pattern targets 4+ digit sequences and thousands-separated
+    amounts; version strings like ``python3.13`` and short floats like
+    ``timeout=0.5`` are not PII and mangling them destroys traceback readability.
+    """
+    traceback = f"Traceback (most recent call last):\n  {fragment}\nValueError: boom"
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert fragment in out["exception"]
+
+
+def test_exception_key_redacts_thousands_separated_amount() -> None:
+    """Thousands-separated monetary amounts (e.g. ``1,847.50``) are scrubbed."""
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        "ValueError: invoice total was 1,847.50 dollars"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert "1,847.50" not in out["exception"]
+    assert "1,847" not in out["exception"]

--- a/apps/backend/tests/unit/core/test_logging.py
+++ b/apps/backend/tests/unit/core/test_logging.py
@@ -45,3 +45,19 @@ def test_configure_logging_suppresses_httpcore_to_warning() -> None:
     """httpcore is the transport layer under httpx; same suppression needed."""
     configure_logging(log_level="info", json_output=False)
     assert logging.getLogger("httpcore").level == logging.WARNING
+
+
+def test_format_exc_info_runs_before_redaction_filter() -> None:
+    """Issue #134: format_exc_info must render the traceback into the event dict
+    before the redaction filter runs, so the filter can scrub PII from it.
+    """
+    configure_logging(
+        log_level="info",
+        json_output=True,
+        redacted_keys=["pdf_bytes"],
+        max_value_length=500,
+    )
+    processors = structlog.get_config()["processors"]
+    fmt_idx = next(i for i, p in enumerate(processors) if p is structlog.processors.format_exc_info)
+    redact_idx = next(i for i, p in enumerate(processors) if isinstance(p, LogRedactionFilter))
+    assert fmt_idx < redact_idx


### PR DESCRIPTION
## Summary

- Adds `structlog.processors.format_exc_info` to the shared processor chain before `LogRedactionFilter`, so the filter sees the rendered traceback string and can scrub it before `ProcessorFormatter` renders the event.
- Extends `LogRedactionFilter` with email and long-numeric regex scrubbing on the `exception` key, so PII embedded in upstream `ValueError` messages (emails, monetary amounts, long ids) is redacted before it reaches the log sink.

Closes #134.

## Test plan

- [x] Failing unit test first: email and numeric PII in `exception` string survived previously; now scrubbed.
- [x] Regression guard: regex scrubbing only applies to the `exception` key — normal fields pass through unchanged.
- [x] Integration test drives a real unhandled `ValueError` through the FastAPI exception-handler chain and verifies the captured log never contains the email or numeric canaries.
- [x] `task check` green from the worktree root.