### PR TITLE
fix(docker): pin backend Dockerfile base image by SHA digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,3 +71,13 @@ updates:
       github-official-actions:
         patterns:
           - "actions/*"
+
+  # Backend Dockerfile base image is pinned by SHA digest (issue #156);
+  # Dependabot proposes digest bumps weekly so the pin stays current
+  # against upstream python:3.13-slim rebuilds instead of silently
+  # rotting into a stale SHA.
+  - package-ecosystem: "docker"
+    directory: "/infra/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -1,5 +1,6 @@
 # ── Build stage ──────────────────────────────────────────────
-FROM python:3.13-slim AS builder
+# python:3.13-slim (pinned 2026-04-17, https://hub.docker.com/_/python)
+FROM python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664 AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /uvx /bin/
 
@@ -25,7 +26,8 @@ COPY apps/backend/pyproject.toml ./
 RUN uv sync --frozen --no-dev
 
 # ── Runtime stage ────────────────────────────────────────────
-FROM python:3.13-slim
+# python:3.13-slim (pinned 2026-04-17, https://hub.docker.com/_/python)
+FROM python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664
 
 # Run as non-root user
 RUN groupadd --gid 1000 appuser && \

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -1,6 +1,10 @@
 # ── Build stage ──────────────────────────────────────────────
+# Sourced once as an `ARG` so the builder and runtime stages always point at
+# the identical digest. Updating the pin means editing one line.
 # python:3.13-slim (pinned 2026-04-17, https://hub.docker.com/_/python)
-FROM python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664 AS builder
+ARG PYTHON_IMAGE=python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664
+
+FROM ${PYTHON_IMAGE} AS builder
 
 # ghcr.io/astral-sh/uv:0.7.2 (pinned 2026-04-17)
 COPY --from=ghcr.io/astral-sh/uv:0.7.2@sha256:3b898ca84fbe7628c5adcd836c1de78a0f1ded68344d019af8478d4358417399 /uv /uvx /bin/
@@ -27,8 +31,11 @@ COPY apps/backend/pyproject.toml ./
 RUN uv sync --frozen --no-dev
 
 # ── Runtime stage ────────────────────────────────────────────
-# python:3.13-slim (pinned 2026-04-17, https://hub.docker.com/_/python)
-FROM python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664
+# Same `ARG PYTHON_IMAGE` as the builder stage above (declared at the top of
+# the file). Re-declared here so the value is in-scope for this stage — the
+# default expression is unchanged, so the digests stay in lockstep.
+ARG PYTHON_IMAGE
+FROM ${PYTHON_IMAGE}
 
 # Run as non-root user
 RUN groupadd --gid 1000 appuser && \

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -2,7 +2,8 @@
 # python:3.13-slim (pinned 2026-04-17, https://hub.docker.com/_/python)
 FROM python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664 AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /uvx /bin/
+# ghcr.io/astral-sh/uv:0.7.2 (pinned 2026-04-17)
+COPY --from=ghcr.io/astral-sh/uv:0.7.2@sha256:3b898ca84fbe7628c5adcd836c1de78a0f1ded68344d019af8478d4358417399 /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -31,10 +31,9 @@ COPY apps/backend/pyproject.toml ./
 RUN uv sync --frozen --no-dev
 
 # ── Runtime stage ────────────────────────────────────────────
-# Same `ARG PYTHON_IMAGE` as the builder stage above (declared at the top of
-# the file). Re-declared here so the value is in-scope for this stage — the
-# default expression is unchanged, so the digests stay in lockstep.
-ARG PYTHON_IMAGE
+# Reuses the top-level `ARG PYTHON_IMAGE` (declared before any `FROM`), which
+# per the Dockerfile ARG scoping rules is available for substitution in every
+# stage's `FROM` line — keeping builder and runtime pinned to the same digest.
 FROM ${PYTHON_IMAGE}
 
 # Run as non-root user


### PR DESCRIPTION
## Summary

- `infra/docker/backend.Dockerfile` used the floating tag `python:3.13-slim` for both the build and runtime stages, so rebuilds of the same commit drifted whenever the tag was republished upstream on Docker Hub.
- Both `FROM` lines are now pinned by digest so the Dockerfile is content-addressable and rebuilds of the same commit produce identical base layers:
  ```dockerfile
  # python:3.13-slim (pinned 2026-04-17, https://hub.docker.com/_/python)
  FROM python:3.13-slim@sha256:d168b8d9eb761f4d3fe305ebd04aeb7e7f2de0297cec5fb2f8f6403244621664 AS builder
  ```
- Digest resolved on 2026-04-17 against [Docker Hub `library/python`](https://hub.docker.com/_/python) via the Docker Registry v2 API (`HEAD /v2/library/python/manifests/3.13-slim`, `docker-content-digest` response header); the tag + pin date are kept as a comment above each `FROM` so future bumps stay human-readable.

## Test plan

- [x] `task check` (root) — 91 unit + 9 contract + 12 error-contract tests pass; pre-commit hooks pass.
- [ ] Verified the Dockerfile still parses cleanly; `docker build` not exercised in agent sandbox (no Docker CLI available).

Closes #156.