### PR TITLE
docs(architecture): align C1-C6 contract descriptions with import-linter-contracts.ini

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,16 +48,16 @@ apps/backend/app/
 
 The extraction feature is built out during feature-dev per the graph tree in
 [`docs/graphs/PDFX/`](graphs/PDFX/). Each Epic maps to one or more subpackages
-inside `features/extraction/`:
+inside `app/features/extraction/`:
 
 | Epic | Files / subpackages | Responsibility |
 |---|---|---|
-| PDFX-E002 | `features/extraction/skills/` | Skill YAML loader, manifest, validation |
-| PDFX-E003 | `features/extraction/parsing/` | Docling wrapper, `TextBlock` abstraction |
-| PDFX-E004 | `features/extraction/intelligence/` + `features/extraction/extraction/` | LangExtract + Ollama provider + structured output validator |
-| PDFX-E005 | `features/extraction/coordinates/` | Offset index, sub-block matcher, span resolver |
-| PDFX-E006 | `features/extraction/schemas/`, `features/extraction/service.py`, `features/extraction/router.py`, `features/extraction/annotation/` | API surface + annotation |
-| PDFX-E007-F001 | `features/extraction/intelligence/ollama_health_probe.py` + `app/api/health_router.py` | Ollama readiness probe wired into `GET /ready` |
+| PDFX-E002 | `app/features/extraction/skills/` | Skill YAML loader, manifest, validation |
+| PDFX-E003 | `app/features/extraction/parsing/` | Docling wrapper, `TextBlock` abstraction |
+| PDFX-E004 | `app/features/extraction/intelligence/` + `app/features/extraction/extraction/` | LangExtract + Ollama provider + structured output validator |
+| PDFX-E005 | `app/features/extraction/coordinates/` | Offset index, sub-block matcher, span resolver |
+| PDFX-E006 | `app/features/extraction/schemas/`, `app/features/extraction/service.py`, `app/features/extraction/router.py`, `app/features/extraction/annotation/` | API surface + annotation |
+| PDFX-E007-F001 | `app/features/extraction/intelligence/ollama_health_probe.py` + `app/api/health_router.py` | Ollama readiness probe wired into `GET /ready` |
 | PDFX-E007-F002 | `app/api/middleware.py` | Request-ID + access-log + CORS middleware stack |
 | PDFX-E007-F003 | `app/core/logging.py` | Structlog pipeline (contextvars, ISO timestamps, JSON/console) |
 | PDFX-E007-F004 | `apps/backend/architecture/import-linter-contracts.ini` + AST-scan tests | Architectural quality gates (C1-C6 + dynamic-import scan) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,14 +50,18 @@ The extraction feature is built out during feature-dev per the graph tree in
 [`docs/graphs/PDFX/`](graphs/PDFX/). Each Epic maps to one or more subpackages
 inside `features/extraction/`:
 
-| Epic | Subpackage | Responsibility |
+| Epic | Files / subpackages | Responsibility |
 |---|---|---|
-| PDFX-E002 | `skills/` | Skill YAML loader, manifest, validation |
-| PDFX-E003 | `parsing/` | Docling wrapper, `TextBlock` abstraction |
-| PDFX-E004 | `intelligence/` + `extraction/` | LangExtract + Ollama provider + structured output validator |
-| PDFX-E005 | `coordinates/` | Offset index, sub-block matcher, span resolver |
-| PDFX-E006 | `schemas/`, `service.py`, `router.py`, `annotation/` | API surface + annotation |
-| PDFX-E007 | `app/api/health_router.py` + `middleware.py` + `import-linter-contracts.ini` | Platform, observability, quality gates |
+| PDFX-E002 | `features/extraction/skills/` | Skill YAML loader, manifest, validation |
+| PDFX-E003 | `features/extraction/parsing/` | Docling wrapper, `TextBlock` abstraction |
+| PDFX-E004 | `features/extraction/intelligence/` + `features/extraction/extraction/` | LangExtract + Ollama provider + structured output validator |
+| PDFX-E005 | `features/extraction/coordinates/` | Offset index, sub-block matcher, span resolver |
+| PDFX-E006 | `features/extraction/schemas/`, `features/extraction/service.py`, `features/extraction/router.py`, `features/extraction/annotation/` | API surface + annotation |
+| PDFX-E007-F001 | `features/extraction/intelligence/ollama_health_probe.py` + `app/api/health_router.py` | Ollama readiness probe wired into `GET /ready` |
+| PDFX-E007-F002 | `app/api/middleware.py` | Request-ID + access-log + CORS middleware stack |
+| PDFX-E007-F003 | `app/core/logging.py` | Structlog pipeline (contextvars, ISO timestamps, JSON/console) |
+| PDFX-E007-F004 | `apps/backend/architecture/import-linter-contracts.ini` + AST-scan tests | Architectural quality gates (C1-C6 + dynamic-import scan) |
+| PDFX-E007-F005 | `apps/backend/scripts/benchmark.py` | Extraction pipeline benchmarking harness |
 
 ### Layer Flow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,11 @@ apps/backend/app/
 ```
 
 The extraction feature is built out during feature-dev per the graph tree in
-[`docs/graphs/PDFX/`](graphs/PDFX/). Each Epic maps to one or more subpackages
-inside `app/features/extraction/`:
+[`docs/graphs/PDFX/`](graphs/PDFX/). Epics E002–E006 each map to one or more
+subpackages inside `app/features/extraction/`. Epic E007 is cross-cutting —
+its sub-features land in supporting locations (`app/api/*`, `app/core/*`,
+`apps/backend/architecture/`, `apps/backend/scripts/`) rather than inside the
+extraction feature. The table below reflects this:
 
 | Epic | Files / subpackages | Responsibility |
 |---|---|---|

--- a/docs/features.md
+++ b/docs/features.md
@@ -85,9 +85,13 @@ contract; PDFX-E007-F004 added C1-C6 and related enforcement:
   and `app/schemas/` cannot import from `app/features/`.
 - `C1` feature independence (placeholder): documents the intent that the
   extraction feature cannot reach into sibling features. Vacuously satisfied
-  today with a single feature module; the real enforcement for dynamic and
-  cross-feature imports is the AST-scan test in
-  [test_dynamic_import_containment.py](../apps/backend/tests/unit/architecture/test_dynamic_import_containment.py).
+  today with a single feature module; related cross-feature import checks
+  live in the AST-scan test
+  [test_dynamic_import_containment.py](../apps/backend/tests/unit/architecture/test_dynamic_import_containment.py),
+  but this placeholder contract does not itself claim dynamic sibling-feature
+  enforcement (its `_collect_dynamic_import_targets()` helper currently returns
+  only the root module of each `importlib.import_module` call, so dynamic
+  sibling-feature imports are not flagged by the C1 check today).
 - `C2a-C2e` intra-feature layer DAG: narrow `forbidden` and `independence`
   contracts that encode the extraction feature's non-linear subpackage DAG
   (leaves independent and non-upward; `extraction` may not import

--- a/docs/features.md
+++ b/docs/features.md
@@ -78,10 +78,43 @@ exception handlers directly.
 ## Backend — Architecture Enforcement
 
 ### Import-Linter Contracts ([apps/backend/architecture/import-linter-contracts.ini](../apps/backend/architecture/import-linter-contracts.ini))
-Post-bootstrap: one contract enforcing that `shared/`, `core/`, and `schemas/`
-cannot import from `features/`. The full extraction-feature layer DAG and
-third-party containment contracts (Docling, PyMuPDF, LangExtract, Ollama client)
-are added by PDFX-E007-F004 during feature-dev.
+The shipped contract set (landed in PDFX-E007-F004):
+
+- `shared-no-features`: `shared/`, `core/`, and `schemas/` cannot import from
+  `features/`.
+- `C1` feature independence (placeholder): documents the intent that the
+  extraction feature cannot reach into sibling features. Vacuously satisfied
+  today with a single feature module; the real enforcement for dynamic and
+  cross-feature imports is the AST-scan test in
+  [test_dynamic_import_containment.py](../apps/backend/tests/unit/architecture/test_dynamic_import_containment.py).
+- `C2a-C2e` intra-feature layer DAG: narrow `forbidden` and `independence`
+  contracts that encode the extraction feature's non-linear subpackage DAG
+  (leaves independent and non-upward; `extraction` may not import
+  `coordinates` or `annotation`; `coordinates` may not import `annotation`,
+  `intelligence`, or `skills`; `schemas` is the base with no sibling
+  imports).
+- `C3` Docling containment: `docling` may only be imported in
+  `features/extraction/parsing/docling_document_parser.py`.
+- `C4` PyMuPDF containment: `pymupdf` and its `fitz` alias may only be
+  imported in `features/extraction/annotation/pdf_annotator.py` and
+  `features/extraction/parsing/docling_document_parser.py` (password-detection
+  preflight).
+- `C5` LangExtract containment: `langextract` may only be imported in
+  `features/extraction/extraction/extraction_engine.py` and
+  `features/extraction/intelligence/ollama_gemma_provider.py` (the community
+  provider plugin entry point).
+- `C6` httpx containment: `httpx` may only be imported in
+  `features/extraction/intelligence/ollama_gemma_provider.py` and
+  `features/extraction/intelligence/ollama_health_probe.py`. The contract is
+  broader than "the Ollama client" — both the provider and the readiness
+  probe build their own `httpx.AsyncClient`, so the containment targets
+  `httpx` itself.
+
+`C3-C6` use `source_modules = app` so the entire backend (including
+`app.api`, `app.core`, etc.) is covered, not just the extraction feature.
+Dynamic imports and cross-feature imports that static analysis cannot see
+are covered by AST-scan tests in
+[test_dynamic_import_containment.py](../apps/backend/tests/unit/architecture/test_dynamic_import_containment.py).
 
 ## Backend — Tests
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -78,10 +78,11 @@ exception handlers directly.
 ## Backend — Architecture Enforcement
 
 ### Import-Linter Contracts ([apps/backend/architecture/import-linter-contracts.ini](../apps/backend/architecture/import-linter-contracts.ini))
-The shipped contract set (landed in PDFX-E007-F004):
+The shipped contract set includes a pre-existing `shared-no-features`
+contract; PDFX-E007-F004 added C1-C6 and related enforcement:
 
-- `shared-no-features`: `shared/`, `core/`, and `schemas/` cannot import from
-  `features/`.
+- `shared-no-features` (predates PDFX-E007-F004): `app/shared/`, `app/core/`,
+  and `app/schemas/` cannot import from `app/features/`.
 - `C1` feature independence (placeholder): documents the intent that the
   extraction feature cannot reach into sibling features. Vacuously satisfied
   today with a single feature module; the real enforcement for dynamic and
@@ -91,24 +92,24 @@ The shipped contract set (landed in PDFX-E007-F004):
   contracts that encode the extraction feature's non-linear subpackage DAG
   (leaves independent and non-upward; `extraction` may not import
   `coordinates` or `annotation`; `coordinates` may not import `annotation`,
-  `intelligence`, or `skills`; `schemas` is the base with no sibling
-  imports).
+  `intelligence`, or `skills`; `app/features/extraction/schemas/` is the
+  base with no sibling imports).
 - `C3` Docling containment: `docling` may only be imported in
-  `features/extraction/parsing/docling_document_parser.py`.
+  `app/features/extraction/parsing/docling_document_parser.py`.
 - `C4` PyMuPDF containment: `pymupdf` and its `fitz` alias may only be
-  imported in `features/extraction/annotation/pdf_annotator.py` and
-  `features/extraction/parsing/docling_document_parser.py` (password-detection
-  preflight).
+  imported in `app/features/extraction/annotation/pdf_annotator.py` and
+  `app/features/extraction/parsing/docling_document_parser.py`
+  (password-detection preflight).
 - `C5` LangExtract containment: `langextract` may only be imported in
-  `features/extraction/extraction/extraction_engine.py` and
-  `features/extraction/intelligence/ollama_gemma_provider.py` (the community
-  provider plugin entry point).
+  `app/features/extraction/extraction/extraction_engine.py` and
+  `app/features/extraction/intelligence/ollama_gemma_provider.py` (the
+  community provider plugin entry point).
 - `C6` httpx containment: `httpx` may only be imported in
-  `features/extraction/intelligence/ollama_gemma_provider.py` and
-  `features/extraction/intelligence/ollama_health_probe.py`. The contract is
-  broader than "the Ollama client" — both the provider and the readiness
-  probe build their own `httpx.AsyncClient`, so the containment targets
-  `httpx` itself.
+  `app/features/extraction/intelligence/ollama_gemma_provider.py` and
+  `app/features/extraction/intelligence/ollama_health_probe.py`. The
+  contract is broader than "the Ollama client" — both the provider and the
+  readiness probe build their own `httpx.AsyncClient`, so the containment
+  targets `httpx` itself.
 
 `C3-C6` use `source_modules = app` so the entire backend (including
 `app.api`, `app.core`, etc.) is covered, not just the extraction feature.


### PR DESCRIPTION
## Summary

- `docs/features.md`: replace the "contracts added during feature-dev" stub with an accurate enumeration of the shipped set — shared-no-features, C1 (placeholder + AST-scan complement), C2a-C2e (intra-feature DAG), C3 Docling, C4 PyMuPDF, C5 LangExtract, C6 httpx.
- Fix the C6 mislabel: it contains `httpx`, not an "Ollama client" abstraction. Both `ollama_gemma_provider.py` and `ollama_health_probe.py` build their own `httpx.AsyncClient`, so the contract targets httpx itself.
- `docs/architecture.md`: widen the epic-to-file table's column header to "Files / subpackages" and split PDFX-E007 into one row per sub-feature (F001 probe, F002 middleware, F003 logging, F004 import-linter, F005 benchmark) so the column semantics hold.

## Test plan

- [x] `task check` passes (lint + types + arch + unit + integration + contract + errors).
- [x] No code changed — scope strictly limited to `docs/features.md` and `docs/architecture.md`.
- [x] No touches to `docs/graphs/PDFX/**`.

Closes #158.