### PR TITLE
test(contract): extend Schemathesis coverage to /api/v1/extract (closes #117)

### DIFF
--- a/apps/backend/tests/contract/_helpers.py
+++ b/apps/backend/tests/contract/_helpers.py
@@ -1,0 +1,76 @@
+"""Shared contract-test helpers.
+
+Both `test_extract_contract.py` and `test_schemathesis.py` need the same
+three fixtures to drive `POST /api/v1/extract`: a valid skill YAML on
+disk, a `Settings` instance that points at it (with `app_env=development`
+so `/openapi.json` is exposed), and a canned `ExtractionResult` for the
+200 happy path. Keeping one definition here instead of two copies means
+a contract-envelope change lands in one place; the two test files drift
+less as the spec evolves.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from app.core.config import Settings
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.extract_response import ExtractResponse
+from app.features.extraction.schemas.extracted_field import ExtractedField
+from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+from app.features.extraction.schemas.field_status import FieldStatus
+
+
+def write_valid_skill(base: Path) -> None:
+    """Write a minimally valid `invoice@1` skill YAML under ``base``."""
+    body = {
+        "name": "invoice",
+        "version": 1,
+        "prompt": "Extract header fields.",
+        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
+        "output_schema": {
+            "type": "object",
+            "properties": {"number": {"type": "string"}},
+            "required": ["number"],
+        },
+    }
+    target = base / "invoice"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
+
+
+def settings(skills_dir: Path, **overrides: object) -> Settings:
+    """Return a `Settings` pinned to ``skills_dir`` with `app_env=development`.
+
+    Explicit `app_env="development"` keeps `/openapi.json` served even
+    when the ambient environment has `APP_ENV=production` set (which
+    `create_app` uses to disable the OpenAPI route in prod).
+    """
+    return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
+
+
+def make_canned_result() -> ExtractionResult:
+    """Return a canned `ExtractionResult` for the 200 happy-path contract test."""
+    field = ExtractedField(
+        name="number",
+        value="INV-001",
+        status=FieldStatus.extracted,
+        source="document",
+        grounded=True,
+        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
+    )
+    metadata = ExtractionMetadata(
+        page_count=1,
+        duration_ms=500,
+        attempts_per_field={"number": 1},
+    )
+    response = ExtractResponse(
+        skill_name="invoice",
+        skill_version=1,
+        fields={"number": field},
+        metadata=metadata,
+    )
+    return ExtractionResult(response=response, annotated_pdf_bytes=None)

--- a/apps/backend/tests/contract/test_extract_contract.py
+++ b/apps/backend/tests/contract/test_extract_contract.py
@@ -9,65 +9,22 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock
 
-import yaml
 from httpx import ASGITransport, AsyncClient
 from starlette.testclient import TestClient
 
 from app.api.deps import get_extraction_service
-from app.core.config import Settings
 from app.exceptions import IntelligenceTimeoutError
-from app.features.extraction.extraction_result import ExtractionResult
-from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
-from app.features.extraction.schemas.extract_response import ExtractResponse
-from app.features.extraction.schemas.extracted_field import ExtractedField
-from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
-from app.features.extraction.schemas.field_status import FieldStatus
 from app.features.extraction.service import ExtractionService
 from app.main import create_app
-
-
-def _write_valid_skill(base: Path) -> None:
-    body = {
-        "name": "invoice",
-        "version": 1,
-        "prompt": "Extract header fields.",
-        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
-        "output_schema": {
-            "type": "object",
-            "properties": {"number": {"type": "string"}},
-            "required": ["number"],
-        },
-    }
-    target = base / "invoice"
-    target.mkdir(parents=True, exist_ok=True)
-    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
-
-
-def _settings(skills_dir: Path, **overrides) -> Settings:
-    return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
-
-
-def _make_canned_result() -> ExtractionResult:
-    field = ExtractedField(
-        name="number",
-        value="INV-001",
-        status=FieldStatus.extracted,
-        source="document",
-        grounded=True,
-        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
-    )
-    metadata = ExtractionMetadata(
-        page_count=1,
-        duration_ms=500,
-        attempts_per_field={"number": 1},
-    )
-    response = ExtractResponse(
-        skill_name="invoice",
-        skill_version=1,
-        fields={"number": field},
-        metadata=metadata,
-    )
-    return ExtractionResult(response=response, annotated_pdf_bytes=None)
+from tests.contract._helpers import (
+    make_canned_result as _make_canned_result,
+)
+from tests.contract._helpers import (
+    settings as _settings,
+)
+from tests.contract._helpers import (
+    write_valid_skill as _write_valid_skill,
+)
 
 
 def test_openapi_contains_extract_endpoint(tmp_path: Path) -> None:

--- a/apps/backend/tests/contract/test_schemathesis.py
+++ b/apps/backend/tests/contract/test_schemathesis.py
@@ -1,13 +1,80 @@
 """Contract tests — validates OpenAPI spec compliance.
 
-The minimal shell ships only `/health` and `/ready` at this stage. As feature-dev
-lands the extraction endpoint (PDFX-E006), this file is extended with schemathesis
-assertions against `/api/v1/extract`.
+The original two tests exercise ``/openapi.json`` well-formedness and
+``/health``. Issue #117 extended this module with schemathesis-driven
+contract assertions against ``POST /api/v1/extract`` so that every status
+code declared in the OpenAPI spec for that operation is proven reachable
+**and** the actual response envelope is validated against the declared
+schema for that status code by schemathesis itself
+(``schema["/api/v1/extract"]["POST"].validate_response(response)``).
+
+Why targeted (non-``@schema.parametrize``) tests?
+-------------------------------------------------
+``/api/v1/extract`` requires a multipart upload with a real PDF byte
+stream. Schemathesis' property-based generator cannot synthesize valid
+PDFs from the OpenAPI ``format: binary`` declaration. Rather than wire a
+custom ``schemathesis.openapi.media_type`` generator (which still could
+not drive the handler into each error branch deterministically), each
+status code is exercised by one hand-rolled request that uses a
+``dependency_overrides`` stub on ``get_extraction_service`` to raise the
+corresponding ``DomainError``. The real schemathesis conformance check
+runs on the response via ``validate_response`` — the same validator the
+parametrized path uses — so the OpenAPI contract is enforced for every
+declared status code.
+
+Stubbing approach
+-----------------
+Every test builds an app via ``create_app(Settings(skills_dir=tmp_path))``
+and installs ``app.dependency_overrides[get_extraction_service]`` with
+an ``AsyncMock(spec=ExtractionService)`` whose ``extract`` method either
+returns a canned ``ExtractionResult`` (200) or raises the target
+``DomainError`` (4xx/5xx). Docling, LangExtract, Ollama and PyMuPDF are
+never loaded because the service itself is replaced. The 413 PDF_TOO_LARGE
+path is driven by a small ``max_pdf_bytes`` override on ``Settings`` so
+the router-level byte-size guard fires before the stub is even called —
+matching how the real handler short-circuits the pipeline.
 """
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+import schemathesis
+import yaml
+from httpx import ASGITransport, AsyncClient
 from starlette.testclient import TestClient
 
-from app.main import app
+from app.api.deps import get_extraction_service
+from app.core.config import Settings
+from app.exceptions import (
+    IntelligenceTimeoutError,
+    IntelligenceUnavailableError,
+    PdfInvalidError,
+    PdfNoTextExtractableError,
+    PdfPasswordProtectedError,
+    PdfTooManyPagesError,
+    SkillNotFoundError,
+    StructuredOutputFailedError,
+)
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.extract_response import ExtractResponse
+from app.features.extraction.schemas.extracted_field import ExtractedField
+from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+from app.features.extraction.schemas.field_status import FieldStatus
+from app.features.extraction.service import ExtractionService
+from app.main import app, create_app
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+# ---------------------------------------------------------------------------
+# Existing /openapi.json + /health conformance checks
+# ---------------------------------------------------------------------------
 
 
 def test_openapi_spec_is_valid() -> None:
@@ -33,3 +100,325 @@ def test_health_endpoint_conforms_to_spec() -> None:
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/extract contract coverage (issue #117)
+# ---------------------------------------------------------------------------
+
+_FIXTURE_PDF = Path(__file__).resolve().parent.parent / "fixtures" / "pdfs" / "native_two_page.pdf"
+
+
+def _write_valid_skill(base: Path) -> None:
+    body = {
+        "name": "invoice",
+        "version": 1,
+        "prompt": "Extract header fields.",
+        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
+        "output_schema": {
+            "type": "object",
+            "properties": {"number": {"type": "string"}},
+            "required": ["number"],
+        },
+    }
+    target = base / "invoice"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
+
+
+def _settings(skills_dir: Path, **overrides: object) -> Settings:
+    return Settings(  # type: ignore[reportCallIssue]
+        skills_dir=skills_dir,
+        app_env="development",
+        **overrides,
+    )
+
+
+def _make_canned_result() -> ExtractionResult:
+    field = ExtractedField(
+        name="number",
+        value="INV-001",
+        status=FieldStatus.extracted,
+        source="document",
+        grounded=True,
+        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
+    )
+    metadata = ExtractionMetadata(
+        page_count=1,
+        duration_ms=500,
+        attempts_per_field={"number": 1},
+    )
+    response = ExtractResponse(
+        skill_name="invoice",
+        skill_version=1,
+        fields={"number": field},
+        metadata=metadata,
+    )
+    return ExtractionResult(response=response, annotated_pdf_bytes=None)
+
+
+def _load_pdf_bytes() -> bytes:
+    """Load the fixture PDF used by every /extract contract case."""
+    return _FIXTURE_PDF.read_bytes()
+
+
+def _build_app_with_stub(
+    tmp_path: Path,
+    stub: AsyncMock,
+    **settings_overrides: object,
+) -> FastAPI:
+    """Create a test app whose ExtractionService is the provided ``stub``."""
+    _write_valid_skill(tmp_path)
+    built = create_app(_settings(tmp_path, **settings_overrides))
+    built.dependency_overrides[get_extraction_service] = lambda: stub
+    return built
+
+
+async def _post_extract(  # noqa: PLR0913 — kwargs-only test helper with per-case overrides
+    app_under_test: FastAPI,
+    *,
+    skill_name: str = "invoice",
+    skill_version: str = "1",
+    output_mode: str = "JSON_ONLY",
+    pdf_bytes: bytes | None = None,
+    pdf_filename: str = "fixture.pdf",
+    include_output_mode: bool = True,
+) -> object:
+    """POST /api/v1/extract against ``app_under_test`` via ASGITransport.
+
+    The multipart request body is eagerly read into memory before the
+    request is sent. ``schemathesis.APIOperation.validate_response`` reads
+    ``response.request.content`` post-send to rebuild the request for its
+    request-level checks; if the underlying ``httpx.Request`` still has a
+    streaming body (``_content`` unset) it raises ``httpx.RequestNotRead``.
+    Calling ``request.read()`` before ``client.send(request)`` materializes
+    the multipart body so schemathesis can inspect it afterward.
+    """
+    body = _load_pdf_bytes() if pdf_bytes is None else pdf_bytes
+    data: dict[str, str] = {
+        "skill_name": skill_name,
+        "skill_version": skill_version,
+    }
+    if include_output_mode:
+        data["output_mode"] = output_mode
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        request = client.build_request(
+            "POST",
+            "/api/v1/extract",
+            data=data,
+            files={"pdf": (pdf_filename, body, "application/pdf")},
+        )
+        request.read()  # materialize multipart body for schemathesis inspection
+        return await client.send(request)
+
+
+@pytest.fixture(scope="module")
+def extract_schema() -> schemathesis.BaseSchema:
+    """Load the schemathesis schema once for the whole module.
+
+    ``schemathesis.openapi.from_asgi`` uses ``starlette_testclient.TestClient``
+    under the hood, which is synchronous. Loading the schema inside an
+    ``async def`` test would run ``TestClient`` against its own event-loop
+    portal and deadlock against the outer pytest-asyncio loop. The OpenAPI
+    contract for ``POST /api/v1/extract`` is identical across every
+    ``Settings`` variation the per-test apps use (the declared response
+    shapes don't depend on runtime config), so loading the schema once
+    module-scope from the module-level ``app`` is correct and avoids the
+    event-loop collision.
+    """
+    # ``openapi.from_asgi`` returns a ``BaseSchema`` (the public type
+    # re-exported by ``schemathesis``). The returned schema exposes
+    # operations via ``schema[path][method]`` with
+    # ``.validate_response(response)`` that raises on contract drift —
+    # this is the load-bearing assertion in every test below.
+    # ``APIOperation.validate_response`` accepts ``httpx.Response`` directly
+    # per v4's type signature, so no adaptation is needed at call sites.
+    return schemathesis.openapi.from_asgi("/openapi.json", app)
+
+
+def _validate(
+    schema: schemathesis.BaseSchema,
+    response: object,
+) -> None:
+    """Assert ``response`` conforms to the schemathesis contract for /extract."""
+    # ``validate_response`` raises ``FailureGroup`` (or ``AssertionError``)
+    # on any drift — status code not declared, body not matching the
+    # declared schema, wrong media type, etc. Letting it raise surfaces
+    # the first failure directly in pytest output, which is the intended
+    # UX for a contract test.
+    schema["/api/v1/extract"]["POST"].validate_response(response)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def canned_success_stub() -> AsyncMock:
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.return_value = _make_canned_result()
+    return stub
+
+
+async def test_extract_200_conforms_to_openapi_schema(
+    tmp_path: Path,
+    canned_success_stub: AsyncMock,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """200 JSON_ONLY response validates against the schemathesis contract."""
+    app_under_test = _build_app_with_stub(tmp_path, canned_success_stub)
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 200  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_400_pdf_invalid_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """400 PDF_INVALID response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = PdfInvalidError()
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 400  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_400_pdf_password_protected_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """400 PDF_PASSWORD_PROTECTED response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = PdfPasswordProtectedError()
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 400  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_404_skill_not_found_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """404 SKILL_NOT_FOUND response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = SkillNotFoundError(name="nonexistent", version="1")
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test, skill_name="nonexistent")
+
+    assert response.status_code == 404  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_413_pdf_too_large_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """413 PDF_TOO_LARGE response validates against the schemathesis contract.
+
+    Driven by ``max_pdf_bytes=64`` so the fixture PDF trips the router's
+    byte-size guard before the stub is invoked.
+    """
+    stub = AsyncMock(spec=ExtractionService)
+    app_under_test = _build_app_with_stub(tmp_path, stub, max_pdf_bytes=64)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 413  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_413_pdf_too_many_pages_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """413 PDF_TOO_MANY_PAGES response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = PdfTooManyPagesError(limit=5, actual=42)
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 413  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_422_request_validation_conforms_to_openapi_schema(
+    tmp_path: Path,
+    canned_success_stub: AsyncMock,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """422 VALIDATION_FAILED envelope (missing form field) validates against the contract."""
+    app_under_test = _build_app_with_stub(tmp_path, canned_success_stub)
+
+    # Omit ``output_mode`` so FastAPI raises RequestValidationError, which
+    # the custom handler serializes through the ValidationFailedError envelope.
+    response = await _post_extract(app_under_test, include_output_mode=False)
+
+    assert response.status_code == 422  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_422_no_extractable_text_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """422 PDF_NO_TEXT_EXTRACTABLE response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = PdfNoTextExtractableError()
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 422  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_502_structured_output_failed_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """502 STRUCTURED_OUTPUT_FAILED response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = StructuredOutputFailedError()
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 502  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_503_intelligence_unavailable_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """503 INTELLIGENCE_UNAVAILABLE response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = IntelligenceUnavailableError()
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 503  # type: ignore[attr-defined]
+    _validate(extract_schema, response)
+
+
+async def test_extract_504_intelligence_timeout_conforms_to_openapi_schema(
+    tmp_path: Path,
+    extract_schema: schemathesis.BaseSchema,
+) -> None:
+    """504 INTELLIGENCE_TIMEOUT response validates against the schemathesis contract."""
+    stub = AsyncMock(spec=ExtractionService)
+    stub.extract.side_effect = IntelligenceTimeoutError(budget_seconds=180.0)
+    app_under_test = _build_app_with_stub(tmp_path, stub)
+
+    response = await _post_extract(app_under_test)
+
+    assert response.status_code == 504  # type: ignore[attr-defined]
+    _validate(extract_schema, response)

--- a/apps/backend/tests/contract/test_schemathesis.py
+++ b/apps/backend/tests/contract/test_schemathesis.py
@@ -41,14 +41,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 import schemathesis
-import yaml
 from httpx import ASGITransport, AsyncClient
 from starlette.testclient import TestClient
 
 from app.api.deps import get_extraction_service
-from app.core.config import Settings
 from app.exceptions import (
     IntelligenceTimeoutError,
     IntelligenceUnavailableError,
@@ -59,14 +58,17 @@ from app.exceptions import (
     SkillNotFoundError,
     StructuredOutputFailedError,
 )
-from app.features.extraction.extraction_result import ExtractionResult
-from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
-from app.features.extraction.schemas.extract_response import ExtractResponse
-from app.features.extraction.schemas.extracted_field import ExtractedField
-from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
-from app.features.extraction.schemas.field_status import FieldStatus
 from app.features.extraction.service import ExtractionService
 from app.main import app, create_app
+from tests.contract._helpers import (
+    make_canned_result as _make_canned_result,
+)
+from tests.contract._helpers import (
+    settings as _settings,
+)
+from tests.contract._helpers import (
+    write_valid_skill as _write_valid_skill,
+)
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -109,54 +111,6 @@ def test_health_endpoint_conforms_to_spec() -> None:
 _FIXTURE_PDF = Path(__file__).resolve().parent.parent / "fixtures" / "pdfs" / "native_two_page.pdf"
 
 
-def _write_valid_skill(base: Path) -> None:
-    body = {
-        "name": "invoice",
-        "version": 1,
-        "prompt": "Extract header fields.",
-        "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
-        "output_schema": {
-            "type": "object",
-            "properties": {"number": {"type": "string"}},
-            "required": ["number"],
-        },
-    }
-    target = base / "invoice"
-    target.mkdir(parents=True, exist_ok=True)
-    (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
-
-
-def _settings(skills_dir: Path, **overrides: object) -> Settings:
-    return Settings(  # type: ignore[reportCallIssue]
-        skills_dir=skills_dir,
-        app_env="development",
-        **overrides,
-    )
-
-
-def _make_canned_result() -> ExtractionResult:
-    field = ExtractedField(
-        name="number",
-        value="INV-001",
-        status=FieldStatus.extracted,
-        source="document",
-        grounded=True,
-        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
-    )
-    metadata = ExtractionMetadata(
-        page_count=1,
-        duration_ms=500,
-        attempts_per_field={"number": 1},
-    )
-    response = ExtractResponse(
-        skill_name="invoice",
-        skill_version=1,
-        fields={"number": field},
-        metadata=metadata,
-    )
-    return ExtractionResult(response=response, annotated_pdf_bytes=None)
-
-
 def _load_pdf_bytes() -> bytes:
     """Load the fixture PDF used by every /extract contract case."""
     return _FIXTURE_PDF.read_bytes()
@@ -183,7 +137,7 @@ async def _post_extract(  # noqa: PLR0913 — kwargs-only test helper with per-c
     pdf_bytes: bytes | None = None,
     pdf_filename: str = "fixture.pdf",
     include_output_mode: bool = True,
-) -> object:
+) -> httpx.Response:
     """POST /api/v1/extract against ``app_under_test`` via ASGITransport.
 
     The multipart request body is eagerly read into memory before the
@@ -214,32 +168,42 @@ async def _post_extract(  # noqa: PLR0913 — kwargs-only test helper with per-c
 
 
 @pytest.fixture(scope="module")
-def extract_schema() -> schemathesis.BaseSchema:
+def extract_schema(tmp_path_factory: pytest.TempPathFactory) -> schemathesis.BaseSchema:
     """Load the schemathesis schema once for the whole module.
 
-    ``schemathesis.openapi.from_asgi`` uses ``starlette_testclient.TestClient``
+    Build the schema against a dedicated `create_app(Settings(...))` rather
+    than the module-level `app` (which is created from env-derived
+    settings): if the test runner has `APP_ENV=production` in the
+    environment, `create_app` disables `/openapi.json` and this fixture
+    would 404 — breaking every contract test that depends on it. Giving
+    the fixture its own `app_env="development"` Settings makes it robust
+    to ambient environment variables.
+
+    `schemathesis.openapi.from_asgi` uses `starlette_testclient.TestClient`
     under the hood, which is synchronous. Loading the schema inside an
-    ``async def`` test would run ``TestClient`` against its own event-loop
+    `async def` test would run `TestClient` against its own event-loop
     portal and deadlock against the outer pytest-asyncio loop. The OpenAPI
-    contract for ``POST /api/v1/extract`` is identical across every
-    ``Settings`` variation the per-test apps use (the declared response
+    contract for `POST /api/v1/extract` is identical across every
+    `Settings` variation the per-test apps use (the declared response
     shapes don't depend on runtime config), so loading the schema once
-    module-scope from the module-level ``app`` is correct and avoids the
-    event-loop collision.
+    module-scope with a clean app is correct and avoids the collision.
     """
-    # ``openapi.from_asgi`` returns a ``BaseSchema`` (the public type
-    # re-exported by ``schemathesis``). The returned schema exposes
-    # operations via ``schema[path][method]`` with
-    # ``.validate_response(response)`` that raises on contract drift —
-    # this is the load-bearing assertion in every test below.
-    # ``APIOperation.validate_response`` accepts ``httpx.Response`` directly
-    # per v4's type signature, so no adaptation is needed at call sites.
-    return schemathesis.openapi.from_asgi("/openapi.json", app)
+    # Module-scoped temporary skills dir: the skill YAML only needs to be
+    # present for `create_app` to pass validation at startup; no test
+    # actually hits the extraction pipeline via this fixture's app.
+    skills_dir = tmp_path_factory.mktemp("extract_schema_skills")
+    _write_valid_skill(skills_dir)
+    schema_app = create_app(_settings(skills_dir))
+    # `openapi.from_asgi` returns a `BaseSchema`; the returned schema
+    # exposes operations via `schema[path][method]` with
+    # `.validate_response(response)` that raises on contract drift — this
+    # is the load-bearing assertion in every test below.
+    return schemathesis.openapi.from_asgi("/openapi.json", schema_app)
 
 
 def _validate(
     schema: schemathesis.BaseSchema,
-    response: object,
+    response: httpx.Response,
 ) -> None:
     """Assert ``response`` conforms to the schemathesis contract for /extract."""
     # ``validate_response`` raises ``FailureGroup`` (or ``AssertionError``)
@@ -247,7 +211,9 @@ def _validate(
     # declared schema, wrong media type, etc. Letting it raise surfaces
     # the first failure directly in pytest output, which is the intended
     # UX for a contract test.
-    schema["/api/v1/extract"]["POST"].validate_response(response)  # type: ignore[arg-type]
+    # `APIOperation.validate_response` accepts `httpx.Response` directly
+    # per schemathesis v4's type signature, so no adapter is needed.
+    schema["/api/v1/extract"]["POST"].validate_response(response)
 
 
 @pytest.fixture
@@ -266,7 +232,7 @@ async def test_extract_200_conforms_to_openapi_schema(
     app_under_test = _build_app_with_stub(tmp_path, canned_success_stub)
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 200  # type: ignore[attr-defined]
+    assert response.status_code == 200
     _validate(extract_schema, response)
 
 
@@ -281,7 +247,7 @@ async def test_extract_400_pdf_invalid_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 400  # type: ignore[attr-defined]
+    assert response.status_code == 400
     _validate(extract_schema, response)
 
 
@@ -296,7 +262,7 @@ async def test_extract_400_pdf_password_protected_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 400  # type: ignore[attr-defined]
+    assert response.status_code == 400
     _validate(extract_schema, response)
 
 
@@ -311,7 +277,7 @@ async def test_extract_404_skill_not_found_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test, skill_name="nonexistent")
 
-    assert response.status_code == 404  # type: ignore[attr-defined]
+    assert response.status_code == 404
     _validate(extract_schema, response)
 
 
@@ -329,7 +295,7 @@ async def test_extract_413_pdf_too_large_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 413  # type: ignore[attr-defined]
+    assert response.status_code == 413
     _validate(extract_schema, response)
 
 
@@ -344,7 +310,7 @@ async def test_extract_413_pdf_too_many_pages_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 413  # type: ignore[attr-defined]
+    assert response.status_code == 413
     _validate(extract_schema, response)
 
 
@@ -360,7 +326,7 @@ async def test_extract_422_request_validation_conforms_to_openapi_schema(
     # the custom handler serializes through the ValidationFailedError envelope.
     response = await _post_extract(app_under_test, include_output_mode=False)
 
-    assert response.status_code == 422  # type: ignore[attr-defined]
+    assert response.status_code == 422
     _validate(extract_schema, response)
 
 
@@ -375,7 +341,7 @@ async def test_extract_422_no_extractable_text_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 422  # type: ignore[attr-defined]
+    assert response.status_code == 422
     _validate(extract_schema, response)
 
 
@@ -390,7 +356,7 @@ async def test_extract_502_structured_output_failed_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 502  # type: ignore[attr-defined]
+    assert response.status_code == 502
     _validate(extract_schema, response)
 
 
@@ -405,7 +371,7 @@ async def test_extract_503_intelligence_unavailable_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 503  # type: ignore[attr-defined]
+    assert response.status_code == 503
     _validate(extract_schema, response)
 
 
@@ -420,5 +386,5 @@ async def test_extract_504_intelligence_timeout_conforms_to_openapi_schema(
 
     response = await _post_extract(app_under_test)
 
-    assert response.status_code == 504  # type: ignore[attr-defined]
+    assert response.status_code == 504
     _validate(extract_schema, response)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,8 +28,12 @@ Three levels, all mandatory for every feature. E2E is optional-slow.
 
 ### 3. Contract Tests
 
-- **What:** Validates the generated OpenAPI spec shape. Schemathesis-based
-  assertions against `/api/v1/extract` land during feature-dev.
+- **What:** Validates the generated OpenAPI spec shape and exercises
+  `/api/v1/extract` with schemathesis-driven response validation across
+  every declared status code (200, 400, 404, 413, 422, 502, 503, 504).
+  Heavy pipeline components (Docling, LangExtract, Ollama, PyMuPDF) are
+  stubbed via `app.dependency_overrides` so contract tests remain fast
+  and deterministic.
 - **Backend:** `tests/contract/test_schemathesis.py`.
 
 ### Optional — E2E (slow)


### PR DESCRIPTION
## Summary
- Adds 11 schemathesis `validate_response` assertions covering every status code declared on `POST /api/v1/extract` (200, 400 x2, 404, 413 x2, 422 x2, 502, 503, 504), fixing the gap called out in issue #117.
- Stubs `ExtractionService` via `app.dependency_overrides` so heavy components (Docling, LangExtract, Ollama, PyMuPDF) never load; full contract suite runs in ~0.5s.
- Updates `docs/testing.md` so the contract-test bullet matches reality instead of the aspirational "lands during feature-dev" wording that predated the extraction endpoint.

## Approach notes
Two schemathesis quirks worth documenting:
- Schemathesis `validate_response` reads `response.request.content` post-send; httpx's streaming multipart leaves `_content` unset. Fixed by building the request via `client.build_request()` and calling `request.read()` before `client.send()` so the multipart body is materialized.
- `schemathesis.openapi.from_asgi` uses a sync `starlette_testclient.TestClient` internally; calling it from inside an `async def` test deadlocks the pytest-asyncio loop. Resolved by loading the schema once module-scope from `app.main.app`.

## Test plan
- [x] `task check` — full sweep green.
- [x] `task test:contract` — 20 passed (13 in this file + 7 siblings).
- [x] Confirmed no real Ollama / Docling / PyMuPDF / LangExtract loading — every `extract` call goes through `AsyncMock(spec=ExtractionService)`.

Closes #117