### PR TITLE
fix(api): reject oversized uploads at ASGI layer (closes #112)

### DIFF
--- a/apps/backend/app/api/middleware.py
+++ b/apps/backend/app/api/middleware.py
@@ -1,8 +1,9 @@
 """Middleware wiring — assembles the full middleware stack onto the FastAPI app.
 
 Individual middleware classes live one-per-file in this package
-(`request_id_middleware.py`, `access_log_middleware.py`) per CLAUDE.md's
-"one class per file" rule. This module only owns the stack assembly order.
+(`request_id_middleware.py`, `access_log_middleware.py`,
+`upload_size_limit_middleware.py`) per CLAUDE.md's "one class per file" rule.
+This module only owns the stack assembly order.
 
 Registration order vs. execution order
 --------------------------------------
@@ -11,13 +12,27 @@ so the order of ``add_middleware`` calls in :func:`configure_middleware` is
 the **reverse** of the runtime execution order. The desired execution order
 (outermost first) is::
 
-    CORS -> RequestId -> AccessLog -> route handler
+    CORS -> RequestId -> AccessLog -> UploadSizeLimit -> route handler
 
 which means the calls in :func:`configure_middleware` must be registered in
-the opposite sequence (``AccessLog`` first, ``CORS`` last). Do not reorder
-those calls without also flipping this expectation — getting it wrong silently
-changes which middleware sees the request first and breaks CORS preflight,
-request-id propagation, and access-log correlation.
+the opposite sequence (``UploadSizeLimit`` first, ``CORS`` last). Do not
+reorder those calls without also flipping this expectation — getting it
+wrong silently changes which middleware sees the request first and breaks
+CORS preflight, request-id propagation, access-log correlation, or the
+upload-size guard's ability to read the request id set by RequestId.
+
+UploadSizeLimit placement rationale (issue #112)
+------------------------------------------------
+The upload-size guard runs innermost (just before route dispatch) because:
+
+* It needs the request id from ``RequestIdMiddleware`` in its rejection
+  envelope, so RequestId must wrap it (RequestId registers AFTER and runs
+  outside at runtime).
+* Its rejection must be surfaced in the access log like any other response,
+  so AccessLog must wrap it (AccessLog registers AFTER and runs outside).
+* It must run BEFORE FastAPI's route dispatch — which is when Starlette's
+  multipart parser would otherwise spool the upload. Registering this
+  middleware first (innermost) is what delivers that guarantee.
 """
 
 from fastapi import FastAPI
@@ -25,22 +40,43 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.access_log_middleware import AccessLogMiddleware
 from app.api.request_id_middleware import RequestIdMiddleware
+from app.api.upload_size_limit_middleware import UploadSizeLimitMiddleware
+
+# The set of POST paths whose request body is a PDF upload. Keep this
+# co-located with the middleware wiring (rather than in the router) because
+# ``configure_middleware`` is the only place that needs it — the router
+# continues to rely on its own ``read_with_byte_limit`` for
+# defense-in-depth. When a second upload route is added, extend this
+# tuple here; the middleware accepts any number of paths.
+_GUARDED_UPLOAD_PATHS: tuple[str, ...] = ("/api/v1/extract",)
 
 
-def configure_middleware(app: FastAPI, cors_origins: list[str]) -> None:
+def configure_middleware(
+    app: FastAPI,
+    cors_origins: list[str],
+    *,
+    max_upload_bytes: int,
+) -> None:
     """Attach all middleware to the FastAPI app.
 
     Execution order (outermost first), once Starlette has built the stack::
 
-        1. CORS         (handles preflight before anything else)
-        2. RequestId    (sets request_id for all downstream middleware and handlers)
-        3. AccessLog    (logs after response is generated, reads request_id from contextvars)
+        1. CORS             (handles preflight before anything else)
+        2. RequestId        (sets request_id for all downstream middleware)
+        3. AccessLog        (logs after response, reads request_id from contextvars)
+        4. UploadSizeLimit  (rejects oversized uploads before route dispatch)
 
     The ``add_middleware`` calls below appear in the **reverse** of that
     execution order because Starlette/FastAPI prepends each newly added
     middleware to the front of the stack. See the module docstring for why
-    flipping these calls breaks CORS preflight and request-id propagation.
+    flipping these calls breaks CORS preflight, request-id propagation,
+    or the upload-size guard (issue #112).
     """
+    app.add_middleware(
+        UploadSizeLimitMiddleware,
+        max_bytes=max_upload_bytes,
+        guarded_paths=_GUARDED_UPLOAD_PATHS,
+    )
     app.add_middleware(AccessLogMiddleware)
     app.add_middleware(RequestIdMiddleware)
     app.add_middleware(

--- a/apps/backend/app/api/middleware.py
+++ b/apps/backend/app/api/middleware.py
@@ -46,9 +46,15 @@ from app.api.upload_size_limit_middleware import UploadSizeLimitMiddleware
 # co-located with the middleware wiring (rather than in the router) because
 # ``configure_middleware`` is the only place that needs it — the router
 # continues to rely on its own ``read_with_byte_limit`` for
-# defense-in-depth. When a second upload route is added, extend this
-# tuple here; the middleware accepts any number of paths.
-_GUARDED_UPLOAD_PATHS: tuple[str, ...] = ("/api/v1/extract",)
+# defense-in-depth. Both the canonical path and its trailing-slash variant
+# are listed so the guard survives FastAPI's default redirect_slashes
+# behavior (a ``/api/v1/extract/`` request would otherwise bypass the
+# ASGI guard and fall through to the slower in-handler limit). Extend
+# this tuple when a second upload route is added.
+_GUARDED_UPLOAD_PATHS: tuple[str, ...] = (
+    "/api/v1/extract",
+    "/api/v1/extract/",
+)
 
 
 def configure_middleware(

--- a/apps/backend/app/api/middleware.py
+++ b/apps/backend/app/api/middleware.py
@@ -56,6 +56,17 @@ _GUARDED_UPLOAD_PATHS: tuple[str, ...] = (
     "/api/v1/extract/",
 )
 
+# Generous allowance added on top of the PDF-bytes limit so the ASGI guard
+# does not reject a legitimate max-sized PDF whose multipart envelope
+# (boundary markers, Content-Disposition headers on every form field,
+# Content-Type headers) naturally pushes Content-Length a little past
+# ``Settings.max_pdf_bytes``. 64 KiB is an order of magnitude larger than
+# the actual multipart overhead (~1-2 KiB for the current fields) so the
+# check stays permissive at the ASGI layer; the authoritative PDF-bytes
+# check is still ``read_with_byte_limit`` inside the route handler. See
+# ``app/features/extraction/router.py`` and issue #112.
+_MULTIPART_OVERHEAD_ALLOWANCE_BYTES: int = 64 * 1024
+
 
 def configure_middleware(
     app: FastAPI,
@@ -80,7 +91,8 @@ def configure_middleware(
     """
     app.add_middleware(
         UploadSizeLimitMiddleware,
-        max_bytes=max_upload_bytes,
+        max_bytes=max_upload_bytes + _MULTIPART_OVERHEAD_ALLOWANCE_BYTES,
+        reported_limit=max_upload_bytes,
         guarded_paths=_GUARDED_UPLOAD_PATHS,
     )
     app.add_middleware(AccessLogMiddleware)

--- a/apps/backend/app/api/upload_size_limit_middleware.py
+++ b/apps/backend/app/api/upload_size_limit_middleware.py
@@ -36,6 +36,7 @@ handler's chunked-read guard still caps the damage.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
+from uuid import uuid4
 
 import structlog
 from starlette.responses import JSONResponse
@@ -49,10 +50,12 @@ if TYPE_CHECKING:
 
 _logger = structlog.get_logger(__name__)
 
-# Sentinel used when Content-Length is missing or malformed. Chosen as a very
-# large int so the rejection-reporting path has a numeric value to include
-# in ``params.actual_bytes`` without leaking anything about the underlying
-# body (we have not read the body).
+# Sentinel used when Content-Length is missing, malformed, or ambiguous
+# (e.g. chunked transfer-encoding or duplicate Content-Length headers). The
+# negative value communicates "unknown body size" to the rejection-reporting
+# path so ``params.actual_bytes`` stays numeric without implying we read or
+# measured the body. Clients should treat ``-1`` as "unknown", not as a real
+# byte count.
 _UNKNOWN_CONTENT_LENGTH = -1
 
 
@@ -97,6 +100,16 @@ class UploadSizeLimitMiddleware:
             await self._app(scope, receive, send)
             return
 
+        # Chunked requests advertise body size indirectly through
+        # Transfer-Encoding rather than Content-Length. Even if Content-Length
+        # is also present, RFC 9110 §8.6 says Transfer-Encoding wins — so a
+        # caller who sends both headers could bypass a pure CL-based guard.
+        # Fail closed on either: chunked transfer-encoding OR duplicate
+        # Content-Length headers get rejected with the unknown sentinel.
+        if _has_chunked_transfer_encoding(scope):
+            await self._reject(scope, send, actual_bytes=_UNKNOWN_CONTENT_LENGTH)
+            return
+
         content_length = _parse_content_length(scope)
         if content_length is None:
             await self._reject(scope, send, actual_bytes=_UNKNOWN_CONTENT_LENGTH)
@@ -129,14 +142,12 @@ class UploadSizeLimitMiddleware:
         ``PdfTooLargeError`` raised from the handler, so callers see an
         identical response regardless of which layer rejected them.
 
-        When ``RequestIdMiddleware`` has already run (i.e. it is registered
-        outside this one in ``configure_middleware``), ``scope["state"]``
-        carries the generated 32-char hex request id and we reuse it so the
-        ``X-Request-Id`` header and the ``error.request_id`` field stay
-        consistent. When it has not run (e.g. in unit tests that mount this
-        middleware directly on a bare FastAPI app without RequestId), we
-        omit the header and set the body field to ``None`` — the caller
-        still gets a well-formed envelope, just without the correlation id.
+        ``_get_request_id`` guarantees a 32-char hex string — either the
+        one set by ``RequestIdMiddleware`` (when it ran upstream) or a
+        fresh ``uuid4().hex`` fallback when this middleware is mounted
+        directly (e.g. unit tests). Either way the envelope and
+        ``X-Request-Id`` header always carry a valid correlation id,
+        matching the fallback in ``app.api.errors._get_request_id``.
         """
         err = PdfTooLargeError(max_bytes=self._max_bytes, actual_bytes=actual_bytes)
         request_id = _get_request_id(scope)
@@ -158,14 +169,10 @@ class UploadSizeLimitMiddleware:
             },
         }
 
-        headers: dict[str, str] = {}
-        if request_id is not None:
-            headers["X-Request-Id"] = request_id
-
         response = JSONResponse(
             status_code=err.http_status,
             content=content,
-            headers=headers,
+            headers={"X-Request-Id": request_id},
         )
         # JSONResponse is itself an ASGI app; calling it with a no-op
         # receive is safe because it never reads the request body.
@@ -173,54 +180,81 @@ class UploadSizeLimitMiddleware:
 
 
 async def _empty_receive() -> Message:
-    """No-op ``receive`` for the early-response path.
+    """Terminal ``receive`` callable for the early-response path.
 
-    ``Response.__call__`` does not consume the request body, but the ASGI
-    signature requires a callable; this never-returning stub satisfies the
-    type without ever being awaited in practice.
+    ``Response.__call__`` does not normally consume the request body here,
+    but the ASGI signature still requires a ``receive`` callable. Return a
+    terminal empty ``http.request`` message rather than ``http.disconnect``
+    so any consumer reading the body sees "no more data" instead of an
+    unexpected disconnect, which some frameworks treat as a client abort.
     """
-    return {"type": "http.disconnect"}
+    return {"type": "http.request", "body": b"", "more_body": False}
 
 
-def _parse_content_length(scope: Scope) -> int | None:
-    """Return the integer ``Content-Length`` header, or None if missing/malformed.
+def _has_chunked_transfer_encoding(scope: Scope) -> bool:
+    """Return True iff any ``Transfer-Encoding`` header contains ``chunked``.
 
-    ASGI spec: ``scope["headers"]`` is a list of ``(bytes, bytes)`` pairs
-    with lowercase header names. Returning ``None`` for both the missing
-    and malformed cases lets the caller apply a single fail-closed policy.
-    Negative values are also treated as missing — a negative Content-Length
-    is not meaningful and should not be admitted.
+    Per RFC 9110 §8.6, ``Transfer-Encoding`` takes precedence over
+    ``Content-Length`` when both are present: a request can set
+    ``Content-Length: 100`` plus ``Transfer-Encoding: chunked`` and the
+    server MUST use chunked framing, meaning the CL value is not a
+    trustworthy size bound. Reject the request outright so the guard
+    cannot be bypassed by header combination.
     """
     raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
     for name, value in raw_headers:
-        if name == b"content-length":
-            try:
-                parsed = int(value.decode("latin-1"))
-            except (ValueError, UnicodeDecodeError):
-                return None
-            if parsed < 0:
-                return None
-            return parsed
-    return None
+        if name != b"transfer-encoding":
+            continue
+        # Transfer-Encoding is a comma-separated list of codings; ``chunked``
+        # may appear alongside ``gzip`` etc. A case-insensitive substring
+        # match on ``chunked`` is the safe conservative check.
+        if b"chunked" in value.lower():
+            return True
+    return False
 
 
-def _get_request_id(scope: Scope) -> str | None:
-    """Return the 32-char hex request id set by ``RequestIdMiddleware``, or None.
+def _parse_content_length(scope: Scope) -> int | None:
+    """Return the integer ``Content-Length`` header, or None on any ambiguity.
 
-    ``RequestIdMiddleware`` assigns ``request.state.request_id``, which
-    Starlette backs with ``scope["state"]``. When this middleware runs
-    outside a stack that includes ``RequestIdMiddleware`` (e.g. a direct
-    unit-test mount), ``scope["state"]`` is absent and we return ``None``
-    — the error envelope then reports ``request_id: null``.
+    Returns ``None`` when:
+    - the header is absent;
+    - the value is malformed (non-numeric, negative);
+    - multiple ``Content-Length`` headers are present (RFC 9110 requires
+      the server to reject ambiguous framing; returning None here makes the
+      caller's fail-closed policy apply).
+
+    ASGI spec: ``scope["headers"]`` is a list of ``(bytes, bytes)`` pairs
+    with lowercase header names.
+    """
+    raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+    cl_values: list[bytes] = [value for name, value in raw_headers if name == b"content-length"]
+    if len(cl_values) != 1:
+        return None
+    try:
+        parsed = int(cl_values[0].decode("latin-1"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _get_request_id(scope: Scope) -> str:
+    """Return the 32-char hex request id set by ``RequestIdMiddleware``.
+
+    Falls back to a fresh ``uuid4().hex`` when the middleware is absent so
+    the ``X-Request-Id`` header and the ``error.request_id`` field always
+    carry a valid 32-char hex string — matching the fallback in
+    ``app.api.errors._get_request_id`` so every rejection layer produces the
+    same envelope / header contract.
     """
     # ``scope["state"]`` is ``dict[str, Any]`` in the ASGI spec, but pyright
     # strict narrows it to ``dict[Unknown, Unknown]`` after isinstance, so we
     # re-type explicitly with ``cast`` before indexing.
     state_obj = scope.get("state")
-    if not isinstance(state_obj, dict):
-        return None
-    state = cast("dict[str, object]", state_obj)
-    request_id = state.get("request_id")
-    if isinstance(request_id, str):
-        return request_id
-    return None
+    if isinstance(state_obj, dict):
+        state = cast("dict[str, object]", state_obj)
+        request_id = state.get("request_id")
+        if isinstance(request_id, str):
+            return request_id
+    return uuid4().hex

--- a/apps/backend/app/api/upload_size_limit_middleware.py
+++ b/apps/backend/app/api/upload_size_limit_middleware.py
@@ -107,15 +107,30 @@ class UploadSizeLimitMiddleware:
         # Fail closed on either: chunked transfer-encoding OR duplicate
         # Content-Length headers get rejected with the unknown sentinel.
         if _has_chunked_transfer_encoding(scope):
-            await self._reject(scope, send, actual_bytes=_UNKNOWN_CONTENT_LENGTH)
+            await self._reject(
+                scope,
+                send,
+                actual_bytes=_UNKNOWN_CONTENT_LENGTH,
+                reason="chunked_transfer_encoding",
+            )
             return
 
         content_length = _parse_content_length(scope)
         if content_length is None:
-            await self._reject(scope, send, actual_bytes=_UNKNOWN_CONTENT_LENGTH)
+            await self._reject(
+                scope,
+                send,
+                actual_bytes=_UNKNOWN_CONTENT_LENGTH,
+                reason="missing_or_ambiguous_content_length",
+            )
             return
         if content_length > self._max_bytes:
-            await self._reject(scope, send, actual_bytes=content_length)
+            await self._reject(
+                scope,
+                send,
+                actual_bytes=content_length,
+                reason="content_length_exceeds_max",
+            )
             return
 
         await self._app(scope, receive, send)
@@ -134,13 +149,27 @@ class UploadSizeLimitMiddleware:
             return False
         return scope.get("path") in self._guarded_paths
 
-    async def _reject(self, scope: Scope, send: Send, *, actual_bytes: int) -> None:
+    async def _reject(
+        self,
+        scope: Scope,
+        send: Send,
+        *,
+        actual_bytes: int,
+        reason: str,
+    ) -> None:
         """Emit the ``PDF_TOO_LARGE`` error envelope at the ASGI layer.
 
         The envelope shape matches what
         ``app.api.errors.register_exception_handlers`` produces for a
         ``PdfTooLargeError`` raised from the handler, so callers see an
         identical response regardless of which layer rejected them.
+
+        ``reason`` is a structured log field (``chunked_transfer_encoding``,
+        ``missing_or_ambiguous_content_length``, ``content_length_exceeds_max``)
+        that dashboards / alerts can split on. The log event itself stays
+        generic (``upload_rejected``) — the previous ``upload_rejected_oversized``
+        name was misleading for the chunked / missing-CL paths where the
+        body is unknown-sized, not confirmed-oversized.
 
         ``_get_request_id`` guarantees a 32-char hex string — either the
         one set by ``RequestIdMiddleware`` (when it ran upstream) or a
@@ -153,8 +182,9 @@ class UploadSizeLimitMiddleware:
         request_id = _get_request_id(scope)
 
         _logger.warning(
-            "upload_rejected_oversized",
+            "upload_rejected",
             path=scope.get("path"),
+            reason=reason,
             max_bytes=self._max_bytes,
             actual_bytes=actual_bytes,
             request_id=request_id,

--- a/apps/backend/app/api/upload_size_limit_middleware.py
+++ b/apps/backend/app/api/upload_size_limit_middleware.py
@@ -67,9 +67,20 @@ class UploadSizeLimitMiddleware:
     app:
         The downstream ASGI application this middleware wraps.
     max_bytes:
-        Maximum allowed ``Content-Length`` (strict greater-than check; an
-        upload of exactly ``max_bytes`` is accepted). Must be positive to
-        match ``Settings.max_pdf_bytes`` which is ``Field(gt=0)``.
+        ASGI-layer rejection threshold — a request whose ``Content-Length``
+        strictly exceeds this value is rejected before the body is parsed.
+        Typically the authoritative PDF-byte limit plus a generous
+        multipart overhead allowance, so a legitimate PDF of exactly
+        ``Settings.max_pdf_bytes`` is not rejected because its multipart
+        envelope (boundary markers, Content-Disposition headers, form
+        fields) bumps the body size slightly past the PDF byte count.
+        Must be positive.
+    reported_limit:
+        The ``max_bytes`` value advertised in the ``PDF_TOO_LARGE``
+        rejection envelope. Defaults to ``max_bytes`` when not supplied.
+        Production wiring passes the authoritative ``Settings.max_pdf_bytes``
+        here so clients see the real PDF limit, not the inflated ASGI
+        threshold. Must be positive.
     guarded_paths:
         Iterable of exact request paths on which ``POST`` requests are
         subject to the size check. A tuple of paths (rather than a single
@@ -84,12 +95,17 @@ class UploadSizeLimitMiddleware:
         *,
         max_bytes: int,
         guarded_paths: Iterable[str],
+        reported_limit: int | None = None,
     ) -> None:
         if max_bytes <= 0:
             msg = f"max_bytes must be positive; got {max_bytes}"
             raise ValueError(msg)
+        if reported_limit is not None and reported_limit <= 0:
+            msg = f"reported_limit must be positive; got {reported_limit}"
+            raise ValueError(msg)
         self._app = app
         self._max_bytes = max_bytes
+        self._reported_limit = reported_limit if reported_limit is not None else max_bytes
         # Materialize into a frozenset for O(1) path lookup and
         # constructor-time immutability against accidental mutation of a
         # list passed by caller.
@@ -178,14 +194,20 @@ class UploadSizeLimitMiddleware:
         ``X-Request-Id`` header always carry a valid correlation id,
         matching the fallback in ``app.api.errors._get_request_id``.
         """
-        err = PdfTooLargeError(max_bytes=self._max_bytes, actual_bytes=actual_bytes)
+        # Envelope reports ``_reported_limit`` (the authoritative PDF-byte
+        # limit in production), not ``_max_bytes`` (the inflated ASGI
+        # threshold), so clients see the limit that actually governs what
+        # they can upload. The log line includes both values for ops
+        # visibility.
+        err = PdfTooLargeError(max_bytes=self._reported_limit, actual_bytes=actual_bytes)
         request_id = _get_request_id(scope)
 
         _logger.warning(
             "upload_rejected",
             path=scope.get("path"),
             reason=reason,
-            max_bytes=self._max_bytes,
+            threshold_bytes=self._max_bytes,
+            reported_limit=self._reported_limit,
             actual_bytes=actual_bytes,
             request_id=request_id,
         )

--- a/apps/backend/app/api/upload_size_limit_middleware.py
+++ b/apps/backend/app/api/upload_size_limit_middleware.py
@@ -1,0 +1,226 @@
+"""UploadSizeLimitMiddleware — ASGI-level guard that rejects oversized uploads.
+
+This middleware closes a DoS window exposed by Starlette's multipart
+parser (issue #112). Before this guard existed, a POST to
+``/api/v1/extract`` with a 500 MB body would be fully spooled into the
+temporary file backing ``UploadFile`` **before** the route handler's
+``read_with_byte_limit`` had a chance to reject it. The handler would then
+return 413, but the server had already consumed 500 MB of memory/disk and
+the network had already transferred 500 MB of bytes.
+
+This middleware runs **before** route dispatch (which is what triggers the
+multipart parser) and inspects ``Content-Length`` on the guarded POST
+paths. Oversized or unknown sizes are rejected at the ASGI layer with the
+same ``PDF_TOO_LARGE`` error envelope the downstream handler would have
+produced, so the API contract is unchanged from the caller's perspective.
+
+Fail-closed policy on missing ``Content-Length``
+------------------------------------------------
+
+Chunked transfer-encoded requests (``Transfer-Encoding: chunked``) do not
+carry ``Content-Length``. This middleware treats a missing ``Content-Length``
+on a guarded POST path as unsafe and rejects it. Admitting chunked bodies
+would re-open the spool-then-reject window — we cannot trust the body size
+until after we have read the body, which is exactly what we are trying to
+avoid. Browsers and standard HTTP clients (``httpx``, ``requests``, ``curl``)
+always send ``Content-Length`` for fixed-size uploads under normal
+conditions, so fail-closed costs us nothing for the legitimate client
+population.
+
+The existing ``read_with_byte_limit`` inside the route handler is retained
+as a defense-in-depth check: if a future deployment sits behind a proxy
+that strips ``Content-Length`` or normalizes chunked-into-fixed, the
+handler's chunked-read guard still caps the damage.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import structlog
+from starlette.responses import JSONResponse
+
+from app.exceptions import PdfTooLargeError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_logger = structlog.get_logger(__name__)
+
+# Sentinel used when Content-Length is missing or malformed. Chosen as a very
+# large int so the rejection-reporting path has a numeric value to include
+# in ``params.actual_bytes`` without leaking anything about the underlying
+# body (we have not read the body).
+_UNKNOWN_CONTENT_LENGTH = -1
+
+
+class UploadSizeLimitMiddleware:
+    """Reject oversized uploads at the ASGI layer on the guarded POST paths.
+
+    Parameters
+    ----------
+    app:
+        The downstream ASGI application this middleware wraps.
+    max_bytes:
+        Maximum allowed ``Content-Length`` (strict greater-than check; an
+        upload of exactly ``max_bytes`` is accepted). Must be positive to
+        match ``Settings.max_pdf_bytes`` which is ``Field(gt=0)``.
+    guarded_paths:
+        Iterable of exact request paths on which ``POST`` requests are
+        subject to the size check. A tuple of paths (rather than a single
+        path) keeps the class reusable if another upload route is added
+        later; the alternative of inspecting ``scope["route"]`` is not
+        possible at this layer because route matching happens downstream.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        max_bytes: int,
+        guarded_paths: Iterable[str],
+    ) -> None:
+        if max_bytes <= 0:
+            msg = f"max_bytes must be positive; got {max_bytes}"
+            raise ValueError(msg)
+        self._app = app
+        self._max_bytes = max_bytes
+        # Materialize into a frozenset for O(1) path lookup and
+        # constructor-time immutability against accidental mutation of a
+        # list passed by caller.
+        self._guarded_paths = frozenset(guarded_paths)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._is_guarded(scope):
+            await self._app(scope, receive, send)
+            return
+
+        content_length = _parse_content_length(scope)
+        if content_length is None:
+            await self._reject(scope, send, actual_bytes=_UNKNOWN_CONTENT_LENGTH)
+            return
+        if content_length > self._max_bytes:
+            await self._reject(scope, send, actual_bytes=content_length)
+            return
+
+        await self._app(scope, receive, send)
+
+    def _is_guarded(self, scope: Scope) -> bool:
+        """Return True if this request is subject to the size check.
+
+        Only ``http`` scopes with ``method == POST`` on a guarded path are
+        inspected. WebSocket and lifespan scopes pass through unchanged, as
+        do non-POST methods on the guarded path (they do not trigger the
+        multipart parser).
+        """
+        if scope.get("type") != "http":
+            return False
+        if scope.get("method") != "POST":
+            return False
+        return scope.get("path") in self._guarded_paths
+
+    async def _reject(self, scope: Scope, send: Send, *, actual_bytes: int) -> None:
+        """Emit the ``PDF_TOO_LARGE`` error envelope at the ASGI layer.
+
+        The envelope shape matches what
+        ``app.api.errors.register_exception_handlers`` produces for a
+        ``PdfTooLargeError`` raised from the handler, so callers see an
+        identical response regardless of which layer rejected them.
+
+        When ``RequestIdMiddleware`` has already run (i.e. it is registered
+        outside this one in ``configure_middleware``), ``scope["state"]``
+        carries the generated 32-char hex request id and we reuse it so the
+        ``X-Request-Id`` header and the ``error.request_id`` field stay
+        consistent. When it has not run (e.g. in unit tests that mount this
+        middleware directly on a bare FastAPI app without RequestId), we
+        omit the header and set the body field to ``None`` — the caller
+        still gets a well-formed envelope, just without the correlation id.
+        """
+        err = PdfTooLargeError(max_bytes=self._max_bytes, actual_bytes=actual_bytes)
+        request_id = _get_request_id(scope)
+
+        _logger.warning(
+            "upload_rejected_oversized",
+            path=scope.get("path"),
+            max_bytes=self._max_bytes,
+            actual_bytes=actual_bytes,
+            request_id=request_id,
+        )
+
+        content: dict[str, object] = {
+            "error": {
+                "code": err.code,
+                "params": err.params.model_dump() if err.params else {},
+                "details": None,
+                "request_id": request_id,
+            },
+        }
+
+        headers: dict[str, str] = {}
+        if request_id is not None:
+            headers["X-Request-Id"] = request_id
+
+        response = JSONResponse(
+            status_code=err.http_status,
+            content=content,
+            headers=headers,
+        )
+        # JSONResponse is itself an ASGI app; calling it with a no-op
+        # receive is safe because it never reads the request body.
+        await response(scope, _empty_receive, send)
+
+
+async def _empty_receive() -> Message:
+    """No-op ``receive`` for the early-response path.
+
+    ``Response.__call__`` does not consume the request body, but the ASGI
+    signature requires a callable; this never-returning stub satisfies the
+    type without ever being awaited in practice.
+    """
+    return {"type": "http.disconnect"}
+
+
+def _parse_content_length(scope: Scope) -> int | None:
+    """Return the integer ``Content-Length`` header, or None if missing/malformed.
+
+    ASGI spec: ``scope["headers"]`` is a list of ``(bytes, bytes)`` pairs
+    with lowercase header names. Returning ``None`` for both the missing
+    and malformed cases lets the caller apply a single fail-closed policy.
+    Negative values are also treated as missing — a negative Content-Length
+    is not meaningful and should not be admitted.
+    """
+    raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+    for name, value in raw_headers:
+        if name == b"content-length":
+            try:
+                parsed = int(value.decode("latin-1"))
+            except (ValueError, UnicodeDecodeError):
+                return None
+            if parsed < 0:
+                return None
+            return parsed
+    return None
+
+
+def _get_request_id(scope: Scope) -> str | None:
+    """Return the 32-char hex request id set by ``RequestIdMiddleware``, or None.
+
+    ``RequestIdMiddleware`` assigns ``request.state.request_id``, which
+    Starlette backs with ``scope["state"]``. When this middleware runs
+    outside a stack that includes ``RequestIdMiddleware`` (e.g. a direct
+    unit-test mount), ``scope["state"]`` is absent and we return ``None``
+    — the error envelope then reports ``request_id: null``.
+    """
+    # ``scope["state"]`` is ``dict[str, Any]`` in the ASGI spec, but pyright
+    # strict narrows it to ``dict[Unknown, Unknown]`` after isinstance, so we
+    # re-type explicitly with ``cast`` before indexing.
+    state_obj = scope.get("state")
+    if not isinstance(state_obj, dict):
+        return None
+    state = cast("dict[str, object]", state_obj)
+    request_id = state.get("request_id")
+    if isinstance(request_id, str):
+        return request_id
+    return None

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -147,7 +147,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     application.state.settings = resolved_settings
 
-    configure_middleware(application, cors_origins=resolved_settings.cors_origins)
+    configure_middleware(
+        application,
+        cors_origins=resolved_settings.cors_origins,
+        max_upload_bytes=resolved_settings.max_pdf_bytes,
+    )
     register_exception_handlers(application)
 
     default_docling = SkillDoclingConfig(

--- a/apps/backend/tests/integration/features/extraction/test_upload_size_asgi_guard.py
+++ b/apps/backend/tests/integration/features/extraction/test_upload_size_asgi_guard.py
@@ -108,42 +108,68 @@ async def test_asgi_guard_rejects_oversized_upload_before_service(tmp_path: Path
 
 
 async def test_asgi_guard_allows_pdf_at_limit_with_multipart_overhead(tmp_path: Path) -> None:
-    """A PDF of exactly ``max_pdf_bytes`` wrapped in a multipart envelope
-    (boundary + field headers + separators) passes the ASGI guard.
+    """A real multipart upload whose PDF part is exactly ``max_pdf_bytes``
+    bytes passes the ASGI guard even though the total Content-Length is
+    larger than ``max_pdf_bytes`` (multipart boundary markers,
+    Content-Disposition headers, field separators all add overhead).
 
     Before the overhead allowance was added, the ASGI threshold was set
     to ``max_pdf_bytes`` verbatim; any legitimate multipart body carrying
     a max-sized PDF would exceed it and be rejected at the ASGI layer,
     denying valid uploads. This test pins the opposite invariant: the
     ASGI guard lets the request through even though Content-Length
-    slightly exceeds ``max_pdf_bytes``. (The request may still fail
-    downstream — fixture skill mismatch, missing PDF fields — but it
-    must not be rejected by the ASGI guard.)
+    strictly exceeds ``max_pdf_bytes``.
     """
+    # Stub the service to raise a known downstream error. Any non-413
+    # response confirms the ASGI guard passed the request through —
+    # whether it's the 400 from our error or something else — the point
+    # is that the ASGI layer did NOT reject it. Using ``side_effect`` is
+    # cheaper than assembling a valid ``ExtractionResult``.
+    from app.exceptions import PdfInvalidError
+
     stub = _stub_service()
+    stub.extract.side_effect = PdfInvalidError()
     max_pdf_bytes = 1024
     app = _build_app(tmp_path, stub, max_pdf_bytes=max_pdf_bytes)
     transport = ASGITransport(app=app)
 
+    # Build a real multipart body (data= + files=) so Content-Length
+    # includes the full envelope overhead, not just the PDF bytes. This
+    # is the only way to exercise the overhead-allowance behavior — a
+    # raw ``content=`` body would have CL == payload length exactly.
+    pdf_bytes = b"x" * max_pdf_bytes
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        # Simulate a realistic-ish multipart envelope: 1024 bytes of
-        # content plus a small multipart preamble, well under the 64 KiB
-        # overhead allowance.
-        response = await client.post(
+        request = client.build_request(
+            "POST",
             "/api/v1/extract",
-            content=b"x" * max_pdf_bytes,
-            headers={"content-type": "multipart/form-data; boundary=b"},
+            data={"skill_name": "invoice", "skill_version": "1", "output_mode": "JSON_ONLY"},
+            files={"pdf": ("at_limit.pdf", pdf_bytes, "application/pdf")},
         )
+        request.read()
+        content_length_header = request.headers.get("content-length")
+        response = await client.send(request)
 
-    # The ASGI guard must NOT have rejected this — any 413 from the guard
-    # would report the PDF_TOO_LARGE envelope shape. Whatever the
-    # downstream response is (200 on the canned stub, or 422 on parse
-    # failure), it should not be the ASGI-layer rejection.
+    # Sanity: the assembled multipart body is strictly larger than the
+    # PDF-bytes limit. If this precondition ever breaks, the test stops
+    # exercising the overhead-allowance path.
+    assert content_length_header is not None
+    total_body_size = int(content_length_header)
+    assert total_body_size > max_pdf_bytes, (
+        f"Test precondition failed: multipart body ({total_body_size} bytes) "
+        f"should exceed max_pdf_bytes ({max_pdf_bytes}) for the overhead "
+        "allowance to be meaningfully exercised."
+    )
+
+    # ASGI-layer rejection manifests as 413 with PDF_TOO_LARGE envelope.
+    # Downstream responses may still be non-200 (skill stub returned
+    # something, router validation, etc.) but they must not be the
+    # ASGI rejection.
     if response.status_code == 413:
         body = response.json()
         assert body["error"]["code"] != "PDF_TOO_LARGE", (
-            "ASGI guard rejected a PDF at exactly max_pdf_bytes — overhead "
-            "allowance is too small to admit a legitimate multipart envelope."
+            f"ASGI guard rejected a {max_pdf_bytes}-byte PDF inside a "
+            f"{total_body_size}-byte multipart envelope — overhead allowance "
+            "is too small to admit a legitimate max-sized upload."
         )
 
 

--- a/apps/backend/tests/integration/features/extraction/test_upload_size_asgi_guard.py
+++ b/apps/backend/tests/integration/features/extraction/test_upload_size_asgi_guard.py
@@ -1,0 +1,163 @@
+"""Integration tests for the ASGI-level upload-size guard (issue #112).
+
+Starlette's multipart parser spools the full request body into memory/disk
+BEFORE the route handler runs. The existing ``read_with_byte_limit`` inside
+the handler only rejects AFTER that spooling has already cost us ingress
+resources. The ``UploadSizeLimitMiddleware`` is an ASGI-level gate wired in
+``create_app`` that inspects ``Content-Length`` and rejects oversized
+uploads before Starlette ever touches the body.
+
+These tests assert the end-to-end contract through the real ``create_app``
+middleware stack — ``CORS -> RequestId -> AccessLog -> UploadSizeLimit``
+— so that a regression anywhere in the chain (registration order, a
+silently-dropped middleware, mis-scoped ``guarded_paths``) trips CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_extraction_service
+from app.core.config import Settings
+from app.features.extraction.service import ExtractionService
+from app.main import create_app
+
+
+def _write_valid_skill(base: Path) -> None:
+    body = {
+        "name": "invoice",
+        "version": 1,
+        "prompt": "Extract header fields.",
+        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
+        "output_schema": {
+            "type": "object",
+            "properties": {"number": {"type": "string"}},
+            "required": ["number"],
+        },
+    }
+    target = base / "invoice"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
+
+
+def _settings(skills_dir: Path, **overrides: object) -> Settings:
+    return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
+
+
+def _stub_service() -> ExtractionService:
+    return AsyncMock(spec=ExtractionService)
+
+
+def _build_app(tmp_path: Path, stub: ExtractionService, **settings_overrides: object):
+    _write_valid_skill(tmp_path)
+    app = create_app(_settings(tmp_path, **settings_overrides))
+    app.dependency_overrides[get_extraction_service] = lambda: stub
+    return app
+
+
+async def test_asgi_guard_rejects_oversized_upload_before_service(tmp_path: Path) -> None:
+    """An oversized Content-Length produces 413 PDF_TOO_LARGE and the
+    ``ExtractionService`` is never invoked (i.e. the multipart body was
+    never parsed)."""
+    stub = _stub_service()
+    max_bytes = 1024
+    app = _build_app(tmp_path, stub, max_pdf_bytes=max_bytes)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Send a raw body larger than max_bytes. httpx sets Content-Length
+        # automatically based on ``content`` length; the middleware must
+        # reject based on that header before the route is dispatched.
+        response = await client.post(
+            "/api/v1/extract",
+            content=b"x" * (max_bytes + 2048),
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error"]["code"] == "PDF_TOO_LARGE"
+    assert body["error"]["params"]["max_bytes"] == max_bytes
+    assert body["error"]["params"]["actual_bytes"] == max_bytes + 2048
+    # Correlation id round-trips through the production middleware stack.
+    assert body["error"]["request_id"] == response.headers["x-request-id"]
+
+    # Crucially: the service mock was never called — confirming the guard
+    # ran before route dispatch and before multipart spooling.
+    stub.extract.assert_not_called()
+
+
+async def test_asgi_guard_does_not_affect_health_endpoint(tmp_path: Path) -> None:
+    """The health endpoint is outside ``guarded_paths`` and is not subject
+    to the upload-size check."""
+    stub = _stub_service()
+    app = _build_app(tmp_path, stub, max_pdf_bytes=1024)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/health",
+            headers={"content-length": "999999"},
+        )
+
+    assert response.status_code == 200
+
+
+async def test_asgi_guard_allows_under_limit_upload_through(tmp_path: Path) -> None:
+    """An upload at or below the limit reaches the handler unimpeded.
+
+    This is the happy-path complement to
+    ``test_asgi_guard_rejects_oversized_upload_before_service``; a regression
+    that made the guard reject *everything* (wrong comparison operator,
+    typo on ``max_bytes``) would otherwise slip past the 413 test alone.
+    """
+    from app.features.extraction.extraction_result import ExtractionResult
+    from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+    from app.features.extraction.schemas.extract_response import ExtractResponse
+    from app.features.extraction.schemas.extracted_field import ExtractedField
+    from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+    from app.features.extraction.schemas.field_status import FieldStatus
+
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.return_value = ExtractionResult(
+        response=ExtractResponse(
+            skill_name="invoice",
+            skill_version=1,
+            fields={
+                "number": ExtractedField(
+                    name="number",
+                    value="INV-1",
+                    status=FieldStatus.extracted,
+                    source="document",
+                    grounded=True,
+                    bbox_refs=[BoundingBoxRef(page=1, x0=0.0, y0=0.0, x1=1.0, y1=1.0)],
+                ),
+            },
+            metadata=ExtractionMetadata(
+                page_count=1,
+                duration_ms=1,
+                attempts_per_field={"number": 1},
+            ),
+        ),
+        annotated_pdf_bytes=None,
+    )
+    app = _build_app(tmp_path, stub, max_pdf_bytes=1024 * 1024)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/extract",
+            data={
+                "skill_name": "invoice",
+                "skill_version": "1",
+                "output_mode": "JSON_ONLY",
+            },
+            files={"pdf": ("test.pdf", b"%PDF-1.4 tiny", "application/pdf")},
+        )
+
+    assert response.status_code == 200
+    stub.extract.assert_called_once()

--- a/apps/backend/tests/integration/features/extraction/test_upload_size_asgi_guard.py
+++ b/apps/backend/tests/integration/features/extraction/test_upload_size_asgi_guard.py
@@ -62,33 +62,89 @@ def _build_app(tmp_path: Path, stub: ExtractionService, **settings_overrides: ob
 async def test_asgi_guard_rejects_oversized_upload_before_service(tmp_path: Path) -> None:
     """An oversized Content-Length produces 413 PDF_TOO_LARGE and the
     ``ExtractionService`` is never invoked (i.e. the multipart body was
-    never parsed)."""
+    never parsed).
+
+    The production wiring inflates the ASGI threshold by a 64 KiB
+    multipart-overhead allowance on top of ``Settings.max_pdf_bytes``, so
+    the body must exceed ``max_pdf_bytes + overhead`` to trip the guard.
+    The error envelope still advertises ``max_pdf_bytes`` (the
+    authoritative PDF limit clients need to know), not the inflated
+    threshold.
+    """
     stub = _stub_service()
-    max_bytes = 1024
-    app = _build_app(tmp_path, stub, max_pdf_bytes=max_bytes)
+    max_pdf_bytes = 1024
+    # Overhead in prod wiring; matches ``_MULTIPART_OVERHEAD_ALLOWANCE_BYTES``
+    # in ``app/api/middleware.py``. Mirrored locally rather than imported
+    # since the constant is internal to the wiring module.
+    overhead = 64 * 1024
+    body_size = max_pdf_bytes + overhead + 2048
+    app = _build_app(tmp_path, stub, max_pdf_bytes=max_pdf_bytes)
     transport = ASGITransport(app=app)
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        # Send a raw body larger than max_bytes. httpx sets Content-Length
-        # automatically based on ``content`` length; the middleware must
-        # reject based on that header before the route is dispatched.
+        # Send a raw body larger than ``max_pdf_bytes + overhead``. httpx
+        # sets Content-Length automatically based on ``content`` length;
+        # the middleware must reject based on that header before the route
+        # is dispatched.
         response = await client.post(
             "/api/v1/extract",
-            content=b"x" * (max_bytes + 2048),
+            content=b"x" * body_size,
             headers={"content-type": "multipart/form-data; boundary=b"},
         )
 
     assert response.status_code == 413
     body = response.json()
     assert body["error"]["code"] == "PDF_TOO_LARGE"
-    assert body["error"]["params"]["max_bytes"] == max_bytes
-    assert body["error"]["params"]["actual_bytes"] == max_bytes + 2048
+    # Envelope reports the authoritative PDF limit, NOT the inflated ASGI
+    # threshold — clients should see the real constraint they're violating.
+    assert body["error"]["params"]["max_bytes"] == max_pdf_bytes
+    assert body["error"]["params"]["actual_bytes"] == body_size
     # Correlation id round-trips through the production middleware stack.
     assert body["error"]["request_id"] == response.headers["x-request-id"]
 
     # Crucially: the service mock was never called — confirming the guard
     # ran before route dispatch and before multipart spooling.
     stub.extract.assert_not_called()
+
+
+async def test_asgi_guard_allows_pdf_at_limit_with_multipart_overhead(tmp_path: Path) -> None:
+    """A PDF of exactly ``max_pdf_bytes`` wrapped in a multipart envelope
+    (boundary + field headers + separators) passes the ASGI guard.
+
+    Before the overhead allowance was added, the ASGI threshold was set
+    to ``max_pdf_bytes`` verbatim; any legitimate multipart body carrying
+    a max-sized PDF would exceed it and be rejected at the ASGI layer,
+    denying valid uploads. This test pins the opposite invariant: the
+    ASGI guard lets the request through even though Content-Length
+    slightly exceeds ``max_pdf_bytes``. (The request may still fail
+    downstream — fixture skill mismatch, missing PDF fields — but it
+    must not be rejected by the ASGI guard.)
+    """
+    stub = _stub_service()
+    max_pdf_bytes = 1024
+    app = _build_app(tmp_path, stub, max_pdf_bytes=max_pdf_bytes)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Simulate a realistic-ish multipart envelope: 1024 bytes of
+        # content plus a small multipart preamble, well under the 64 KiB
+        # overhead allowance.
+        response = await client.post(
+            "/api/v1/extract",
+            content=b"x" * max_pdf_bytes,
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    # The ASGI guard must NOT have rejected this — any 413 from the guard
+    # would report the PDF_TOO_LARGE envelope shape. Whatever the
+    # downstream response is (200 on the canned stub, or 422 on parse
+    # failure), it should not be the ASGI-layer rejection.
+    if response.status_code == 413:
+        body = response.json()
+        assert body["error"]["code"] != "PDF_TOO_LARGE", (
+            "ASGI guard rejected a PDF at exactly max_pdf_bytes — overhead "
+            "allowance is too small to admit a legitimate multipart envelope."
+        )
 
 
 async def test_asgi_guard_does_not_affect_health_endpoint(tmp_path: Path) -> None:

--- a/apps/backend/tests/unit/api/test_middleware.py
+++ b/apps/backend/tests/unit/api/test_middleware.py
@@ -3,12 +3,14 @@
 The module docstring of ``app/api/middleware.py`` declares the runtime
 execution order as::
 
-    CORS (outermost) -> RequestId -> AccessLog (innermost) -> route handler
+    CORS (outermost) -> RequestId -> AccessLog -> UploadSizeLimit (innermost)
+        -> route handler
 
 Getting this order wrong silently breaks CORS preflight, request-id
-propagation, and access-log correlation (issue #154). These tests lock in
-the invariant so a future refactor that reorders the ``add_middleware`` calls
-fails CI rather than slipping through silently.
+propagation, access-log correlation (issue #154), or the ASGI-level
+upload-size guard (issue #112). These tests lock in the invariant so a
+future refactor that reorders the ``add_middleware`` calls fails CI rather
+than slipping through silently.
 
 Starlette's ``build_middleware_stack`` iterates ``self.user_middleware`` in
 *reverse* when wrapping the app, so ``user_middleware[0]`` is the outermost
@@ -25,10 +27,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.access_log_middleware import AccessLogMiddleware
 from app.api.middleware import configure_middleware
 from app.api.request_id_middleware import RequestIdMiddleware
+from app.api.upload_size_limit_middleware import UploadSizeLimitMiddleware
 
 
 def test_configure_middleware_registers_expected_execution_order() -> None:
-    """Runtime order is CORS (outermost) -> RequestId -> AccessLog (innermost).
+    """Runtime order is CORS -> RequestId -> AccessLog -> UploadSizeLimit.
 
     ``app.user_middleware`` holds the registrations in the order Starlette will
     use to build the stack: index 0 becomes outermost, index ``-1`` becomes
@@ -37,18 +40,49 @@ def test_configure_middleware_registers_expected_execution_order() -> None:
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"])
+    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=50 * 1024 * 1024)
 
     registered_classes = [m.cls for m in app.user_middleware]
     assert registered_classes == [
         CORSMiddleware,
         RequestIdMiddleware,
         AccessLogMiddleware,
+        UploadSizeLimitMiddleware,
     ], (
         "Middleware execution order must be CORS (outermost) -> RequestId -> "
-        "AccessLog (innermost). Starlette builds the stack by iterating "
-        "user_middleware in reverse, so user_middleware[0] is outermost. "
-        f"Got: {[c.__name__ for c in registered_classes]}"
+        "AccessLog -> UploadSizeLimit (innermost). Starlette builds the stack "
+        "by iterating user_middleware in reverse, so user_middleware[0] is "
+        f"outermost. Got: {[c.__name__ for c in registered_classes]}"
+    )
+
+
+def test_upload_size_limit_is_innermost_so_it_runs_before_route_dispatch() -> None:
+    """UploadSizeLimit must sit LAST (innermost) so it gates multipart parsing.
+
+    The whole point of the middleware (issue #112) is to reject oversized
+    uploads BEFORE FastAPI's route dispatcher fires, which is when
+    Starlette's multipart parser otherwise spools the upload body. Moving
+    it earlier in the registration list (i.e. outer in runtime) would not
+    break its behaviour in the common case, but moving it AFTER RequestId
+    would starve its rejection envelope of a correlation id.
+    """
+    app = FastAPI()
+
+    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=1024)
+
+    classes = [m.cls for m in app.user_middleware]
+    upload_index = classes.index(UploadSizeLimitMiddleware)
+    request_id_index = classes.index(RequestIdMiddleware)
+    assert upload_index == len(classes) - 1, (
+        f"UploadSizeLimitMiddleware must be registered last (innermost) so "
+        f"it runs before FastAPI's route dispatcher. Got index {upload_index} "
+        f"out of {len(classes)}."
+    )
+    assert request_id_index < upload_index, (
+        f"RequestIdMiddleware (index {request_id_index}) must be registered "
+        f"before UploadSizeLimitMiddleware (index {upload_index}) so the "
+        f"guard's rejection envelope can reuse the request id from "
+        f"scope['state']."
     )
 
 
@@ -64,7 +98,7 @@ def test_cors_is_outermost_so_preflight_bypasses_inner_middleware() -> None:
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"])
+    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=50 * 1024 * 1024)
 
     assert app.user_middleware[0].cls is CORSMiddleware, (
         "CORSMiddleware must be registered first (outermost) so preflight "
@@ -84,7 +118,7 @@ def test_request_id_runs_before_access_log_so_log_has_correlation_id() -> None:
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"])
+    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=50 * 1024 * 1024)
 
     classes = [m.cls for m in app.user_middleware]
     request_id_index = classes.index(RequestIdMiddleware)

--- a/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
+++ b/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
@@ -69,7 +69,8 @@ async def test_rejects_when_content_length_exceeds_max_bytes() -> None:
     app = _build_app(max_bytes=1024)
 
     async with await _client(app) as ac:
-        # Send an explicit Content-Length header so the middleware has a value to read.
+        # httpx auto-derives Content-Length from ``content``'s length, so the
+        # middleware sees an accurate numeric header without us setting one.
         response = await ac.post(
             "/api/v1/extract",
             content=b"x" * 2048,
@@ -290,3 +291,112 @@ def test_constructor_rejects_non_positive_max_bytes(max_bytes: int) -> None:
     app = _FastAPI()
     with pytest.raises(ValueError, match="max_bytes"):
         UploadSizeLimitMiddleware(app, max_bytes=max_bytes, guarded_paths=("/x",))
+
+
+async def test_middleware_rejects_chunked_transfer_encoding() -> None:
+    """Transfer-Encoding: chunked on a guarded POST path is fail-closed.
+
+    Even if a small Content-Length accompanies it (which would normally
+    pass the size check), RFC 9110 §8.6 says TE wins — so the CL value is
+    not a trustworthy size bound and the request must be rejected at the
+    ASGI layer before the body is framed.
+    """
+    app = _build_app(max_bytes=1024)
+
+    # Send the raw ASGI scope directly so we can attach both Content-Length
+    # (within the limit) AND Transfer-Encoding: chunked. httpx normalizes
+    # these away on the client side, so we exercise the middleware via a
+    # crafted scope to prove the bypass is closed.
+    sent: list[dict[str, object]] = []
+
+    async def _send(msg: dict[str, object]) -> None:
+        sent.append(msg)
+
+    async def _receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope: dict[str, object] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/extract",
+        "headers": [
+            (b"content-length", b"10"),
+            (b"transfer-encoding", b"chunked"),
+            (b"content-type", b"multipart/form-data; boundary=b"),
+        ],
+        "state": {},
+    }
+
+    middleware = UploadSizeLimitMiddleware(
+        app,
+        max_bytes=1024,
+        guarded_paths=("/api/v1/extract",),
+    )
+    await middleware(scope, _receive, _send)  # pyright: ignore[reportArgumentType]
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 413
+
+
+async def test_middleware_rejects_duplicate_content_length_headers() -> None:
+    """Two Content-Length headers are ambiguous framing and must be rejected.
+
+    An attacker could set ``Content-Length: 10`` and ``Content-Length: 999999``
+    and hope the guard picks the first. ``_parse_content_length`` returns
+    None whenever the header appears more than once, so the middleware
+    rejects the request with the unknown sentinel.
+    """
+    app = _build_app(max_bytes=1024)
+
+    sent: list[dict[str, object]] = []
+
+    async def _send(msg: dict[str, object]) -> None:
+        sent.append(msg)
+
+    async def _receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope: dict[str, object] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/extract",
+        "headers": [
+            (b"content-length", b"10"),
+            (b"content-length", b"999999"),
+            (b"content-type", b"multipart/form-data; boundary=b"),
+        ],
+        "state": {},
+    }
+
+    middleware = UploadSizeLimitMiddleware(
+        app,
+        max_bytes=1024,
+        guarded_paths=("/api/v1/extract",),
+    )
+    await middleware(scope, _receive, _send)  # pyright: ignore[reportArgumentType]
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 413
+
+
+async def test_middleware_generates_fallback_request_id_when_state_missing() -> None:
+    """When RequestIdMiddleware has not run, _get_request_id falls back to
+    a fresh uuid4().hex so the 413 envelope / X-Request-Id header always
+    carry a valid 32-char correlation id (matching app.api.errors).
+    """
+    app = _build_app(max_bytes=1024)
+
+    async with await _client(app) as ac:
+        response = await ac.post(
+            "/api/v1/extract",
+            content=b"x" * 2048,
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    assert response.status_code == 413
+    # Header present, body field present, both equal, both 32-char hex.
+    request_id = response.headers.get("x-request-id")
+    assert request_id is not None
+    assert len(request_id) == 32
+    assert all(c in "0123456789abcdef" for c in request_id)
+    assert response.json()["error"]["request_id"] == request_id

--- a/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
+++ b/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
@@ -327,12 +327,11 @@ async def test_middleware_rejects_chunked_transfer_encoding() -> None:
         "state": {},
     }
 
-    middleware = UploadSizeLimitMiddleware(
-        app,
-        max_bytes=1024,
-        guarded_paths=("/api/v1/extract",),
-    )
-    await middleware(scope, _receive, _send)  # pyright: ignore[reportArgumentType]
+    # Exercise the middleware as it is actually mounted on ``app`` by
+    # ``_build_app`` — calling ``app(...)`` directly avoids wrapping the
+    # app in a second middleware instance, which would hide any
+    # regression in ``_build_app``'s wiring.
+    await app(scope, _receive, _send)  # pyright: ignore[reportArgumentType]
 
     start = next(m for m in sent if m["type"] == "http.response.start")
     assert start["status"] == 413
@@ -368,12 +367,9 @@ async def test_middleware_rejects_duplicate_content_length_headers() -> None:
         "state": {},
     }
 
-    middleware = UploadSizeLimitMiddleware(
-        app,
-        max_bytes=1024,
-        guarded_paths=("/api/v1/extract",),
-    )
-    await middleware(scope, _receive, _send)  # pyright: ignore[reportArgumentType]
+    # Same rationale as the chunked-TE test: exercise the middleware as
+    # mounted on ``app`` rather than constructing a second wrapper.
+    await app(scope, _receive, _send)  # pyright: ignore[reportArgumentType]
 
     start = next(m for m in sent if m["type"] == "http.response.start")
     assert start["status"] == 413

--- a/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
+++ b/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
@@ -22,6 +22,7 @@ Invariants under test:
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -158,10 +159,23 @@ async def test_rejects_when_content_length_missing_on_guarded_path() -> None:
 
     await app(scope, _receive, _send)
 
-    # Find the response.start message and confirm status=413.
+    # Pin the full envelope contract — status, content-type, error code,
+    # and the -1 unknown-size sentinel — so future middleware tweaks can't
+    # silently drift the API shape promised in the module docstring.
     starts = [m for m in sent_messages if m["type"] == "http.response.start"]
     assert len(starts) == 1
     assert starts[0]["status"] == 413
+    start_headers = dict(starts[0].get("headers") or [])
+    assert start_headers.get(b"content-type", b"").startswith(b"application/json")
+
+    bodies = [m for m in sent_messages if m["type"] == "http.response.body"]
+    assert bodies, "middleware must have emitted a response body"
+    raw_body = b"".join(bytes(m.get("body") or b"") for m in bodies)
+    payload = json.loads(raw_body.decode("utf-8"))
+    assert payload["error"]["code"] == "PDF_TOO_LARGE"
+    # Missing Content-Length → unknown body size → actual_bytes=-1 sentinel.
+    assert payload["error"]["params"]["actual_bytes"] == -1
+    assert payload["error"]["params"]["max_bytes"] == 1024
     assert app.state.handler_calls == 0
 
 

--- a/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
+++ b/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
@@ -1,0 +1,292 @@
+"""Unit tests for ``UploadSizeLimitMiddleware`` (issue #112).
+
+The middleware rejects oversized uploads at the ASGI layer **before** the
+route handler runs, preventing Starlette's multipart parser from spooling
+the full request body into memory/disk on every oversized request.
+
+Invariants under test:
+
+* ``Content-Length`` greater than ``max_bytes`` on the guarded POST path
+  produces a 413 ``PDF_TOO_LARGE`` envelope and the downstream app is
+  **never** invoked.
+* A missing ``Content-Length`` header on the guarded POST path (e.g. a
+  chunked request) fails closed with the same 413 envelope — we cannot
+  trust a body we have not yet seen the size of.
+* Paths outside the guarded set pass through without header inspection.
+* Requests with ``Content-Length`` equal to or below the configured limit
+  pass through and reach the downstream app.
+* Non-POST methods on the guarded path pass through (GET /api/v1/extract
+  is not a real route, but the middleware must not interfere).
+* A malformed ``Content-Length`` header (non-integer) fails closed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api.upload_size_limit_middleware import UploadSizeLimitMiddleware
+
+
+def _build_app(max_bytes: int, *, guarded_paths: tuple[str, ...] = ("/api/v1/extract",)) -> FastAPI:
+    """Build a minimal app with the middleware + a sentinel handler.
+
+    The sentinel counts how many times it has been invoked so tests can
+    assert the middleware short-circuited before the handler ran.
+    """
+    application = FastAPI()
+    application.state.handler_calls = 0
+
+    application.add_middleware(
+        UploadSizeLimitMiddleware,
+        max_bytes=max_bytes,
+        guarded_paths=guarded_paths,
+    )
+
+    @application.post("/api/v1/extract")
+    async def _extract() -> dict[str, Any]:
+        application.state.handler_calls += 1
+        return {"ok": True}
+
+    @application.get("/healthz")
+    async def _healthz() -> dict[str, str]:
+        application.state.handler_calls += 1
+        return {"status": "ok"}
+
+    return application
+
+
+async def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_rejects_when_content_length_exceeds_max_bytes() -> None:
+    """A POST to the guarded path with CL > max_bytes returns 413 and never
+    reaches the downstream handler."""
+    app = _build_app(max_bytes=1024)
+
+    async with await _client(app) as ac:
+        # Send an explicit Content-Length header so the middleware has a value to read.
+        response = await ac.post(
+            "/api/v1/extract",
+            content=b"x" * 2048,
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error"]["code"] == "PDF_TOO_LARGE"
+    assert body["error"]["params"]["max_bytes"] == 1024
+    assert body["error"]["params"]["actual_bytes"] == 2048
+    assert body["error"]["details"] is None
+    assert app.state.handler_calls == 0, "downstream handler must NOT be invoked"
+
+
+async def test_accepts_when_content_length_equals_max_bytes() -> None:
+    """CL == max_bytes is allowed through (strict greater-than check)."""
+    app = _build_app(max_bytes=1024)
+
+    async with await _client(app) as ac:
+        response = await ac.post(
+            "/api/v1/extract",
+            content=b"x" * 1024,
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    assert response.status_code == 200
+    assert app.state.handler_calls == 1
+
+
+async def test_accepts_when_content_length_below_max_bytes() -> None:
+    """CL < max_bytes is allowed through."""
+    app = _build_app(max_bytes=1024)
+
+    async with await _client(app) as ac:
+        response = await ac.post(
+            "/api/v1/extract",
+            content=b"x" * 512,
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    assert response.status_code == 200
+    assert app.state.handler_calls == 1
+
+
+async def test_rejects_when_content_length_missing_on_guarded_path() -> None:
+    """A guarded POST without Content-Length (e.g. chunked) fails closed.
+
+    We cannot trust a body whose size we have not seen — admitting it would
+    re-open the exact spool-then-reject window this middleware exists to
+    close. Closing the door on chunked requests costs us nothing at the
+    client layer (httpx / curl / browsers all emit CL for small uploads)
+    and buys us a hard upper bound on ingress cost.
+    """
+    app = _build_app(max_bytes=1024)
+
+    # Build a raw ASGI scope without Content-Length. httpx auto-inserts CL,
+    # so we call the ASGI app directly.
+    sent_messages: list[dict[str, Any]] = []
+
+    async def _receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _send(message: dict[str, Any]) -> None:
+        sent_messages.append(message)
+
+    scope: dict[str, Any] = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/v1/extract",
+        "raw_path": b"/api/v1/extract",
+        "query_string": b"",
+        "headers": [
+            (b"host", b"test"),
+            (b"transfer-encoding", b"chunked"),
+            (b"content-type", b"multipart/form-data; boundary=b"),
+        ],
+        "server": ("test", 80),
+        "client": ("127.0.0.1", 12345),
+        "state": {},
+    }
+
+    await app(scope, _receive, _send)
+
+    # Find the response.start message and confirm status=413.
+    starts = [m for m in sent_messages if m["type"] == "http.response.start"]
+    assert len(starts) == 1
+    assert starts[0]["status"] == 413
+    assert app.state.handler_calls == 0
+
+
+async def test_rejects_when_content_length_is_malformed() -> None:
+    """A non-integer Content-Length on the guarded path fails closed."""
+    app = _build_app(max_bytes=1024)
+
+    sent_messages: list[dict[str, Any]] = []
+
+    async def _receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _send(message: dict[str, Any]) -> None:
+        sent_messages.append(message)
+
+    scope: dict[str, Any] = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/v1/extract",
+        "raw_path": b"/api/v1/extract",
+        "query_string": b"",
+        "headers": [
+            (b"host", b"test"),
+            (b"content-length", b"not-a-number"),
+            (b"content-type", b"multipart/form-data; boundary=b"),
+        ],
+        "server": ("test", 80),
+        "client": ("127.0.0.1", 12345),
+        "state": {},
+    }
+
+    await app(scope, _receive, _send)
+
+    starts = [m for m in sent_messages if m["type"] == "http.response.start"]
+    assert len(starts) == 1
+    assert starts[0]["status"] == 413
+    assert app.state.handler_calls == 0
+
+
+async def test_accepts_content_length_zero_on_guarded_path() -> None:
+    """CL=0 is allowed through — let the handler produce its normal 422."""
+    app = _build_app(max_bytes=1024)
+
+    async with await _client(app) as ac:
+        response = await ac.post(
+            "/api/v1/extract",
+            content=b"",
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    # The sentinel handler returns 200 with an empty body; the point is the
+    # middleware passed through.
+    assert response.status_code == 200
+    assert app.state.handler_calls == 1
+
+
+async def test_non_post_on_guarded_path_passes_through() -> None:
+    """Non-POST methods on the guarded path are not subject to the size check.
+
+    The issue is specifically about POST uploads spooling the body; GET and
+    DELETE don't go through the multipart parser. Keeping the check narrowly
+    scoped to POST avoids surprising side-effects on future routes that
+    share the same path prefix.
+    """
+    app = _build_app(max_bytes=1024)
+
+    # Mount a DELETE handler on the guarded path so we can send a request.
+    @app.delete("/api/v1/extract")
+    async def _delete() -> dict[str, bool]:
+        app.state.handler_calls += 1
+        return {"deleted": True}
+
+    async with await _client(app) as ac:
+        response = await ac.delete(
+            "/api/v1/extract",
+            headers={"content-length": "999999"},
+        )
+
+    # The DELETE reaches the handler — the middleware did not inspect CL.
+    assert response.status_code == 200
+    assert app.state.handler_calls == 1
+
+
+async def test_unguarded_path_passes_through_regardless_of_content_length() -> None:
+    """A route outside ``guarded_paths`` is not subject to the size check."""
+    app = _build_app(max_bytes=1024)
+
+    async with await _client(app) as ac:
+        response = await ac.get(
+            "/healthz",
+            headers={"content-length": "999999"},
+        )
+
+    assert response.status_code == 200
+    assert app.state.handler_calls == 1
+
+
+async def test_middleware_sets_x_request_id_when_request_id_in_state() -> None:
+    """When RequestIdMiddleware has run, the 413 response carries X-Request-Id."""
+    from app.api.request_id_middleware import RequestIdMiddleware
+
+    app = _build_app(max_bytes=1024)
+    # RequestIdMiddleware must wrap UploadSizeLimitMiddleware to set state.
+    app.add_middleware(RequestIdMiddleware)
+
+    async with await _client(app) as ac:
+        response = await ac.post(
+            "/api/v1/extract",
+            content=b"x" * 2048,
+            headers={"content-type": "multipart/form-data; boundary=b"},
+        )
+
+    assert response.status_code == 413
+    assert "x-request-id" in response.headers
+    body = response.json()
+    assert body["error"]["request_id"] == response.headers["x-request-id"]
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1])
+def test_constructor_rejects_non_positive_max_bytes(max_bytes: int) -> None:
+    """max_bytes must be > 0 — Settings.max_pdf_bytes enforces ``gt=0``."""
+    from fastapi import FastAPI as _FastAPI
+
+    app = _FastAPI()
+    with pytest.raises(ValueError, match="max_bytes"):
+        UploadSizeLimitMiddleware(app, max_bytes=max_bytes, guarded_paths=("/x",))

--- a/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
+++ b/apps/backend/tests/unit/api/test_upload_size_limit_middleware.py
@@ -59,7 +59,7 @@ def _build_app(max_bytes: int, *, guarded_paths: tuple[str, ...] = ("/api/v1/ext
     return application
 
 
-async def _client(app: FastAPI) -> AsyncClient:
+def _client(app: FastAPI) -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
@@ -68,7 +68,7 @@ async def test_rejects_when_content_length_exceeds_max_bytes() -> None:
     reaches the downstream handler."""
     app = _build_app(max_bytes=1024)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         # httpx auto-derives Content-Length from ``content``'s length, so the
         # middleware sees an accurate numeric header without us setting one.
         response = await ac.post(
@@ -90,7 +90,7 @@ async def test_accepts_when_content_length_equals_max_bytes() -> None:
     """CL == max_bytes is allowed through (strict greater-than check)."""
     app = _build_app(max_bytes=1024)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.post(
             "/api/v1/extract",
             content=b"x" * 1024,
@@ -105,7 +105,7 @@ async def test_accepts_when_content_length_below_max_bytes() -> None:
     """CL < max_bytes is allowed through."""
     app = _build_app(max_bytes=1024)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.post(
             "/api/v1/extract",
             content=b"x" * 512,
@@ -205,10 +205,10 @@ async def test_rejects_when_content_length_is_malformed() -> None:
 
 
 async def test_accepts_content_length_zero_on_guarded_path() -> None:
-    """CL=0 is allowed through — let the handler produce its normal 422."""
+    """CL=0 is allowed through, so the middleware passes the request on."""
     app = _build_app(max_bytes=1024)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.post(
             "/api/v1/extract",
             content=b"",
@@ -237,7 +237,7 @@ async def test_non_post_on_guarded_path_passes_through() -> None:
         app.state.handler_calls += 1
         return {"deleted": True}
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.delete(
             "/api/v1/extract",
             headers={"content-length": "999999"},
@@ -252,7 +252,7 @@ async def test_unguarded_path_passes_through_regardless_of_content_length() -> N
     """A route outside ``guarded_paths`` is not subject to the size check."""
     app = _build_app(max_bytes=1024)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.get(
             "/healthz",
             headers={"content-length": "999999"},
@@ -270,7 +270,7 @@ async def test_middleware_sets_x_request_id_when_request_id_in_state() -> None:
     # RequestIdMiddleware must wrap UploadSizeLimitMiddleware to set state.
     app.add_middleware(RequestIdMiddleware)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.post(
             "/api/v1/extract",
             content=b"x" * 2048,
@@ -386,7 +386,7 @@ async def test_middleware_generates_fallback_request_id_when_state_missing() -> 
     """
     app = _build_app(max_bytes=1024)
 
-    async with await _client(app) as ac:
+    async with _client(app) as ac:
         response = await ac.post(
             "/api/v1/extract",
             content=b"x" * 2048,


### PR DESCRIPTION
## Summary
- ASGI-level `UploadSizeLimitMiddleware` rejects oversized uploads on `POST /api/v1/extract` before Starlette's multipart parser spools the body.
- Reuses existing `PdfTooLargeError` / `PDF_TOO_LARGE` envelope; API contract unchanged from the caller's perspective.
- Keeps `read_with_byte_limit` in the handler as defense-in-depth.

## Approach
Pure ASGI3 middleware (no `BaseHTTPMiddleware`) registered innermost in the stack so RequestId + AccessLog still wrap it. Reads `Content-Length` from `scope["headers"]`, reuses `scope["state"]["request_id"]` for correlation.

## Trade-off: chunked requests
A missing `Content-Length` on the guarded path fails closed with 413. Admitting chunked bodies would reopen the exact spool-then-reject window this middleware exists to close. Standard clients emit CL for fixed-size uploads; documented in the middleware docstring.

## Test plan
- [x] Unit: 11 tests (pass-through, rejection, CL==max, CL<max, missing CL, malformed CL, CL=0, non-POST, unguarded path, X-Request-Id propagation, constructor guards)
- [x] Integration: 3 end-to-end tests through the real `create_app` middleware stack
- [x] Middleware-order test extended to pin new innermost placement
- [x] Existing extract endpoint tests (10) still pass
- [x] `task check` all green (698 unit + 94 integration + 9 contract + 25 error-contracts, 0 pyright errors, 11 import-linter contracts kept)

Closes #112