### PR TITLE
fix(coordinates): fall back to whole-block bbox when glyph geometry unavailable (closes #151)

### DIFF
--- a/apps/backend/app/features/extraction/coordinates/span_resolver.py
+++ b/apps/backend/app/features/extraction/coordinates/span_resolver.py
@@ -39,7 +39,9 @@ class SpanResolver:
                                           issue #151; future glyph-level
                                           geometry will re-enable tight
                                           bboxes.)
-    4. Single-block span, matcher miss  → same as 3 but whole-block bbox.
+    4. Single-block span, matcher miss  → logs the matcher failure; the
+                                          bbox output is the same whole-block
+                                          BoundingBoxRef as case 3.
     5. Multi-block / cross-page span    → one whole-block BoundingBoxRef per
                                           touched block, all with grounded=True.
     6. Offsets outside any block        → grounded=False with empty bbox_refs

--- a/apps/backend/app/features/extraction/coordinates/span_resolver.py
+++ b/apps/backend/app/features/extraction/coordinates/span_resolver.py
@@ -33,8 +33,12 @@ class SpanResolver:
     2. `grounded is False`              → status=extracted, source=inferred,
                                           grounded=False.
     3. Single-block span, matcher hit   → status=extracted, source=document,
-                                          grounded=True, one tight sub-block
-                                          BoundingBoxRef.
+                                          grounded=True, one whole-block
+                                          BoundingBoxRef. (Tight sub-block
+                                          interpolation was removed per
+                                          issue #151; future glyph-level
+                                          geometry will re-enable tight
+                                          bboxes.)
     4. Single-block span, matcher miss  → same as 3 but whole-block bbox.
     5. Multi-block / cross-page span    → one whole-block BoundingBoxRef per
                                           touched block, all with grounded=True.
@@ -203,19 +207,15 @@ def _whole_block_bbox(block: TextBlock) -> BoundingBoxRef:
 
 
 def _tight_sub_block_bbox(block: TextBlock, match: CharRange) -> BoundingBoxRef:
-    text_length = len(block.text)
-    if text_length == 0:
-        return _whole_block_bbox(block)
-    width = block.bbox.x1 - block.bbox.x0
-    ratio_start = match.start / text_length
-    ratio_end = match.end / text_length
-    return BoundingBoxRef(
-        page=block.page_number,
-        x0=block.bbox.x0 + ratio_start * width,
-        y0=block.bbox.y0,
-        x1=block.bbox.x0 + ratio_end * width,
-        y1=block.bbox.y1,
-    )
+    # Issue #151 interim mitigation: we used to interpolate a sub-block
+    # rectangle via character-offset ratios, which assumes monospaced text and
+    # drifts for proportional fonts / CJK / emoji / diacritics. Until per-cell
+    # glyph geometry is plumbed through TextBlock from Docling, fall back to
+    # the whole-block bbox — correctness over sub-block precision. The `match`
+    # argument is retained so callers and the function signature stay stable
+    # for the future glyph-aware implementation.
+    del match  # unused until glyph-level geometry is available
+    return _whole_block_bbox(block)
 
 
 def _collect_multi_block_bboxes(

--- a/apps/backend/app/features/extraction/coordinates/span_resolver.py
+++ b/apps/backend/app/features/extraction/coordinates/span_resolver.py
@@ -32,9 +32,15 @@ class SpanResolver:
     1. `value is None`                 → status=failed, grounded=False.
     2. `grounded is False`              → status=extracted, source=inferred,
                                           grounded=False.
-    3. Single-block span, matcher hit   → status=extracted, source=document,
+    3. Single-block span, offsets hit   → status=extracted, source=document,
                                           grounded=True, one whole-block
-                                          BoundingBoxRef. (Tight sub-block
+                                          BoundingBoxRef. Covers both the
+                                          direct-offset happy path (the
+                                          reported slice `block.text[start:end]`
+                                          equals `value`) and the matcher-hit
+                                          fallback (SubBlockMatcher.locate
+                                          recovers a range when the offsets
+                                          drift). (Tight sub-block
                                           interpolation was removed per
                                           issue #151; future glyph-level
                                           geometry will re-enable tight

--- a/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
+++ b/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
@@ -6,8 +6,6 @@ declared field names, and returns one `ExtractedField` per declared field in
 declared order — enforcing the "every field always present" API invariant.
 """
 
-import math
-
 from structlog.testing import capture_logs
 
 from app.features.extraction.coordinates.offset_index import OffsetIndex
@@ -49,7 +47,13 @@ def _index(*entries: tuple[int, int, str]) -> OffsetIndex:
     )
 
 
-def test_single_block_sub_block_match_returns_tight_bbox() -> None:
+def test_single_block_sub_block_match_returns_whole_block_bbox() -> None:
+    # Interim mitigation for issue #151: the resolver no longer interpolates
+    # sub-block positions using character ratios (which drifts for proportional
+    # fonts / CJK / emoji / diacritics). A single-block match now returns the
+    # whole-block bbox, trading sub-block precision for correctness. When
+    # per-glyph geometry is plumbed through TextBlock, tight sub-block bboxes
+    # can be reintroduced.
     resolver = SpanResolver()
     block = _block(
         block_id="b0",
@@ -78,12 +82,40 @@ def test_single_block_sub_block_match_returns_tight_bbox() -> None:
     assert field.grounded is True
     assert len(field.bbox_refs) == 1
     ref = field.bbox_refs[0]
-    assert ref.page == 1
-    # Horizontal ratio: 7/20 .. 16/20 over x range 10..210 (width 200).
-    assert math.isclose(ref.x0, 10.0 + (7 / 20) * 200.0)
-    assert math.isclose(ref.x1, 10.0 + (16 / 20) * 200.0)
-    assert ref.y0 == 100.0
-    assert ref.y1 == 120.0
+    assert (ref.page, ref.x0, ref.y0, ref.x1, ref.y1) == (1, 10.0, 100.0, 210.0, 120.0)
+
+
+def test_tight_sub_block_bbox_falls_back_to_whole_block_when_glyph_geometry_unavailable() -> None:
+    # Issue #151: without per-glyph geometry we cannot position a sub-block
+    # rectangle over the actual glyphs. For text that mixes narrow and wide
+    # glyphs ("il111 MMMW" — narrow chars followed by wide ones under any
+    # proportional font), character-ratio interpolation would drift the
+    # highlight away from the real position. We return the whole-block bbox
+    # instead — correctness over sub-block precision.
+    resolver = SpanResolver()
+    block = _block(
+        block_id="b0",
+        text="il111 MMMW",
+        bbox=(0.0, 0.0, 100.0, 20.0),
+    )
+    doc = _doc(block)
+    index = _index((0, 10, "b0"))
+    raw = RawExtraction(
+        field_name="word",
+        value="MMMW",
+        char_offset_start=6,
+        char_offset_end=10,
+        grounded=True,
+        attempts=1,
+    )
+
+    result = resolver.resolve([raw], index, doc, ["word"])
+
+    ref = result[0].bbox_refs[0]
+    # Whole-block bbox, NOT the drifty character-ratio interpolation
+    # (which would have produced x0=60, x1=100 — clearly missing the "MMMW"
+    # glyphs since they occupy the right-hand ~70% of the visual box).
+    assert (ref.x0, ref.y0, ref.x1, ref.y1) == (0.0, 0.0, 100.0, 20.0)
 
 
 def test_single_block_matcher_miss_falls_back_to_whole_block_bbox() -> None:
@@ -589,11 +621,12 @@ def test_sub_block_bbox_preserves_full_block_vertical_extent() -> None:
     assert ref.y1 == 70.0
 
 
-def test_repeated_value_in_block_uses_offset_reported_occurrence() -> None:
+def test_repeated_value_in_block_matches_offset_range_without_matcher_invocation() -> None:
     # "A=42 B=42" — LangExtract reports offsets for the second "42" (positions
     # 7..9 in the block). SubBlockMatcher.locate would return the FIRST "42"
-    # at positions 2..4. The resolver must use the offset-based range to
-    # highlight the correct (second) occurrence.
+    # at positions 2..4. The resolver must use the offset-reported range as
+    # the authoritative match (avoiding the matcher fallback), and — per the
+    # issue #151 interim mitigation — emit the whole-block bbox.
     resolver = SpanResolver()
     block = _block(block_id="b0", text="A=42 B=42", bbox=(0, 0, 100, 20))
     doc = _doc(block)
@@ -607,16 +640,17 @@ def test_repeated_value_in_block_uses_offset_reported_occurrence() -> None:
         attempts=1,
     )
 
-    result = resolver.resolve([raw], index, doc, ["amount"])
+    with capture_logs() as logs:
+        result = resolver.resolve([raw], index, doc, ["amount"])
 
     ref = result[0].bbox_refs[0]
-    # The second "42" occupies chars 7..9 out of 9 chars total, so the
-    # horizontal bbox should span ratio 7/9..9/9 of the block width 100.
-    assert math.isclose(ref.x0, 7 / 9 * 100.0)
-    assert math.isclose(ref.x1, 100.0)
+    assert (ref.x0, ref.x1) == (0.0, 100.0)
+    assert (ref.y0, ref.y1) == (0.0, 20.0)
+    # Matcher was NOT consulted — offsets hit the value directly.
+    assert [e for e in logs if e.get("reason") == "matcher_failed"] == []
 
 
-def test_repeated_value_first_occurrence_uses_offset_reported_range() -> None:
+def test_repeated_value_first_occurrence_also_resolves_without_matcher_invocation() -> None:
     # Same block "A=42 B=42" but offsets point to the first "42" (2..4).
     resolver = SpanResolver()
     block = _block(block_id="b0", text="A=42 B=42", bbox=(0, 0, 90, 20))
@@ -634,9 +668,9 @@ def test_repeated_value_first_occurrence_uses_offset_reported_range() -> None:
     result = resolver.resolve([raw], index, doc, ["amount"])
 
     ref = result[0].bbox_refs[0]
-    # First "42": chars 2..4, ratio 2/9..4/9 of width 90.
-    assert math.isclose(ref.x0, 2 / 9 * 90.0)
-    assert math.isclose(ref.x1, 4 / 9 * 90.0)
+    # Whole-block bbox (issue #151 interim mitigation).
+    assert (ref.x0, ref.x1) == (0.0, 90.0)
+    assert (ref.y0, ref.y1) == (0.0, 20.0)
 
 
 def test_multi_block_span_skips_zero_width_empty_blocks() -> None:

--- a/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
+++ b/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
@@ -71,7 +71,7 @@ def _index(*entries: tuple[int, int, str]) -> OffsetIndex:
     )
 
 
-def test_single_block_sub_block_match_returns_whole_block_bbox() -> None:
+def test_single_block_offsets_hit_returns_whole_block_bbox() -> None:
     # Interim mitigation for issue #151: the resolver no longer interpolates
     # sub-block positions using character ratios (which drifts for proportional
     # fonts / CJK / emoji / diacritics). A single-block match now returns the

--- a/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
+++ b/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
@@ -11,11 +11,27 @@ from structlog.testing import capture_logs
 from app.features.extraction.coordinates.offset_index import OffsetIndex
 from app.features.extraction.coordinates.offset_index_entry import OffsetIndexEntry
 from app.features.extraction.coordinates.span_resolver import SpanResolver
+from app.features.extraction.coordinates.sub_block_matcher import SubBlockMatcher
 from app.features.extraction.extraction.raw_extraction import RawExtraction
 from app.features.extraction.parsing.bounding_box import BoundingBox
 from app.features.extraction.parsing.parsed_document import ParsedDocument
 from app.features.extraction.parsing.text_block import TextBlock
 from app.features.extraction.schemas.field_status import FieldStatus
+
+
+class _ForbiddenMatcher(SubBlockMatcher):
+    """Stub that fails the enclosing test if locate() is invoked.
+
+    Lets tests prove the matcher is NOT consulted on the happy-path
+    (direct-offset hit) case, rather than inferring it from the absence
+    of a matcher_failed log event — which could also mean the matcher
+    was called and succeeded silently.
+    """
+
+    def locate(self, block_text: str, value: str) -> None:
+        msg = f"SubBlockMatcher.locate should not have been called (block_text={block_text!r}, value={value!r})"
+        raise AssertionError(msg)
+
 
 _DEFAULT_BBOX = (0.0, 0.0, 100.0, 20.0)
 
@@ -627,7 +643,11 @@ def test_repeated_value_in_block_matches_offset_range_without_matcher_invocation
     # at positions 2..4. The resolver must use the offset-reported range as
     # the authoritative match (avoiding the matcher fallback), and — per the
     # issue #151 interim mitigation — emit the whole-block bbox.
-    resolver = SpanResolver()
+    # Inject a spy matcher that raises if invoked. Proves the happy-path
+    # branch never consults the matcher — stronger than a log-absence
+    # assertion, which could pass even if the matcher was called and
+    # succeeded silently.
+    resolver = SpanResolver(matcher=_ForbiddenMatcher())
     block = _block(block_id="b0", text="A=42 B=42", bbox=(0, 0, 100, 20))
     doc = _doc(block)
     index = _index((0, 9, "b0"))
@@ -640,14 +660,11 @@ def test_repeated_value_in_block_matches_offset_range_without_matcher_invocation
         attempts=1,
     )
 
-    with capture_logs() as logs:
-        result = resolver.resolve([raw], index, doc, ["amount"])
+    result = resolver.resolve([raw], index, doc, ["amount"])
 
     ref = result[0].bbox_refs[0]
     assert (ref.x0, ref.x1) == (0.0, 100.0)
     assert (ref.y0, ref.y1) == (0.0, 20.0)
-    # Matcher was NOT consulted — offsets hit the value directly.
-    assert [e for e in logs if e.get("reason") == "matcher_failed"] == []
 
 
 def test_repeated_value_first_occurrence_also_resolves_without_matcher_invocation() -> None:

--- a/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
+++ b/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
@@ -6,6 +6,9 @@ declared field names, and returns one `ExtractedField` per declared field in
 declared order — enforcing the "every field always present" API invariant.
 """
 
+from typing import NoReturn
+
+import pytest
 from structlog.testing import capture_logs
 
 from app.features.extraction.coordinates.offset_index import OffsetIndex
@@ -26,9 +29,14 @@ class _ForbiddenMatcher(SubBlockMatcher):
     (direct-offset hit) case, rather than inferring it from the absence
     of a matcher_failed log event — which could also mean the matcher
     was called and succeeded silently.
+
+    The return annotation is `NoReturn` (not `CharRange | None` like the
+    base) because every call path raises; `NoReturn` is a subtype of any
+    return annotation and keeps the override type-compatible with the
+    base signature under strict type checking.
     """
 
-    def locate(self, block_text: str, value: str) -> None:
+    def locate(self, block_text: str, value: str) -> NoReturn:
         msg = f"SubBlockMatcher.locate should not have been called (block_text={block_text!r}, value={value!r})"
         raise AssertionError(msg)
 
@@ -101,26 +109,45 @@ def test_single_block_sub_block_match_returns_whole_block_bbox() -> None:
     assert (ref.page, ref.x0, ref.y0, ref.x1, ref.y1) == (1, 10.0, 100.0, 210.0, 120.0)
 
 
-def test_tight_sub_block_bbox_falls_back_to_whole_block_when_glyph_geometry_unavailable() -> None:
+@pytest.mark.parametrize(
+    ("text", "value", "offset_start", "offset_end"),
+    [
+        # Narrow chars followed by wide ones — under any proportional font
+        # the interpolation would push the highlight left of the real glyphs.
+        ("il111 MMMW", "MMMW", 6, 10),
+        # Wide chars followed by narrow ones — the inverse drift scenario.
+        ("MMMW il111", "il111", 5, 10),
+        # CJK + Latin mixed — wide East-Asian glyphs deviate most from
+        # proportional-width assumptions.
+        ("\u65e5\u672c amount \u00a51000", "amount", 3, 9),
+    ],
+    ids=["narrow_then_wide", "wide_then_narrow", "cjk_mixed_latin"],
+)
+def test_tight_sub_block_bbox_falls_back_to_whole_block_when_glyph_geometry_unavailable(
+    text: str,
+    value: str,
+    offset_start: int,
+    offset_end: int,
+) -> None:
     # Issue #151: without per-glyph geometry we cannot position a sub-block
-    # rectangle over the actual glyphs. For text that mixes narrow and wide
-    # glyphs ("il111 MMMW" — narrow chars followed by wide ones under any
-    # proportional font), character-ratio interpolation would drift the
-    # highlight away from the real position. We return the whole-block bbox
-    # instead — correctness over sub-block precision.
+    # rectangle over the actual glyphs. For any text that mixes narrow and
+    # wide glyphs (Latin proportional fonts, CJK, emoji, diacritics) the
+    # character-ratio interpolation would drift the highlight away from
+    # the real position. We return the whole-block bbox instead —
+    # correctness over sub-block precision.
     resolver = SpanResolver()
     block = _block(
         block_id="b0",
-        text="il111 MMMW",
+        text=text,
         bbox=(0.0, 0.0, 100.0, 20.0),
     )
     doc = _doc(block)
-    index = _index((0, 10, "b0"))
+    index = _index((0, len(text), "b0"))
     raw = RawExtraction(
         field_name="word",
-        value="MMMW",
-        char_offset_start=6,
-        char_offset_end=10,
+        value=value,
+        char_offset_start=offset_start,
+        char_offset_end=offset_end,
         grounded=True,
         attempts=1,
     )
@@ -128,9 +155,9 @@ def test_tight_sub_block_bbox_falls_back_to_whole_block_when_glyph_geometry_unav
     result = resolver.resolve([raw], index, doc, ["word"])
 
     ref = result[0].bbox_refs[0]
-    # Whole-block bbox, NOT the drifty character-ratio interpolation
-    # (which would have produced x0=60, x1=100 — clearly missing the "MMMW"
-    # glyphs since they occupy the right-hand ~70% of the visual box).
+    # Whole-block bbox regardless of offset range — proves we never
+    # emitted a drifty character-ratio interpolation for any of the
+    # narrow/wide mix scenarios parametrized above.
     assert (ref.x0, ref.y0, ref.x1, ref.y1) == (0.0, 0.0, 100.0, 20.0)
 
 
@@ -669,7 +696,10 @@ def test_repeated_value_in_block_matches_offset_range_without_matcher_invocation
 
 def test_repeated_value_first_occurrence_also_resolves_without_matcher_invocation() -> None:
     # Same block "A=42 B=42" but offsets point to the first "42" (2..4).
-    resolver = SpanResolver()
+    # Inject the same forbidden-matcher spy used in the sibling test so the
+    # "without matcher invocation" claim is actually enforced (not just
+    # asserted via log absence).
+    resolver = SpanResolver(matcher=_ForbiddenMatcher())
     block = _block(block_id="b0", text="A=42 B=42", bbox=(0, 0, 90, 20))
     doc = _doc(block)
     index = _index((0, 9, "b0"))


### PR DESCRIPTION
## Summary
- `SpanResolver._tight_sub_block_bbox` no longer interpolates sub-block x-coordinates by character ratio — returns the whole-block bbox instead.
- Character-ratio interpolation drifts on proportional fonts; drift is worst for CJK / emoji / diacritics. Whole-block rectangles always contain the matched text, trading sub-block precision for correctness.
- The "real" fix — plumb Docling's per-cell glyph geometry through `TextBlock` — is deferred as a follow-up; this PR is the interim mitigation the issue body proposes.

## Test plan
- [x] New: `test_tight_sub_block_bbox_falls_back_to_whole_block_when_glyph_geometry_unavailable` — parametrized over a narrow-then-wide payload (`il111 MMMW`), asserts `(x0, y0, x1, y1) == block.bbox`.
- [x] Updated three pre-existing tests in `test_span_resolver.py` that had pinned the drifty interpolation as "expected" — now assert whole-block coords.
- [x] `task check` green: lint, types (pyright strict), import-linter (C1–C6), unit 91, integration non-slow, contract 9, error-contracts 25.

Closes #151