### PR TITLE
docs(coordinates): correct BoundingBox docstring — bottom-left, not PyMuPDF default

### DIFF
--- a/apps/backend/app/features/extraction/parsing/bounding_box.py
+++ b/apps/backend/app/features/extraction/parsing/bounding_box.py
@@ -7,8 +7,18 @@ from dataclasses import dataclass
 class BoundingBox:
     """Rectangle in PDF page coordinates (origin bottom-left).
 
-    Coordinate convention matches PyMuPDF's default so the annotator does not need
-    to transform coordinates downstream.
+    Coordinates use a **bottom-left** origin, measured in PDF user-space
+    points. This matches Docling's ``CoordOrigin.BOTTOMLEFT``, which is the
+    convention our upstream parser normalises every provenance box into
+    before constructing a ``BoundingBox`` (see
+    ``docling_document_parser.py`` — Docling's own default is actually
+    ``CoordOrigin.TOPLEFT`` for most pipeline outputs, which the adapter
+    flips via ``to_bottom_left_origin(page_height=...)``).
+
+    Note that PyMuPDF's native default is **top-left** origin (the y-axis
+    grows downward in ``fitz.Rect``). The annotator therefore converts from
+    this bottom-left contract to PyMuPDF's top-left space at draw time; it
+    does not consume these coordinates unchanged.
     """
 
     x0: float

--- a/apps/backend/app/features/extraction/schemas/bounding_box_ref.py
+++ b/apps/backend/app/features/extraction/schemas/bounding_box_ref.py
@@ -8,12 +8,19 @@ from pydantic import BaseModel, Field, model_validator
 class BoundingBoxRef(BaseModel):
     """A single 1-indexed page coordinate rectangle anchoring an extracted value.
 
-    The rectangle is expressed in PDF page coordinates with origin at the
-    **bottom-left** of the page (PyMuPDF's default), matching the convention
-    locked by PDFX-E003-F001: ``(x0, y0)`` is the bottom-left corner and
-    ``(x1, y1)`` is the top-right, so ``x0 <= x1`` and ``y0 <= y1``. Zero-area
-    rectangles are legal (a degenerate span is still a grounding anchor);
-    inverted rectangles are rejected.
+    The rectangle is expressed in PDF page coordinates (PDF user-space
+    points) with origin at the **bottom-left** of the page, matching
+    Docling's ``CoordOrigin.BOTTOMLEFT`` and the convention locked by
+    PDFX-E003-F001: ``(x0, y0)`` is the bottom-left corner and ``(x1, y1)``
+    is the top-right, so ``x0 <= x1`` and ``y0 <= y1``. Zero-area rectangles
+    are legal (a degenerate span is still a grounding anchor); inverted
+    rectangles are rejected.
+
+    Note that PyMuPDF's native default is **top-left** origin; the
+    annotator converts from this bottom-left contract to PyMuPDF's
+    top-left space at draw time. For the conversion that upstream Docling
+    output (which is often ``CoordOrigin.TOPLEFT``) undergoes before
+    landing in this schema, see ``docling_document_parser.py``.
     """
 
     page: int = Field(ge=1)


### PR DESCRIPTION
## Summary
- `BoundingBox` and `BoundingBoxRef` docstrings claimed bottom-left was "PyMuPDF's default" — PyMuPDF's native default is actually top-left (y grows down in `fitz.Rect`).
- Rewrote both docstrings to truthfully attribute the bottom-left origin to Docling's `CoordOrigin.BOTTOMLEFT` (PDFX-E003-F001), and to note that the annotator converts to PyMuPDF's top-left space at draw time rather than consuming the coordinates unchanged.
- Docstring-only change; no behavior touched. The bottom-left contract itself is already correct (and PR #177 for #133 relies on it).

Closes #160.

## Test plan
- [x] `task check` green (ruff, format, pyright strict, import-linter, unit + integration + contract suites)