### PR TITLE
fix(extraction): bound concurrent pipelines with a semaphore (closes #109)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -45,3 +45,10 @@ OLLAMA_PROBE_TIMEOUT_SECONDS=5.0
 # End-to-end timeout for the full extraction pipeline in seconds.
 # Covers parsing + extraction + coordinate resolution + annotation.
 EXTRACTION_TIMEOUT_SECONDS=180.0
+
+# Extraction admission control (issue #109)
+# Maximum number of concurrent extraction pipelines per process. Over-limit
+# requests are rejected immediately with HTTP 503 (EXTRACTION_OVERLOADED)
+# rather than queued, so callers do not wait behind their own 504 budget.
+# Tune to (roughly) available CPU cores for Docling + Ollama parallelism.
+MAX_CONCURRENT_EXTRACTIONS=4

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -138,3 +138,11 @@ class Settings(BaseSettings):
 
     # Extraction pipeline (PDFX-E006-F002)
     extraction_timeout_seconds: Annotated[float, Field(gt=0)] = 180.0
+
+    # Extraction admission control (issue #109)
+    # Hard cap on concurrent extraction pipelines running inside a single
+    # process. When the cap is reached, further requests are rejected
+    # immediately with EXTRACTION_OVERLOADED (HTTP 503) — they are not
+    # queued on a semaphore wait list. Queuing would pile up callers behind
+    # their own 504 timeout budget and defeat the backpressure contract.
+    max_concurrent_extractions: Annotated[int, Field(gt=0)] = 4

--- a/apps/backend/app/exceptions/__init__.py
+++ b/apps/backend/app/exceptions/__init__.py
@@ -4,6 +4,7 @@ Import errors from this module, never from _generated/ directly.
 """
 
 from app.exceptions._generated import (
+    ExtractionOverloadedError,
     IntelligenceTimeoutError,
     IntelligenceUnavailableError,
     InternalError,
@@ -23,6 +24,7 @@ from app.exceptions.base import DomainError
 
 __all__ = [
     "DomainError",
+    "ExtractionOverloadedError",
     "IntelligenceTimeoutError",
     "IntelligenceUnavailableError",
     "InternalError",

--- a/apps/backend/app/exceptions/_generated/__init__.py
+++ b/apps/backend/app/exceptions/_generated/__init__.py
@@ -1,5 +1,7 @@
 """Generated error classes. Do not edit."""
 
+from app.exceptions._generated.extraction_overloaded_error import ExtractionOverloadedError
+from app.exceptions._generated.extraction_overloaded_params import ExtractionOverloadedParams
 from app.exceptions._generated.intelligence_timeout_error import IntelligenceTimeoutError
 from app.exceptions._generated.intelligence_timeout_params import IntelligenceTimeoutParams
 from app.exceptions._generated.intelligence_unavailable_error import IntelligenceUnavailableError
@@ -23,6 +25,8 @@ from app.exceptions._generated.validation_failed_error import ValidationFailedEr
 from app.exceptions._generated.validation_failed_params import ValidationFailedParams
 
 __all__ = [
+    "ExtractionOverloadedError",
+    "ExtractionOverloadedParams",
     "IntelligenceTimeoutError",
     "IntelligenceTimeoutParams",
     "IntelligenceUnavailableError",

--- a/apps/backend/app/exceptions/_generated/_registry.py
+++ b/apps/backend/app/exceptions/_generated/_registry.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.exceptions.base import DomainError
 
+from app.exceptions._generated.extraction_overloaded_error import ExtractionOverloadedError
 from app.exceptions._generated.intelligence_timeout_error import IntelligenceTimeoutError
 from app.exceptions._generated.intelligence_unavailable_error import IntelligenceUnavailableError
 from app.exceptions._generated.internal_error import InternalError
@@ -37,4 +38,5 @@ ERROR_CLASSES: dict[str, type[DomainError]] = {
     "INTELLIGENCE_TIMEOUT": IntelligenceTimeoutError,
     "PDF_TOO_LARGE": PdfTooLargeError,
     "PDF_PARSER_UNAVAILABLE": PdfParserUnavailableError,
+    "EXTRACTION_OVERLOADED": ExtractionOverloadedError,
 }

--- a/apps/backend/app/exceptions/_generated/extraction_overloaded_error.py
+++ b/apps/backend/app/exceptions/_generated/extraction_overloaded_error.py
@@ -1,0 +1,16 @@
+"""Generated from errors.yaml. Do not edit."""
+
+from typing import ClassVar
+
+from app.exceptions._generated.extraction_overloaded_params import ExtractionOverloadedParams
+from app.exceptions.base import DomainError
+
+
+class ExtractionOverloadedError(DomainError):
+    """Error: EXTRACTION_OVERLOADED."""
+
+    code: ClassVar[str] = "EXTRACTION_OVERLOADED"
+    http_status: ClassVar[int] = 503
+
+    def __init__(self, *, max_concurrent: int) -> None:
+        super().__init__(params=ExtractionOverloadedParams(max_concurrent=max_concurrent))

--- a/apps/backend/app/exceptions/_generated/extraction_overloaded_params.py
+++ b/apps/backend/app/exceptions/_generated/extraction_overloaded_params.py
@@ -1,0 +1,9 @@
+"""Generated from errors.yaml. Do not edit."""
+
+from pydantic import BaseModel
+
+
+class ExtractionOverloadedParams(BaseModel):
+    """Parameters for EXTRACTION_OVERLOADED error."""
+
+    max_concurrent: int

--- a/apps/backend/app/features/extraction/router.py
+++ b/apps/backend/app/features/extraction/router.py
@@ -179,7 +179,10 @@ def _serialize_result(result: ExtractionResult, output_mode: OutputMode) -> Resp
             "model": ErrorResponse,
         },
         503: {
-            "description": "Intelligence backend (Ollama) is unavailable",
+            "description": (
+                "Intelligence backend (Ollama) is unavailable, or the extraction "
+                "service is already at its configured concurrency cap"
+            ),
             "model": ErrorResponse,
         },
         504: {

--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -20,9 +20,11 @@ elsewhere; once that work completes, its result is discarded.
 up on CPU and Ollama, a per-service ``asyncio.Semaphore`` caps the
 number of concurrent pipelines at ``Settings.max_concurrent_extractions``
 (issue #109). Over-cap requests are rejected immediately with
-``ExtractionOverloadedError`` (HTTP 503) — the semaphore is checked
-non-blockingly before entry and is never awaited, so callers do not
-queue behind their own 504 budget.
+``ExtractionOverloadedError`` (HTTP 503). ``extract()`` checks
+``Semaphore.locked()`` before entering the ``async with`` block and
+short-circuits if no permit is available, so admitted callers acquire
+the semaphore without waiting and rejected callers fail fast instead
+of queuing behind their own 504 timeout budget.
 """
 
 from __future__ import annotations

--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -15,6 +15,14 @@ use ``asyncio.to_thread``). A timed-out request returns 504 while
 the thread may still be finishing. The unfinished background work may
 overlap with later requests unless concurrency is explicitly limited
 elsewhere; once that work completes, its result is discarded.
+
+**Admission control.** To keep timed-out background work from piling
+up on CPU and Ollama, a per-service ``asyncio.Semaphore`` caps the
+number of concurrent pipelines at ``Settings.max_concurrent_extractions``
+(issue #109). Over-cap requests are rejected immediately with
+``ExtractionOverloadedError`` (HTTP 503) — the semaphore is checked
+non-blockingly before entry and is never awaited, so callers do not
+queue behind their own 504 budget.
 """
 
 from __future__ import annotations
@@ -23,7 +31,11 @@ import asyncio
 import time
 from typing import TYPE_CHECKING
 
-from app.exceptions import IntelligenceTimeoutError, StructuredOutputFailedError
+from app.exceptions import (
+    ExtractionOverloadedError,
+    IntelligenceTimeoutError,
+    StructuredOutputFailedError,
+)
 from app.features.extraction.extraction.extraction_engine import declared_field_names
 from app.features.extraction.extraction_result import ExtractionResult
 from app.features.extraction.parsing.docling_config_merger import merge_docling_config
@@ -69,6 +81,14 @@ class ExtractionService:
         self._intelligence_provider = intelligence_provider
         self._settings = settings
         self._timeout_seconds = settings.extraction_timeout_seconds
+        # Admission-control semaphore (issue #109). One permit per
+        # concurrent pipeline; over-cap requests are rejected up-front
+        # in ``extract`` rather than awaiting on ``acquire`` (which would
+        # defeat the backpressure contract — callers would sit in the
+        # wait queue until their 504 budget ran out, with the background
+        # work still consuming CPU and Ollama on the other side).
+        self._max_concurrent_extractions = settings.max_concurrent_extractions
+        self._semaphore = asyncio.Semaphore(self._max_concurrent_extractions)
 
     async def extract(
         self,
@@ -80,12 +100,43 @@ class ExtractionService:
         """Run the full pipeline and return the extraction result.
 
         Raises:
+            ExtractionOverloadedError: the service is already at its
+                configured concurrency cap; the request is rejected
+                immediately without queuing.
             IntelligenceTimeoutError: pipeline exceeded the timeout budget.
             StructuredOutputFailedError: every declared field failed extraction,
                 or the skill declared zero fields.
             SkillNotFoundError: requested skill is not in the manifest.
             Other DomainError subclasses: propagated from downstream components.
         """
+        # Admission check (issue #109). ``Semaphore.locked()`` is True iff
+        # every permit is currently held. The check and the ``async with``
+        # below are effectively atomic on a single-loop scheduler: when
+        # ``locked()`` returns False there is at least one free permit, and
+        # ``Semaphore.acquire()`` only yields when the counter is zero — so
+        # the semaphore is never awaited here, guaranteeing fail-fast
+        # rejection instead of queuing.
+        if self._semaphore.locked():
+            raise ExtractionOverloadedError(
+                max_concurrent=self._max_concurrent_extractions,
+            )
+
+        async with self._semaphore:
+            return await self._run_pipeline(
+                pdf_bytes,
+                skill_name,
+                skill_version,
+                output_mode,
+            )
+
+    async def _run_pipeline(
+        self,
+        pdf_bytes: bytes,
+        skill_name: str,
+        skill_version: str,
+        output_mode: OutputMode,
+    ) -> ExtractionResult:
+        """Execute the pipeline under the end-to-end timeout budget."""
         t0 = time.monotonic()
         try:
             async with asyncio.timeout(self._timeout_seconds):

--- a/apps/backend/tests/unit/exceptions/test_error_contract_shape.py
+++ b/apps/backend/tests/unit/exceptions/test_error_contract_shape.py
@@ -29,6 +29,8 @@ EXPECTED_CODES = {
     "PDF_TOO_LARGE",
     # Parser runtime-dependency guard (issue #153)
     "PDF_PARSER_UNAVAILABLE",
+    # Admission control for the extraction pipeline (issue #109)
+    "EXTRACTION_OVERLOADED",
 }
 
 PRUNED_CODES = {
@@ -77,6 +79,7 @@ def test_no_stale_generated_error_files() -> None:
         "structured_output_failed_error",
         "pdf_too_large_error",
         "pdf_parser_unavailable_error",
+        "extraction_overloaded_error",
     }
     stale = {"conflict_error", "rate_limited_error", "widget_not_found_error"}
     present_stems = {p.stem for p in GENERATED_DIR.glob("*_error.py")}

--- a/apps/backend/tests/unit/features/extraction/test_extraction_service.py
+++ b/apps/backend/tests/unit/features/extraction/test_extraction_service.py
@@ -720,15 +720,44 @@ async def test_extraction_service_releases_semaphore_on_success() -> None:
     assert isinstance(result, ExtractionResult)
 
 
+class _FailOnceParser:
+    """Parser that raises PdfInvalidError on the first call, then succeeds.
+
+    Lets the release-on-error test reuse the SAME service instance (and
+    therefore its semaphore) across both calls — the prior pattern of
+    swapping to a fresh service would also be green even if the original
+    service never released the permit, because the fresh service has its
+    own semaphore.
+    """
+
+    def __init__(self, doc: ParsedDocument | None = None) -> None:
+        self._doc = doc or _build_parsed_doc()
+        self._calls = 0
+
+    async def parse(self, _pdf_bytes: bytes, _docling_config: Any) -> ParsedDocument:
+        self._calls += 1
+        if self._calls == 1:
+            raise PdfInvalidError
+        return self._doc
+
+
 async def test_extraction_service_releases_semaphore_on_error() -> None:
-    """After a pipeline error, the semaphore permit is still returned."""
+    """After a pipeline error, the semaphore permit is returned to the SAME
+    service instance.
+
+    Crucial that both calls go through the same service (not a fresh one):
+    a fresh service has a fresh semaphore, so it would pass this test even
+    if the original service leaked the permit. Using `_FailOnceParser`
+    keeps the first call's error surface while letting the second call
+    succeed through the same pipeline components.
+    """
     settings = _build_settings(max_concurrent_extractions=1)
-    # Use a parser that always raises — the permit must still be released.
-    service = _build_service(parser=_ErrorParser(), settings=settings)
+    service = _build_service(parser=_FailOnceParser(), settings=settings)
 
     with pytest.raises(PdfInvalidError):
         await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
-    # Switch to a healthy pipeline and confirm the next call is not rejected.
-    healthy = _build_service(settings=settings)
-    result = await healthy.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    # Same service — if the permit leaked, this call would raise
+    # ExtractionOverloadedError instead of succeeding.
+    result = await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
     assert isinstance(result, ExtractionResult)

--- a/apps/backend/tests/unit/features/extraction/test_extraction_service.py
+++ b/apps/backend/tests/unit/features/extraction/test_extraction_service.py
@@ -15,6 +15,7 @@ import pytest
 
 from app.core.config import Settings
 from app.exceptions import (
+    ExtractionOverloadedError,
     IntelligenceTimeoutError,
     PdfInvalidError,
     SkillNotFoundError,
@@ -639,3 +640,95 @@ async def test_extraction_service_timeout_with_blocking_thread_raises() -> None:
             "1",
             OutputMode.JSON_ONLY,
         )
+
+
+async def test_extraction_service_rejects_when_at_capacity() -> None:
+    """Issue #109: over-cap requests fail fast with ExtractionOverloadedError.
+
+    The semaphore bounds concurrent pipelines. With cap=1, holding one
+    request in-flight means any further request must be rejected immediately
+    — not queued — so callers do not pile up behind a 504 budget while the
+    background Docling+Ollama work keeps consuming CPU.
+    """
+
+    class _GatedEngine:
+        """Engine that waits for a caller-controlled event before returning."""
+
+        def __init__(self, gate: asyncio.Event) -> None:
+            self._gate = gate
+            self.in_flight = 0
+            self.max_in_flight = 0
+
+        async def extract(
+            self,
+            _text: str,
+            _skill: Any,
+            _provider: Any,
+        ) -> list[RawExtraction]:
+            self.in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self.in_flight)
+            try:
+                await self._gate.wait()
+                return _build_raw_extractions()
+            finally:
+                self.in_flight -= 1
+
+    gate = asyncio.Event()
+    engine = _GatedEngine(gate)
+    settings = _build_settings(max_concurrent_extractions=1)
+    service = _build_service(engine=engine, settings=settings)
+
+    # Launch first call — it will hold the semaphore until we release the gate.
+    first = asyncio.create_task(
+        service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY),
+    )
+    # Give the first task a chance to enter the pipeline and acquire the semaphore.
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if engine.in_flight >= 1:
+            break
+    assert engine.in_flight == 1, "First call should have entered the pipeline"
+
+    # Second and third concurrent calls must fail fast (no queuing).
+    with pytest.raises(ExtractionOverloadedError) as excinfo_2:
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+    assert excinfo_2.value.http_status == 503
+    assert excinfo_2.value.params is not None
+    assert excinfo_2.value.params.model_dump() == {"max_concurrent": 1}
+
+    with pytest.raises(ExtractionOverloadedError):
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    # The gated engine must never have seen more than one in-flight call.
+    assert engine.max_in_flight == 1
+
+    # Release the first call and make sure it completes successfully.
+    gate.set()
+    result = await first
+    assert isinstance(result, ExtractionResult)
+
+
+async def test_extraction_service_releases_semaphore_on_success() -> None:
+    """After a successful extract, the semaphore permit is returned."""
+    settings = _build_settings(max_concurrent_extractions=1)
+    service = _build_service(settings=settings)
+
+    # First call should succeed and release the permit.
+    await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+    # A second call should not be rejected (permit was released).
+    result = await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+    assert isinstance(result, ExtractionResult)
+
+
+async def test_extraction_service_releases_semaphore_on_error() -> None:
+    """After a pipeline error, the semaphore permit is still returned."""
+    settings = _build_settings(max_concurrent_extractions=1)
+    # Use a parser that always raises — the permit must still be released.
+    service = _build_service(parser=_ErrorParser(), settings=settings)
+
+    with pytest.raises(PdfInvalidError):
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+    # Switch to a healthy pipeline and confirm the next call is not rejected.
+    healthy = _build_service(settings=settings)
+    result = await healthy.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+    assert isinstance(result, ExtractionResult)

--- a/packages/error-contracts/errors.yaml
+++ b/packages/error-contracts/errors.yaml
@@ -85,3 +85,9 @@ errors:
     description: The PDF parser cannot run because a required runtime dependency (e.g. docling, pymupdf) is not installed in this deployment
     params:
       dependency: string
+
+  EXTRACTION_OVERLOADED:
+    http_status: 503
+    description: The extraction service is at its configured concurrency cap; request rejected without queuing so the caller can retry elsewhere
+    params:
+      max_concurrent: integer

--- a/packages/error-contracts/src/generated.ts
+++ b/packages/error-contracts/src/generated.ts
@@ -15,7 +15,8 @@ export type ErrorCode =
   | "STRUCTURED_OUTPUT_FAILED"
   | "INTELLIGENCE_TIMEOUT"
   | "PDF_TOO_LARGE"
-  | "PDF_PARSER_UNAVAILABLE";
+  | "PDF_PARSER_UNAVAILABLE"
+  | "EXTRACTION_OVERLOADED";
 
 export interface ErrorParamsByCode {
   NOT_FOUND: Record<string, never>;
@@ -32,6 +33,7 @@ export interface ErrorParamsByCode {
   INTELLIGENCE_TIMEOUT: { budget_seconds: number };
   PDF_TOO_LARGE: { max_bytes: number; actual_bytes: number };
   PDF_PARSER_UNAVAILABLE: { dependency: string };
+  EXTRACTION_OVERLOADED: { max_concurrent: number };
 }
 
 export interface ApiErrorPayload<C extends ErrorCode = ErrorCode> {
@@ -41,7 +43,7 @@ export interface ApiErrorPayload<C extends ErrorCode = ErrorCode> {
   request_id: string;
 }
 
-export const ERROR_CODES: readonly ErrorCode[] = ["NOT_FOUND", "VALIDATION_FAILED", "INTERNAL_ERROR", "SKILL_VALIDATION_FAILED", "SKILL_NOT_FOUND", "PDF_INVALID", "PDF_PASSWORD_PROTECTED", "PDF_TOO_MANY_PAGES", "PDF_NO_TEXT_EXTRACTABLE", "INTELLIGENCE_UNAVAILABLE", "STRUCTURED_OUTPUT_FAILED", "INTELLIGENCE_TIMEOUT", "PDF_TOO_LARGE", "PDF_PARSER_UNAVAILABLE"] as const;
+export const ERROR_CODES: readonly ErrorCode[] = ["NOT_FOUND", "VALIDATION_FAILED", "INTERNAL_ERROR", "SKILL_VALIDATION_FAILED", "SKILL_NOT_FOUND", "PDF_INVALID", "PDF_PASSWORD_PROTECTED", "PDF_TOO_MANY_PAGES", "PDF_NO_TEXT_EXTRACTABLE", "INTELLIGENCE_UNAVAILABLE", "STRUCTURED_OUTPUT_FAILED", "INTELLIGENCE_TIMEOUT", "PDF_TOO_LARGE", "PDF_PARSER_UNAVAILABLE", "EXTRACTION_OVERLOADED"] as const;
 
 export const HTTP_STATUS_BY_CODE: Record<ErrorCode, number> = {
   NOT_FOUND: 404,
@@ -58,4 +60,5 @@ export const HTTP_STATUS_BY_CODE: Record<ErrorCode, number> = {
   INTELLIGENCE_TIMEOUT: 504,
   PDF_TOO_LARGE: 413,
   PDF_PARSER_UNAVAILABLE: 500,
+  EXTRACTION_OVERLOADED: 503,
 };

--- a/packages/error-contracts/src/required-keys.json
+++ b/packages/error-contracts/src/required-keys.json
@@ -15,7 +15,8 @@
     "STRUCTURED_OUTPUT_FAILED",
     "INTELLIGENCE_TIMEOUT",
     "PDF_TOO_LARGE",
-    "PDF_PARSER_UNAVAILABLE"
+    "PDF_PARSER_UNAVAILABLE",
+    "EXTRACTION_OVERLOADED"
   ],
   "params_by_key": {
     "NOT_FOUND": [],
@@ -50,6 +51,9 @@
     ],
     "PDF_PARSER_UNAVAILABLE": [
       "dependency"
+    ],
+    "EXTRACTION_OVERLOADED": [
+      "max_concurrent"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds an `asyncio.Semaphore` to `ExtractionService` sized by `Settings.max_concurrent_extractions` (default 4, configurable via `MAX_CONCURRENT_EXTRACTIONS`).
- Over-capacity requests are rejected immediately with the new `ExtractionOverloadedError` (HTTP 503, params `{max_concurrent}`). The semaphore is never awaited, so callers never queue behind their own 504 timeout budget.
- Pipeline body moved into a private `_run_pipeline()` so the permit releases on every exit path (success, timeout, domain errors).

## Error-contract changes
- New `EXTRACTION_OVERLOADED` code added to `packages/error-contracts/errors.yaml` (503, params: `max_concurrent: integer`).
- `task errors:generate` regenerated: `_generated/extraction_overloaded_error.py`, `_generated/extraction_overloaded_params.py`, `_generated/__init__.py`, `_generated/_registry.py`, `packages/error-contracts/src/generated.ts`, `packages/error-contracts/src/required-keys.json`.

## Test plan
- [x] `task check` — full sweep green (lint, types pyright strict, import-linter, skills:validate, unit 689, integration 91 non-slow, contract 9, errors drift + tests 25).
- [x] 3 new unit tests: `test_extraction_service_rejects_when_at_capacity`, `test_extraction_service_releases_semaphore_on_success`, `test_extraction_service_releases_semaphore_on_error`.
- [x] Existing `test_error_contract_shape` drift guard updated to include the new code.

Closes #109