### PR TITLE
docs: label reshape-plan and bootstrap-decisions as historical

### DIFF
--- a/docs/bootstrap-decisions.md
+++ b/docs/bootstrap-decisions.md
@@ -7,7 +7,7 @@ status: complete
 
 # Bootstrap Decisions — PDFX (2026-04-13)
 
-> **Status: Historical** — this document captures the decisions from the 2026-04-13 bootstrap phase
+> **Document status: Historical** — this document captures the decisions from the 2026-04-13 bootstrap phase
 > of the project. It is preserved for context and traceability but is not
 > current operational guidance. For current architecture, see
 > [docs/architecture.md](./architecture.md).

--- a/docs/bootstrap-decisions.md
+++ b/docs/bootstrap-decisions.md
@@ -7,6 +7,11 @@ status: complete
 
 # Bootstrap Decisions — PDFX (2026-04-13)
 
+> **Status: Historical** — this document captures the decisions from the 2026-04-13 bootstrap phase
+> of the project. It is preserved for context and traceability but is not
+> current operational guidance. For current architecture, see
+> [docs/architecture.md](./architecture.md).
+
 Record of the `project-bootstrap` skill run that stripped this repository
 from a full-stack monorepo template into a minimal shell for the PDF Data
 Extraction Microservice (`PDFX`). The strip was driven by the graph tree at

--- a/docs/reshape-plan.md
+++ b/docs/reshape-plan.md
@@ -5,9 +5,11 @@
 > current operational guidance. For current architecture, see
 > [docs/architecture.md](./architecture.md).
 
-> Single source of truth for the template monorepo reshape.
-> Produced in a planning session. No code changes accompany this file.
-> The execution session that follows this plan treats this document as authoritative.
+> Single source of truth for the template monorepo reshape, at the time of
+> the original planning session. No code changes accompany this file. The
+> execution session that followed this plan treated this document as
+> authoritative for that historical reshape effort; it is not authoritative
+> today.
 
 ---
 

--- a/docs/reshape-plan.md
+++ b/docs/reshape-plan.md
@@ -1,5 +1,10 @@
 # Reshape Plan
 
+> **Status: Historical** — this document captures the plan from the template-reshape phase
+> of the project. It is preserved for context and traceability but is not
+> current operational guidance. For current architecture, see
+> [docs/architecture.md](./architecture.md).
+
 > Single source of truth for the template monorepo reshape.
 > Produced in a planning session. No code changes accompany this file.
 > The execution session that follows this plan treats this document as authoritative.


### PR DESCRIPTION
## Summary

- Adds a prominent `> **Status: Historical**` block near the top of `docs/reshape-plan.md` and `docs/bootstrap-decisions.md` so readers know they are preserved records of the template-reshape / bootstrap phase, not current operational guidance.
- Each header links to `docs/architecture.md` as the pointer to current architecture.
- No other content was altered; label-only change.

Closes #161.

## Test plan

- [x] `task check` passes locally (parity run; docs don't affect check)
- [x] Both files still render (H1 unchanged, existing blockquotes preserved below the new status header)