### PR TITLE
fix(parsing): iterate Docling text items in reading order (closes #150)

### DIFF
--- a/apps/backend/app/features/extraction/parsing/docling_document_parser.py
+++ b/apps/backend/app/features/extraction/parsing/docling_document_parser.py
@@ -315,6 +315,19 @@ class _RealDoclingDocumentAdapter:
     convention (origin bottom-left, `y0 <= y1`) and matches PyMuPDF, which
     the annotator uses downstream without further transformation. (GH issue
     #133.)
+
+    Reading order (GH issue #150): the traversal delegates to Docling's
+    public `DoclingDocument.iterate_items()` API, which walks the document
+    hierarchy in visual READING order (top-to-bottom, left-to-right per
+    page, respecting column and table structure). Iterating `.texts`
+    directly — as an earlier revision did — returns items in Docling's
+    implementation-dependent STORAGE order, which on multi-column / table-
+    heavy layouts interleaves columns incorrectly and causes downstream
+    span-resolution failures (LangExtract reports `hallucinated_offsets`
+    for values that are in fact present in the source PDF). The fallback
+    to `.texts` is retained only for documents whose shape predates
+    `iterate_items()` (e.g., minimal test doubles in other features' fakes);
+    real Docling-produced documents always expose `iterate_items()`.
     """
 
     def __init__(self, docling_document: Any) -> None:
@@ -326,9 +339,8 @@ class _RealDoclingDocumentAdapter:
         return len(pages)
 
     def iter_text_items(self) -> Iterable[_DoclingTextItemLike]:
-        texts: Any = getattr(self._docling_document, "texts", None) or []
         pages: Any = getattr(self._docling_document, "pages", None) or {}
-        for text_item in texts:
+        for text_item in self._iter_reading_order():
             item: Any = text_item
             text_value: Any = getattr(item, "text", None)
             provs: Any = getattr(item, "prov", None) or []
@@ -361,6 +373,34 @@ class _RealDoclingDocumentAdapter:
                 bbox_x1=float(bbox.r),
                 bbox_y1=float(bbox.t),
             )
+
+    def _iter_reading_order(self) -> Iterable[Any]:
+        """Yield every Docling node item in visual reading order.
+
+        Uses `DoclingDocument.iterate_items()` when available — this is
+        Docling's public reading-order traversal API (Docling >= 2.x) and
+        yields `(item, level)` tuples for every node in the document tree,
+        in top-to-bottom / left-to-right / per-column visual order. The
+        caller filters down to text-bearing items by testing `.text` and
+        `.prov` attributes, so non-text nodes (tables, pictures) are
+        ignored without a type check against Docling's own class hierarchy
+        — preserving this file's containment of Docling's public types.
+
+        When `iterate_items()` is not available (legacy documents or test
+        doubles that predate this API), the adapter falls back to iterating
+        `.texts` directly, which is Docling's internal storage order. That
+        fallback is imperfect on multi-column layouts but keeps the adapter
+        robust against shape drift. Real Docling-produced documents always
+        expose `iterate_items()`.
+        """
+        iterate_items: Any = getattr(self._docling_document, "iterate_items", None)
+        if callable(iterate_items):
+            iterator: Any = iterate_items()
+            for pair in iterator:
+                item: Any = pair[0]
+                yield item
+            return
+        yield from getattr(self._docling_document, "texts", None) or []
 
 
 @dataclass(frozen=True)

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -778,11 +778,25 @@ class _FakeDoclingPageItem:
 @dataclass
 class _FakeRawDoclingDocument:
     """Fake shape matching what `_RealDoclingDocumentAdapter` reads from a live
-    DoclingDocument: `.texts` (list of text nodes) and `.pages` (dict keyed by
-    page_no to a PageItem carrying `.size.height`)."""
+    DoclingDocument: `.texts` (list of text nodes in STORAGE order), `.pages`
+    (dict keyed by page_no to a PageItem carrying `.size.height`), and
+    `iterate_items()` which yields `(item, level)` tuples in READING order
+    (top-to-bottom, left-to-right, across page breaks) — see Docling 2.88's
+    `DoclingDocument.iterate_items` API.
+
+    The default `iterate_items` implementation simply yields the `.texts` in
+    order (identity between storage and reading order). Tests that need to
+    exercise the reading-order path set `iterate_order` explicitly to a
+    permutation of `.texts` that differs from storage order.
+    """
 
     texts: list[_FakeDoclingTextNode]
     pages: dict[int, _FakeDoclingPageItem]
+    iterate_order: list[_FakeDoclingTextNode] | None = None
+
+    def iterate_items(self) -> list[tuple[_FakeDoclingTextNode, int]]:
+        order = self.iterate_order if self.iterate_order is not None else self.texts
+        return [(node, 0) for node in order]
 
 
 def test_adapter_normalizes_top_left_origin_bbox_to_bottom_left() -> None:
@@ -942,3 +956,168 @@ def test_adapter_raises_key_error_when_prov_page_no_missing_from_pages() -> None
     with pytest.raises(KeyError) as excinfo:
         list(adapter.iter_text_items())
     assert "7" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Reading-order traversal in _RealDoclingDocumentAdapter
+# (regression for GH issue #150)
+#
+# Docling's `document.texts` is an implementation-dependent STORAGE order that
+# does not match the visual READING order on multi-column / table-heavy
+# layouts. If the adapter iterates `.texts` directly, LangExtract receives a
+# concatenated text where columns interleave incorrectly and the span resolver
+# reports spurious `hallucinated_offsets` for values that are in fact present.
+#
+# The adapter must delegate to `DoclingDocument.iterate_items()`, the public
+# API that walks the document hierarchy in reading order (top-to-bottom,
+# left-to-right per page, respecting column / table structure).
+# ---------------------------------------------------------------------------
+
+
+def _bbox_bottom_left(*, left: float, bottom: float, right: float, top: float) -> _FakeDoclingBBox:
+    """Helper: build a BOTTOMLEFT-origin fake bbox with `y0 = bottom <= y1 = top`."""
+    return _FakeDoclingBBox(
+        left=left,
+        top=top,
+        right=right,
+        bottom=bottom,
+        coord_origin="BOTTOMLEFT",
+    )
+
+
+def test_iter_text_items_returns_reading_order_for_multi_column_layout() -> None:
+    """Issue #150: multi-column pages must emerge in reading order, not storage order.
+
+    Simulate a two-column page where Docling's `.texts` storage lists all of
+    column A first ("A-top", "A-bottom"), then all of column B ("B-top",
+    "B-bottom"). The visual reading order (which `iterate_items()` is
+    contracted to produce) interleaves them: A-top, B-top, A-bottom,
+    B-bottom. The adapter must yield the items in that reading order.
+
+    Before the fix, the adapter walked `.texts` and produced storage order
+    (A-top, A-bottom, B-top, B-bottom), which downstream `TextConcatenator`
+    concatenates into a text blob where LangExtract cannot match cross-
+    column values.
+    """
+    page = _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0, width=600.0))
+    a_top = _FakeDoclingTextNode(
+        text="A-top",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=50.0, bottom=900.0, right=250.0, top=950.0),
+            ),
+        ],
+    )
+    a_bottom = _FakeDoclingTextNode(
+        text="A-bottom",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=50.0, bottom=500.0, right=250.0, top=550.0),
+            ),
+        ],
+    )
+    b_top = _FakeDoclingTextNode(
+        text="B-top",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=350.0, bottom=900.0, right=550.0, top=950.0),
+            ),
+        ],
+    )
+    b_bottom = _FakeDoclingTextNode(
+        text="B-bottom",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=350.0, bottom=500.0, right=550.0, top=550.0),
+            ),
+        ],
+    )
+    raw_doc = _FakeRawDoclingDocument(
+        # `.texts` carries STORAGE order (column A first, then column B).
+        texts=[a_top, a_bottom, b_top, b_bottom],
+        pages={1: page},
+        # `iterate_items()` carries READING order (interleaved across columns).
+        iterate_order=[a_top, b_top, a_bottom, b_bottom],
+    )
+    adapter = _RealDoclingDocumentAdapter(raw_doc)
+
+    items = list(adapter.iter_text_items())
+
+    assert [item.text for item in items] == ["A-top", "B-top", "A-bottom", "B-bottom"]
+
+
+def test_iter_text_items_uses_iterate_items_and_ignores_texts_order() -> None:
+    """Adapter contract: if `iterate_items()` is present, `.texts` is unused for ordering.
+
+    This pins the implementation to the reading-order API. Placing `.texts`
+    in a deliberately different order from `iterate_items()` ensures a
+    regression that reverts to the old `.texts` walk fails this test.
+    """
+    node_one = _FakeDoclingTextNode(
+        text="first-in-reading-order",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=10.0, bottom=800.0, right=100.0, top=820.0),
+            ),
+        ],
+    )
+    node_two = _FakeDoclingTextNode(
+        text="second-in-reading-order",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=10.0, bottom=700.0, right=100.0, top=720.0),
+            ),
+        ],
+    )
+    raw_doc = _FakeRawDoclingDocument(
+        # Reverse storage order — if the adapter reads this, the assertion fails.
+        texts=[node_two, node_one],
+        pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
+        iterate_order=[node_one, node_two],
+    )
+    adapter = _RealDoclingDocumentAdapter(raw_doc)
+
+    items = list(adapter.iter_text_items())
+
+    assert [item.text for item in items] == [
+        "first-in-reading-order",
+        "second-in-reading-order",
+    ]
+
+
+def test_iter_text_items_falls_back_to_texts_when_iterate_items_missing() -> None:
+    """Graceful fallback: if a DoclingDocument lacks `iterate_items` (older
+    Docling build or a test double without the method), the adapter must
+    still produce something rather than crash. Storage order is the only
+    available signal in that case, so it is acceptable as a fallback.
+    """
+
+    @dataclass
+    class _LegacyDoclingDocument:
+        texts: list[_FakeDoclingTextNode]
+        pages: dict[int, _FakeDoclingPageItem]
+
+    node = _FakeDoclingTextNode(
+        text="legacy",
+        prov=[
+            _FakeDoclingProv(
+                page_no=1,
+                bbox=_bbox_bottom_left(left=10.0, bottom=700.0, right=100.0, top=720.0),
+            ),
+        ],
+    )
+    raw_doc = _LegacyDoclingDocument(
+        texts=[node],
+        pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
+    )
+    adapter = _RealDoclingDocumentAdapter(raw_doc)
+
+    items = list(adapter.iter_text_items())
+
+    assert [item.text for item in items] == ["legacy"]


### PR DESCRIPTION
## Summary

- `_RealDoclingDocumentAdapter` now delegates traversal to Docling's public `DoclingDocument.iterate_items()` API so text items emerge in visual reading order (top-to-bottom / left-to-right / per column), instead of the implementation-dependent `document.texts` storage order.
- `.texts` is retained as a fallback for test doubles that predate `iterate_items()`; real Docling-produced documents always expose the reading-order API.
- Three new unit tests pin the behaviour: reading-order interleaving on a simulated two-column page, storage-order-ignored guard, and the legacy fallback path.

## Why

`TextConcatenator` concatenates `ParsedDocument.blocks` in the order the adapter yields them. On multi-column and table-heavy layouts, Docling's storage order does not match the visual reading order, so LangExtract received a concatenated blob where column A and column B text interleaved incorrectly. The span resolver then reported spurious `hallucinated_offsets` for values that were in fact present on the page (issue #150).

## Option picked

**Option B** (the preferred option in the issue body): use Docling's built-in reading-order traversal via `DoclingDocument.iterate_items()`. The Docling 2.88 docs explicitly document this method as "Iterate the elements in reading order, including hierarchy level." Option A (sort by `(page_number, -bbox_y1, bbox_x0)`) would also close the worst case but reintroduces a heuristic the library already implements correctly. Option B is strictly better and stays inside this repo's Docling containment (`docling_document_parser.py` is still the only file that touches Docling APIs — PDFX-E003-F002 technical constraint).

## Scope discipline

- Narrow change: only `iter_text_items` now consults `iterate_items()`; the Protocol shape, the caller (`_to_parsed_document`), and `TextConcatenator` are untouched.
- No behavioural change for non-text items (tables, pictures) — the existing `text`/`prov` filter naturally excludes them.
- No new dependencies; no new top-level folders; no error-code additions.

## Test plan

- [x] `task check` passes locally (lint, import-linter, ruff format, pyright strict, unit + integration + contract tests, error-contracts drift check)
- [x] New unit test `test_iter_text_items_returns_reading_order_for_multi_column_layout` fails against the old `.texts` walk and passes against the new `iterate_items()` path
- [x] Docling-containment AST scan (`test_only_docling_document_parser_references_docling`) still passes — no new files import Docling
- [x] All existing adapter tests (coordinate origin normalisation, KeyError on missing page, etc.) still pass
- [ ] Integration test against a real multi-column PDF fixture — deferred; no suitable fixture exists in `apps/backend/tests/fixtures/pdfs/` and the prompt explicitly said not to invent one. Worth a follow-up to add a two-column fixture and a slow-marked end-to-end assertion.

Closes #150.