### PR TITLE
ci: pin GitHub Actions to SHAs for supply-chain hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       run:
         working-directory: apps/backend
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: apps/backend/uv.lock
@@ -73,10 +73,10 @@ jobs:
       run:
         working-directory: packages/error-contracts
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/dependabot-lockfile-sync.yml
+++ b/.github/workflows/dependabot-lockfile-sync.yml
@@ -112,7 +112,7 @@ jobs:
           fi
 
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -161,7 +161,7 @@ jobs:
 
       - name: Set up uv
         if: steps.loop_guard.outputs.skip != 'true' && (steps.changed.outputs.needs_uv_backend == 'true' || steps.changed.outputs.needs_uv_error_contracts == 'true')
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
 
       - name: Set up Python
         if: steps.loop_guard.outputs.skip != 'true' && (steps.changed.outputs.needs_uv_backend == 'true' || steps.changed.outputs.needs_uv_error_contracts == 'true')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Build backend Docker image
         run: docker build -f infra/docker/backend.Dockerfile -t pdf-data-extraction-backend:${{ github.sha }} .


### PR DESCRIPTION
## Summary

Pin every third-party action reference in `.github/workflows/` by 40-char commit SHA instead of floating tag, following GitHub's own security hardening guidance for workflows that request `contents: write` / `pull-requests: write` permissions.

Third-party-action tag mutation is a real supply-chain vector: a compromised action maintainer can push a malicious commit to the tag, and every consumer that referenced the tag silently picks up the compromised code on the next run. SHA-pinning makes such a compromise a code-change event that fails review, rather than an invisible runtime event.

The existing semver tag is kept as a trailing comment on each `uses:` line for two reasons:
  1. Dependabot's `github-actions` ecosystem still recognises the pin, rewrites SHA + tag atomically when a new release lands, and the existing Dependabot auto-merge + lockfile-sync chain handles it without human intervention.
  2. Humans can eyeball which version is pinned without dereferencing the SHA through the GitHub UI.

## Refs pinned

| Action | Tag -> resolved version | SHA | Occurrences |
| --- | --- | --- | --- |
| `actions/checkout` | `v6` -> `v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | 4 (ci.yml x2, deploy.yml x1, dependabot-lockfile-sync.yml x1) |
| `astral-sh/setup-uv` | `v7` -> `v7.6.0` | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` | 3 (ci.yml x2, dependabot-lockfile-sync.yml x1) |

**Total: 7 refs converted from floating-tag to SHA-pinned.** None were already SHA-pinned.

`dependabot-automerge.yml` has no third-party `uses:` entries (it invokes `gh pr merge` directly), so nothing to pin there.

## Release notes for review

- [actions/checkout v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)
- [astral-sh/setup-uv v7.6.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.6.0)

Both resolved SHAs verified against `gh api /repos/<owner>/<repo>/commits/<tag>` at PR open time.

## Test plan

- [x] Every edited workflow parses as valid YAML (`python -c "import yaml; yaml.safe_load(open('<path>'))"` -> OK for ci.yml, deploy.yml, dependabot-lockfile-sync.yml, dependabot-automerge.yml).
- [x] No `uses: <owner>/<action>@v<N>` floating-tag refs remain in `.github/workflows/` (verified with ripgrep).
- [x] `task check` passes locally (backend checks, 91 integration + 9 contract tests, error-contracts regeneration no-diff, 12 error-contract tests).
- [ ] CI succeeds on this PR with the new pinned refs -- this is the load-bearing signal that the SHAs resolve to functionally-equivalent action versions.

Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)