### PR TITLE
fix(compose): bind-mount apps/backend/skills/ in dev for hot-reload

### DIFF
--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - "8000:8000"
     volumes:
       - ../../apps/backend/app:/app/app  # Only mount source, not .venv
+      # Live-mount skill YAMLs so editing a skill does not require an image
+      # rebuild. Read-only because the container never writes to skills/.
+      # Container path matches `Settings.skills_dir`'s default (`/app/skills`
+      # under the Dockerfile's `WORKDIR /app`).
+      - ../../apps/backend/skills:/app/skills:ro
     environment:
       - APP_ENV=development
       - LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- Adds a read-only bind mount of host `apps/backend/skills/` onto container `/app/skills` in the **dev** compose file (`infra/compose/docker-compose.yml`), so editing a skill YAML no longer requires an image rebuild.
- Container path matches the `Settings.skills_dir` default (as documented in prod compose), mounted `:ro` because the container never writes to `skills/`.

Scope: **dev compose only**. The prod compose (`infra/compose/docker-compose.prod.yml`) is intentionally **untouched** — it ships with a commented-placeholder mount from the PR for issue #108 that operators customize per deployment. Conflating those two concerns is out of scope here.

Closes #164.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('infra/compose/docker-compose.yml'))"` parses cleanly
- [x] `git diff origin/main -- infra/compose/docker-compose.prod.yml` is empty (prod untouched)
- [x] `task check` passes locally (unit + integration + contract + error-contract)
- [ ] Manual verification: `docker compose -f infra/compose/docker-compose.yml up --build`, edit a skill YAML on the host, observe the change visible inside the container without rebuild