### PR TITLE
fix(ollama): add format:json and options.temperature:0 to /api/generate payload

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -85,7 +85,21 @@ def build_tags_url(base_url: str) -> str:
 
 
 def _build_payload(model: str, prompt: str) -> dict[str, Any]:
-    return {"model": model, "prompt": prompt, "stream": False}
+    # ``format="json"`` engages Ollama's native JSON-constrained decoding so the
+    # server returns well-formed JSON on the first attempt instead of forcing
+    # ``StructuredOutputValidator`` to re-prompt for parse errors on every
+    # request. ``options={"temperature": 0}`` pins deterministic sampling: same
+    # prompt -> same completion, so any validator retry repeats from a stable
+    # baseline rather than drifting between attempts. The validator still
+    # enforces our downstream schema shape, but it no longer pays the malformed-
+    # output retry cost on the happy path. See issue #136.
+    return {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "format": "json",
+        "options": {"temperature": 0},
+    }
 
 
 @register(r"^gemma", priority=20)

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -232,7 +232,8 @@ async def test_generate_payload_includes_format_json_and_zero_temperature() -> N
 
     _, payload = fake.post_calls[0]
     assert payload["format"] == "json"
-    assert payload["options"] == {"temperature": 0}
+    assert isinstance(payload["options"], dict)
+    assert payload["options"]["temperature"] == 0
 
 
 async def test_generate_strips_trailing_slash_from_base_url() -> None:

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -213,6 +213,28 @@ async def test_generate_sends_model_and_url_from_settings() -> None:
     assert payload["stream"] is False
 
 
+async def test_generate_payload_includes_format_json_and_zero_temperature() -> None:
+    """Regression guard for issue #136.
+
+    The ``/api/generate`` payload must include ``format="json"`` so Ollama
+    constrains output to valid JSON natively (reducing ``StructuredOutputValidator``
+    retries for malformed text) and ``options={"temperature": 0}`` so generations
+    are deterministic (repeatable retries, no drift between attempts). Before the
+    fix, the payload carried only ``model``/``prompt``/``stream``, and every
+    request paid the full formatting cost in validator retries.
+    """
+    fake = _FakeAsyncClient(
+        post_outcomes=[_FakeResponse(body={"response": '{"name":"Alice"}'})],
+    )
+    provider = _build_provider(fake_client=fake)
+
+    await provider.generate("hi", _NAME_STRING_SCHEMA)
+
+    _, payload = fake.post_calls[0]
+    assert payload["format"] == "json"
+    assert payload["options"] == {"temperature": 0}
+
+
 async def test_generate_strips_trailing_slash_from_base_url() -> None:
     fake = _FakeAsyncClient(
         post_outcomes=[_FakeResponse(body={"response": '{"name":"Alice"}'})],


### PR DESCRIPTION
## Summary
- `_build_payload` in `ollama_gemma_provider.py` now sends `format="json"` and `options={"temperature": 0}` alongside the existing `model`/`prompt`/`stream` fields.
- `format="json"` engages Ollama's native JSON-constrained decoding so the server returns well-formed JSON on the first attempt, eliminating most `StructuredOutputValidator` re-prompts for parse errors.
- `options.temperature=0` pins deterministic sampling so validator retries repeat from a stable baseline instead of drifting between attempts.
- The validator still enforces our downstream schema shape; only the malformed-output retry cost on the happy path goes away.

## Test plan
- [x] New failing unit test `test_generate_payload_includes_format_json_and_zero_temperature` pins the payload contract via the `_FakeAsyncClient.post_calls[0][1]` seam.
- [x] Full `tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py` suite (38 tests) green.
- [x] `task check` green from the worktree root.

Closes #136.