### PR TITLE
refactor(one-class-per-file): split health_router + Docling parser (closes #159)

### DIFF
--- a/apps/backend/app/api/health_router.py
+++ b/apps/backend/app/api/health_router.py
@@ -1,32 +1,19 @@
 """Health and readiness endpoints — mounted at root, outside /api/v1/."""
 
-from typing import Annotated, Literal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 from app.api.deps import get_probe_cache, get_skill_manifest
 from app.api.probe_cache import (
     ProbeCache,  # runtime: FastAPI resolves Annotated[..., Depends()]
 )
+from app.api.schemas.not_ready_response import NotReadyResponse
+from app.api.schemas.ready_response import ReadyResponse
 from app.features.extraction.skills import SkillManifest
 
 router = APIRouter(tags=["health"])
-
-
-class _ReadyResponse(BaseModel):
-    status: Literal["ready"]
-
-
-class _NotReadyResponse(BaseModel):
-    status: Literal["not_ready"]
-    # ``no_skills_loaded`` covers the production-container scenario where the
-    # image ships ``apps/backend/skills/`` holding only ``.gitkeep`` and the
-    # operator has not mounted a real skills directory over it. Without this
-    # dimension, ``/ready`` would report green and every extraction request
-    # would 404 on skill lookup (issue #108).
-    reason: Literal["ollama_unreachable", "no_skills_loaded"]
 
 
 @router.get("/health")
@@ -40,11 +27,11 @@ async def health() -> dict[str, str]:
     responses={
         200: {
             "description": ("Ollama is reachable and the skill manifest is populated."),
-            "model": _ReadyResponse,
+            "model": ReadyResponse,
         },
         503: {
             "description": ("Ollama is unreachable or no skills are loaded; service is not ready."),
-            "model": _NotReadyResponse,
+            "model": NotReadyResponse,
         },
     },
 )

--- a/apps/backend/app/api/schemas/__init__.py
+++ b/apps/backend/app/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Response schemas scoped to the api routers (OpenAPI decoration only)."""

--- a/apps/backend/app/api/schemas/not_ready_response.py
+++ b/apps/backend/app/api/schemas/not_ready_response.py
@@ -1,0 +1,24 @@
+"""Response schema for the /ready 503 path — OpenAPI decoration only.
+
+The handler in ``app/api/health_router.py`` constructs its JSON payload
+inline; this class exists solely so FastAPI can document the 503 response
+shape on ``/ready``. ``reason`` enumerates the two ungreen dimensions of
+readiness the handler distinguishes — operator config (``no_skills_loaded``)
+and external-dependency health (``ollama_unreachable``).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class NotReadyResponse(BaseModel):
+    status: Literal["not_ready"]
+    # ``no_skills_loaded`` covers the production-container scenario where the
+    # image ships ``apps/backend/skills/`` holding only ``.gitkeep`` and the
+    # operator has not mounted a real skills directory over it. Without this
+    # dimension, ``/ready`` would report green and every extraction request
+    # would 404 on skill lookup (issue #108).
+    reason: Literal["ollama_unreachable", "no_skills_loaded"]

--- a/apps/backend/app/api/schemas/ready_response.py
+++ b/apps/backend/app/api/schemas/ready_response.py
@@ -1,0 +1,16 @@
+"""Response schema for the /ready 200 path — OpenAPI decoration only.
+
+The handler in ``app/api/health_router.py`` constructs its JSON payload
+inline; this class exists solely so FastAPI can document the 200 response
+shape on ``/ready``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ReadyResponse(BaseModel):
+    status: Literal["ready"]

--- a/apps/backend/app/features/extraction/parsing/_docling_converter_like.py
+++ b/apps/backend/app/features/extraction/parsing/_docling_converter_like.py
@@ -1,0 +1,21 @@
+"""Protocol describing the minimum shape the parser needs from a Docling converter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from app.features.extraction.parsing._docling_document_like import DoclingDocumentLike
+
+
+@runtime_checkable
+class DoclingConverterLike(Protocol):
+    """Minimum shape the parser needs from a Docling converter.
+
+    ``convert`` accepts the raw PDF bytes and returns a ``DoclingDocumentLike``.
+    Keeping the signature bytes-in / adapter-out means the real Docling
+    factory owns every decision about ``DocumentStream`` wrapping, and the
+    parser itself stays agnostic.
+    """
+
+    def convert(self, pdf_bytes: bytes) -> DoclingDocumentLike: ...

--- a/apps/backend/app/features/extraction/parsing/_docling_document_like.py
+++ b/apps/backend/app/features/extraction/parsing/_docling_document_like.py
@@ -1,0 +1,19 @@
+"""Protocol describing the minimum shape the parser needs from a Docling document."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from app.features.extraction.parsing._docling_text_item_like import DoclingTextItemLike
+
+
+@runtime_checkable
+class DoclingDocumentLike(Protocol):
+    """Minimum shape the parser needs from a Docling document."""
+
+    @property
+    def page_count(self) -> int: ...
+    def iter_text_items(self) -> Iterable[DoclingTextItemLike]: ...

--- a/apps/backend/app/features/extraction/parsing/_docling_text_item_like.py
+++ b/apps/backend/app/features/extraction/parsing/_docling_text_item_like.py
@@ -1,0 +1,35 @@
+"""Protocol describing the minimum shape the parser needs from a text item.
+
+This is an internal-to-parsing-package Protocol; adapters in this package
+yield objects satisfying it. Callers outside the package never see instances
+of this Protocol directly (the parser exposes its own ``TextBlock`` value
+type), so the Protocol is module-private (leading-underscore filename).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DoclingTextItemLike(Protocol):
+    """Minimum shape the parser needs from one text-bearing item.
+
+    Adapters expose bounding-box coordinates in PDF page coordinates with the
+    origin at the bottom-left of the page (``y0 <= y1``, with ``y`` growing
+    upward). Any translation from Docling's native convention lives in the
+    adapter, not here.
+    """
+
+    @property
+    def text(self) -> str: ...
+    @property
+    def page_number(self) -> int: ...
+    @property
+    def bbox_x0(self) -> float: ...
+    @property
+    def bbox_y0(self) -> float: ...
+    @property
+    def bbox_x1(self) -> float: ...
+    @property
+    def bbox_y1(self) -> float: ...

--- a/apps/backend/app/features/extraction/parsing/_flat_docling_text_item.py
+++ b/apps/backend/app/features/extraction/parsing/_flat_docling_text_item.py
@@ -1,0 +1,21 @@
+"""Frozen dataclass implementation of ``DoclingTextItemLike``.
+
+The real-Docling adapter yields instances of this class to bridge Docling's
+own types into the parser's Protocol shape. It is a frozen dataclass so
+callers cannot mutate a yielded item while the parser is still walking the
+document.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FlatDoclingTextItem:
+    text: str
+    page_number: int
+    bbox_x0: float
+    bbox_y0: float
+    bbox_x1: float
+    bbox_y1: float

--- a/apps/backend/app/features/extraction/parsing/_real_docling_converter_adapter.py
+++ b/apps/backend/app/features/extraction/parsing/_real_docling_converter_adapter.py
@@ -1,0 +1,148 @@
+"""Real-Docling converter adapter and its factory.
+
+This file is **the only place in the codebase permitted to import Docling**
+(import-linter contract C3). The adapter class ``RealDoclingConverterAdapter``
+wraps Docling's concrete ``DocumentConverter`` and exposes the subset the
+parser consumes via the local ``DoclingConverterLike`` Protocol. The
+``default_converter_factory`` function builds the adapter by lazy-importing
+Docling so unit tests (which inject fake factories) never trigger the real
+Docling import path and module load stays cheap.
+
+The ``DoclingConverterFactory`` type alias lives here because it is the
+return-type signature of ``default_converter_factory``; callers in
+``docling_document_parser.py`` import the alias to type their
+``converter_factory`` constructor parameter.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from app.exceptions import PdfParserUnavailableError
+from app.features.extraction.parsing._docling_converter_like import DoclingConverterLike
+from app.features.extraction.parsing._real_docling_document_adapter import (
+    RealDoclingDocumentAdapter,
+)
+from app.features.extraction.parsing.docling_config import DoclingConfig
+
+if TYPE_CHECKING:
+    from app.features.extraction.parsing._docling_document_like import DoclingDocumentLike
+
+_log = structlog.get_logger(__name__)
+
+
+DoclingConverterFactory = Callable[[DoclingConfig], DoclingConverterLike]
+
+
+class RealDoclingConverterAdapter:
+    """Adapts Docling's real ``DocumentConverter`` to ``DoclingConverterLike``.
+
+    The class methods are the single place (together with
+    ``default_converter_factory`` below) where Docling's actual types are
+    read; everywhere else in the parser the code only ever touches our
+    local Protocols.
+    """
+
+    def __init__(self, real_converter: Any) -> None:
+        self._real_converter: Any = real_converter
+
+    def convert(self, pdf_bytes: bytes) -> DoclingDocumentLike:
+        base_models: Any = importlib.import_module("docling.datamodel.base_models")
+        document_stream_cls: Any = base_models.DocumentStream
+        source: Any = document_stream_cls(name="input.pdf", stream=io.BytesIO(pdf_bytes))
+        result: Any = self._real_converter.convert(source)
+        return RealDoclingDocumentAdapter(result.document)
+
+
+def default_converter_factory(config: DoclingConfig) -> DoclingConverterLike:
+    """Build a real Docling-backed converter adapter honoring ``config``.
+
+    Imports of Docling are lazy (``importlib.import_module``) so:
+
+    1. Module load does not pay the Docling startup cost.
+    2. Unit tests that inject their own ``converter_factory`` never trigger
+       any Docling code path, even indirectly.
+    3. Environments without Docling installed (e.g., CI before PDFX-E001-F002
+       lands) can still import this module — the ImportError is only raised
+       when someone actually invokes the default factory.
+
+    The returned object conforms to ``DoclingConverterLike`` via a small
+    adapter class that wraps Docling's real types and exposes the subset
+    this parser consumes.
+    """
+    try:
+        base_models: Any = importlib.import_module("docling.datamodel.base_models")
+        pipeline_options_mod: Any = importlib.import_module(
+            "docling.datamodel.pipeline_options",
+        )
+        document_converter_mod: Any = importlib.import_module(
+            "docling.document_converter",
+        )
+    except ImportError as exc:
+        _log.error(
+            "parser_dependency_unavailable",
+            dependency="docling",
+            detail=(
+                "docling is not installed; DoclingDocumentParser's default "
+                "converter factory cannot build a real Docling pipeline. "
+                "Docling becomes a pinned runtime dependency in PDFX-E001-F002. "
+                "Until then, unit tests must inject a fake `converter_factory` "
+                "via DoclingDocumentParser(converter_factory=...)."
+            ),
+        )
+        raise PdfParserUnavailableError(dependency="docling") from exc
+
+    input_format: Any = base_models.InputFormat
+    pdf_pipeline_options_cls: Any = pipeline_options_mod.PdfPipelineOptions
+    table_structure_options_cls: Any = pipeline_options_mod.TableStructureOptions
+    table_former_mode: Any = pipeline_options_mod.TableFormerMode
+    # Tesseract via CLI — not EasyOCR. ``EasyOcrOptions`` triggered
+    # ``ImportError: EasyOCR is not installed`` on any runtime OCR path because
+    # ``easyocr`` is not a Docling base dependency (it is a heavy torch/opencv
+    # extra that would undo the CUDA-bloat work tracked in issue #139).
+    # ``TesseractCliOcrOptions`` shells out to the system ``tesseract`` binary
+    # and needs no Python bindings — the Dockerfile ships ``tesseract-ocr`` +
+    # ``tesseract-ocr-eng`` via apt. See docs/decisions.md ADR-013 and
+    # issue #106.
+    tesseract_cli_ocr_options_cls: Any = pipeline_options_mod.TesseractCliOcrOptions
+    document_converter_cls: Any = document_converter_mod.DocumentConverter
+    pdf_format_option_cls: Any = document_converter_mod.PdfFormatOption
+
+    # OCR mode mapping, per PDFX-E003-F002 scope:
+    #   - "off":   do_ocr=False               (skip OCR entirely)
+    #   - "auto":  do_ocr=True, force_full_page_ocr=False
+    #              (Docling auto-detects the absence of a text layer and
+    #               runs OCR on pages that lack one)
+    #   - "force": do_ocr=True, force_full_page_ocr=True
+    #              (OCR every page even when a text layer is present)
+    do_ocr: bool = config.ocr != "off"
+    force_full_page_ocr: bool = config.ocr == "force"
+    mode: Any = (
+        table_former_mode.ACCURATE if config.table_mode == "accurate" else table_former_mode.FAST
+    )
+
+    pipeline_options: Any = pdf_pipeline_options_cls()
+    pipeline_options.do_ocr = do_ocr
+    pipeline_options.do_table_structure = True
+    pipeline_options.table_structure_options = table_structure_options_cls(
+        do_cell_matching=True,
+        mode=mode,
+    )
+    if do_ocr:
+        pipeline_options.ocr_options = tesseract_cli_ocr_options_cls(
+            force_full_page_ocr=force_full_page_ocr,
+        )
+
+    real_converter: Any = document_converter_cls(
+        format_options={
+            input_format.PDF: pdf_format_option_cls(
+                pipeline_options=pipeline_options,
+            ),
+        },
+    )
+    return RealDoclingConverterAdapter(real_converter)

--- a/apps/backend/app/features/extraction/parsing/_real_docling_converter_adapter.py
+++ b/apps/backend/app/features/extraction/parsing/_real_docling_converter_adapter.py
@@ -1,7 +1,9 @@
 """Real-Docling converter adapter and its factory.
 
-This file is **the only place in the codebase permitted to import Docling**
-(import-linter contract C3). The adapter class ``RealDoclingConverterAdapter``
+This file is the parser layer's concrete Docling import/factory entry
+point, one of three files on import-linter contract C3's allow-list
+(alongside ``_real_docling_document_adapter.py`` and the parser coordinator
+``docling_document_parser.py``). The ``RealDoclingConverterAdapter`` class
 wraps Docling's concrete ``DocumentConverter`` and exposes the subset the
 parser consumes via the local ``DoclingConverterLike`` Protocol. The
 ``default_converter_factory`` function builds the adapter by lazy-importing

--- a/apps/backend/app/features/extraction/parsing/_real_docling_document_adapter.py
+++ b/apps/backend/app/features/extraction/parsing/_real_docling_document_adapter.py
@@ -1,0 +1,132 @@
+"""Adapter from Docling's concrete ``DoclingDocument`` to the parser's Protocol.
+
+This file, together with ``_real_docling_converter_adapter.py``, is part of
+the Docling containment boundary (import-linter contract C3). Only these
+files — and nothing else in the service — touch Docling's types. They
+present the local ``DoclingDocumentLike`` / ``DoclingConverterLike``
+Protocols to the rest of the parser so downstream code never learns
+anything about Docling's class hierarchy.
+
+The adapter itself does not statically import ``docling`` — it operates on
+``Any``-typed objects passed in by the converter-adapter factory — but it
+lives inside the C3 boundary because any reasonable shape-change from
+Docling would ripple here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.features.extraction.parsing._flat_docling_text_item import FlatDoclingTextItem
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from app.features.extraction.parsing._docling_text_item_like import DoclingTextItemLike
+
+
+class RealDoclingDocumentAdapter:
+    """Adapts Docling's ``DoclingDocument`` to ``DoclingDocumentLike``.
+
+    Implements ``iter_text_items`` by walking Docling's text-bearing node items
+    and translating each provenance entry into a simple flat item that
+    exposes bottom-left-origin coordinates. Docling's ``BoundingBox`` carries a
+    ``coord_origin`` field (``CoordOrigin.TOPLEFT`` or ``CoordOrigin.BOTTOMLEFT``) —
+    TOPLEFT is in fact Docling's *default* for most pipeline outputs — so the
+    adapter cannot assume one origin. When a prov bbox reports TOPLEFT
+    coordinates (via ``coord_origin``), the adapter flips it to BOTTOMLEFT with
+    ``bbox.to_bottom_left_origin(page_height=...)`` before unpacking, using the
+    owning page's height from ``doc.pages[page_no].size``; boxes already in
+    BOTTOMLEFT are unpacked as-is. This matches our canonical ``BoundingBox``
+    convention (origin bottom-left, ``y0 <= y1``) and matches PyMuPDF, which
+    the annotator uses downstream without further transformation. (GH issue
+    #133.)
+
+    Reading order (GH issue #150): the traversal delegates to Docling's
+    public ``DoclingDocument.iterate_items()`` API, which walks the document
+    hierarchy in visual READING order (top-to-bottom, left-to-right per
+    page, respecting column and table structure). Iterating ``.texts``
+    directly — as an earlier revision did — returns items in Docling's
+    implementation-dependent STORAGE order, which on multi-column / table-
+    heavy layouts interleaves columns incorrectly and causes downstream
+    span-resolution failures (LangExtract reports ``hallucinated_offsets``
+    for values that are in fact present in the source PDF). The fallback
+    to ``.texts`` is retained only for documents whose shape predates
+    ``iterate_items()`` (e.g., minimal test doubles in other features' fakes);
+    real Docling-produced documents always expose ``iterate_items()``.
+    """
+
+    def __init__(self, docling_document: Any) -> None:
+        self._docling_document: Any = docling_document
+
+    @property
+    def page_count(self) -> int:
+        pages: Any = self._docling_document.pages
+        return len(pages)
+
+    def iter_text_items(self) -> Iterable[DoclingTextItemLike]:
+        pages: Any = getattr(self._docling_document, "pages", None) or {}
+        for text_item in self._iter_reading_order():
+            item: Any = text_item
+            text_value: Any = getattr(item, "text", None)
+            provs: Any = getattr(item, "prov", None) or []
+            if not text_value or not provs:
+                continue
+            prov: Any = provs[0]
+            page_no: int = int(prov.page_no)
+            raw_bbox: Any = prov.bbox
+            # Docling's ``CoordOrigin`` is a ``str, Enum`` whose members stringify
+            # to ``CoordOrigin.TOPLEFT`` / ``CoordOrigin.BOTTOMLEFT`` (standard
+            # ``Enum.__str__``). Match on ``str(origin).endswith("TOPLEFT")`` so
+            # the check accepts both the real enum's string form and plain-
+            # string test doubles like ``"TOPLEFT"``.
+            origin: Any = getattr(raw_bbox, "coord_origin", None)
+            needs_flip: bool = origin is not None and str(origin).endswith("TOPLEFT")
+            if needs_flip:
+                # Direct indexing: if ``page_no`` is missing from ``doc.pages``,
+                # raise KeyError with the offending page number instead of
+                # silently returning None and blowing up later on ``.size``.
+                page: Any = pages[page_no]
+                page_height: float = float(page.size.height)
+                bbox: Any = raw_bbox.to_bottom_left_origin(page_height=page_height)
+            else:
+                bbox = raw_bbox
+            yield FlatDoclingTextItem(
+                text=str(text_value),
+                page_number=page_no,
+                bbox_x0=float(bbox.l),
+                bbox_y0=float(bbox.b),
+                bbox_x1=float(bbox.r),
+                bbox_y1=float(bbox.t),
+            )
+
+    def _iter_reading_order(self) -> Iterable[Any]:
+        """Yield every Docling node item in visual reading order.
+
+        Uses ``DoclingDocument.iterate_items()`` when available — this is
+        Docling's public reading-order traversal API (Docling >= 2.x) and
+        yields ``(item, level)`` tuples for every node in the document tree,
+        in top-to-bottom / left-to-right / per-column visual order. The
+        caller filters down to text-bearing items by testing ``.text`` and
+        ``.prov`` attributes, so non-text nodes (tables, pictures) are
+        ignored without a type check against Docling's own class hierarchy
+        — preserving this file's containment of Docling's public types.
+
+        When ``iterate_items()`` is not available (legacy documents or test
+        doubles that predate this API), the adapter falls back to iterating
+        ``.texts`` directly, which is Docling's internal storage order. That
+        fallback is imperfect on multi-column layouts but keeps the adapter
+        robust against shape drift. Real Docling-produced documents always
+        expose ``iterate_items()``.
+        """
+        iterate_items: Any = getattr(self._docling_document, "iterate_items", None)
+        if callable(iterate_items):
+            iterator: Any = iterate_items()
+            for pair in iterator:
+                item: Any = pair[0]
+                yield item
+            return
+        yield from getattr(self._docling_document, "texts", None) or []
+
+
+__all__ = ["RealDoclingDocumentAdapter"]

--- a/apps/backend/app/features/extraction/parsing/_real_docling_document_adapter.py
+++ b/apps/backend/app/features/extraction/parsing/_real_docling_document_adapter.py
@@ -1,8 +1,9 @@
 """Adapter from Docling's concrete ``DoclingDocument`` to the parser's Protocol.
 
-This file, together with ``_real_docling_converter_adapter.py``, is part of
-the Docling containment boundary (import-linter contract C3). Only these
-files — and nothing else in the service — touch Docling's types. They
+This file, together with ``_real_docling_converter_adapter.py`` and
+``docling_document_parser.py``, is part of the Docling containment
+boundary (import-linter contract C3). These three files — and nothing
+else in the service — are allowed to reference Docling's types. They
 present the local ``DoclingDocumentLike`` / ``DoclingConverterLike``
 Protocols to the rest of the parser so downstream code never learns
 anything about Docling's class hierarchy.

--- a/apps/backend/app/features/extraction/parsing/docling_config.py
+++ b/apps/backend/app/features/extraction/parsing/docling_config.py
@@ -21,7 +21,7 @@ class DoclingConfig:
     table_mode: TableMode
 
     def __post_init__(self) -> None:
-        # Fail fast on typos. `DoclingDocumentParser._default_converter_factory`
+        # Fail fast on typos. `DoclingDocumentParser.default_converter_factory`
         # otherwise silently maps anything that is not "off" to OCR-on and
         # anything that is not "accurate" to the FAST table-structure mode,
         # which turns configuration typos (e.g. ocr="froce") into silent

--- a/apps/backend/app/features/extraction/parsing/docling_config.py
+++ b/apps/backend/app/features/extraction/parsing/docling_config.py
@@ -21,7 +21,7 @@ class DoclingConfig:
     table_mode: TableMode
 
     def __post_init__(self) -> None:
-        # Fail fast on typos. `DoclingDocumentParser.default_converter_factory`
+        # Fail fast on typos. `_real_docling_converter_adapter.default_converter_factory`
         # otherwise silently maps anything that is not "off" to OCR-on and
         # anything that is not "accurate" to the FAST table-structure mode,
         # which turns configuration typos (e.g. ocr="froce") into silent

--- a/apps/backend/app/features/extraction/parsing/docling_document_parser.py
+++ b/apps/backend/app/features/extraction/parsing/docling_document_parser.py
@@ -5,9 +5,11 @@ factory live in sibling files (``_real_docling_converter_adapter.py``,
 ``_real_docling_document_adapter.py``, ``_flat_docling_text_item.py``); the
 Protocols they implement live in ``_docling_*.py`` / ``pdf_preflight.py``.
 Splitting the file was driven by issue #159 (CLAUDE.md Sacred Rule #1 —
-one class per file) — import-linter contract C3 was widened from a single
-filename to the full ``features/extraction/parsing/`` package so the Docling
-containment boundary still holds across the new layout.
+one class per file) — import-linter contract C3 was expanded from a single
+file to a specific allow-list of three sibling Docling files so the
+Docling containment boundary still holds across the new layout. The three
+files are this one, ``_real_docling_converter_adapter.py``, and
+``_real_docling_document_adapter.py``.
 
 PyMuPDF (``fitz``) is still imported here because ``_default_pdf_preflight``
 uses it to validate PDF bytes + detect encryption *before* Docling runs.

--- a/apps/backend/app/features/extraction/parsing/docling_document_parser.py
+++ b/apps/backend/app/features/extraction/parsing/docling_document_parser.py
@@ -1,60 +1,25 @@
-"""DoclingDocumentParser: the only file in the repository permitted to use Docling.
+"""DoclingDocumentParser: the public ``DocumentParser`` backed by Docling.
 
-This module implements the `DocumentParser` Protocol from PDFX-E003-F001 against
-the Docling library. Docling is a heavy AI dependency (ONNX runtime, image
-processing, OCR weights) and its import alone is an appreciable chunk of the
-service's cold-start budget. Containing `import docling` to this single file
-keeps the blast radius small and mirrors the architectural contract that
-`import-linter` will enforce in PDFX-E007-F004.
+This file is the parser's public face. The Docling-touching adapters and
+factory live in sibling files (``_real_docling_converter_adapter.py``,
+``_real_docling_document_adapter.py``, ``_flat_docling_text_item.py``); the
+Protocols they implement live in ``_docling_*.py`` / ``pdf_preflight.py``.
+Splitting the file was driven by issue #159 (CLAUDE.md Sacred Rule #1 —
+one class per file) — import-linter contract C3 was widened from a single
+filename to the full ``features/extraction/parsing/`` package so the Docling
+containment boundary still holds across the new layout.
 
-Design summary (load-bearing; do not re-architect without updating the spec):
-
-* The parser is a thin coordinator. It delegates PDF parsing to a Docling
-  `DocumentConverter`, walks the resulting Docling document, and emits our own
-  feature-owned value types (`ParsedDocument`, `TextBlock`, `BoundingBox`).
-* Both the converter factory (which lazy-imports Docling and constructs the
-  pipeline) and the conversion step are synchronous and CPU-bound. `async
-  parse` offloads them together in a single `asyncio.to_thread` call so the
-  FastAPI event loop is never starved during cold start or parsing.
-* The concrete Docling objects are obtained through a `converter_factory`
-  callable injected via the constructor. The default factory performs a
-  *lazy* import of Docling and builds a real `DocumentConverter`; unit tests
-  pass a fake factory and therefore never trigger the real import. This is
-  why module load stays cheap and why unit tests run without Docling being
-  installed locally (Docling becomes a pinned runtime dependency in the
-  sibling feature PDFX-E001-F002).
-* Everything the parser consumes from the converter is duck-typed against
-  small local `_DoclingConverterLike` / `_DoclingDocumentLike` / `_DoclingTextItemLike`
-  Protocols. The real-Docling adapter in `_default_converter_factory` bridges
-  Docling's public types into these Protocols so that `_to_parsed_document`
-  does not need to know anything about Docling's own class hierarchy.
-* Coordinate convention: every `BoundingBox` this parser emits is in PDF page
-  coordinates with origin bottom-left. The local `_DoclingTextItemLike`
-  Protocol requires adapters to expose bottom-left-origin values; the
-  real-Docling adapter performs the translation there if Docling's native
-  convention disagrees (verified empirically during PDFX-E003-F002 integration
-  testing — open question #3 in the feature spec).
-
-Carve-out to CLAUDE.md "one class per file":
-This file holds four classes — `DoclingDocumentParser` plus three private
-adapters (`_RealDoclingConverterAdapter`, `_RealDoclingDocumentAdapter`,
-`_FlatDoclingTextItem`). The adapters cannot live in sibling files because
-every line that reads Docling's real types must stay inside this single file
-to honor the Docling-containment technical constraint (enforced in PDFX-E007-F004
-via `import-linter`). They are module-private (leading underscore), exist only
-to bridge Docling's concrete types into this parser's local `_DoclingXxxLike`
-Protocols, and are never imported from anywhere else in the service.
+PyMuPDF (``fitz``) is still imported here because ``_default_pdf_preflight``
+uses it to validate PDF bytes + detect encryption *before* Docling runs.
+Import-linter contract C4 whitelists this file for pymupdf/fitz.
 """
 
 from __future__ import annotations
 
 import asyncio
 import importlib
-import io
 import logging
-from collections.abc import Callable, Iterable
-from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -65,10 +30,18 @@ from app.exceptions import (
     PdfPasswordProtectedError,
     PdfTooManyPagesError,
 )
+from app.features.extraction.parsing._real_docling_converter_adapter import (
+    DoclingConverterFactory,
+    default_converter_factory,
+)
 from app.features.extraction.parsing.bounding_box import BoundingBox
-from app.features.extraction.parsing.docling_config import DoclingConfig
 from app.features.extraction.parsing.parsed_document import ParsedDocument
 from app.features.extraction.parsing.text_block import TextBlock
+
+if TYPE_CHECKING:
+    from app.features.extraction.parsing._docling_document_like import DoclingDocumentLike
+    from app.features.extraction.parsing.docling_config import DoclingConfig
+    from app.features.extraction.parsing.pdf_preflight import PdfPreflight
 
 _log = structlog.get_logger(__name__)
 
@@ -79,85 +52,17 @@ _log = structlog.get_logger(__name__)
 logging.getLogger("docling").setLevel(logging.WARNING)
 
 
-@runtime_checkable
-class _DoclingTextItemLike(Protocol):
-    """Minimum shape the parser needs from one text-bearing item.
-
-    Adapters expose bounding-box coordinates in PDF page coordinates with the
-    origin at the bottom-left of the page (`y0 <= y1`, with `y` growing
-    upward). Any translation from Docling's native convention lives in the
-    adapter, not here.
-    """
-
-    @property
-    def text(self) -> str: ...
-    @property
-    def page_number(self) -> int: ...
-    @property
-    def bbox_x0(self) -> float: ...
-    @property
-    def bbox_y0(self) -> float: ...
-    @property
-    def bbox_x1(self) -> float: ...
-    @property
-    def bbox_y1(self) -> float: ...
-
-
-@runtime_checkable
-class _DoclingDocumentLike(Protocol):
-    """Minimum shape the parser needs from a Docling document."""
-
-    @property
-    def page_count(self) -> int: ...
-    def iter_text_items(self) -> Iterable[_DoclingTextItemLike]: ...
-
-
-@runtime_checkable
-class _DoclingConverterLike(Protocol):
-    """Minimum shape the parser needs from a Docling converter.
-
-    `convert` accepts the raw PDF bytes and returns a `_DoclingDocumentLike`.
-    Keeping the signature bytes-in / adapter-out means the real Docling
-    factory owns every decision about `DocumentStream` wrapping, and the
-    parser itself stays agnostic.
-    """
-
-    def convert(self, pdf_bytes: bytes) -> _DoclingDocumentLike: ...
-
-
-DoclingConverterFactory = Callable[[DoclingConfig], _DoclingConverterLike]
-
-
-@runtime_checkable
-class PdfPreflight(Protocol):
-    """Validates raw PDF bytes and returns the page count, *before* Docling runs.
-
-    Must raise `PdfInvalidError` for bytes that are not a valid PDF and
-    `PdfPasswordProtectedError` for encrypted PDFs. On success, returns the
-    PDF's page count so the parser can enforce `max_pdf_pages` *before*
-    triggering Docling's full conversion pipeline (which includes OCR and is
-    the expensive cost the page-count cap is meant to defend against —
-    PDFX-E003-F004 technical constraint).
-
-    The default implementation uses PyMuPDF (`fitz`) and is the only place in
-    this file allowed to import `fitz`; unit tests inject a trivial preflight
-    (a plain function satisfies the Protocol structurally) that returns a
-    chosen page count without loading PyMuPDF.
-    """
-
-    def __call__(self, pdf_bytes: bytes) -> int: ...
-
-
 def _default_pdf_preflight(pdf_bytes: bytes) -> int:
     """Validate PDF bytes using PyMuPDF and return page count.
 
     PyMuPDF is lazy-imported so unit tests that inject their own preflight
-    never trigger the `fitz` import path. This containment mirrors the
-    Docling lazy-import strategy used by `_default_converter_factory`.
+    never trigger the ``fitz`` import path. This containment mirrors the
+    Docling lazy-import strategy used by ``default_converter_factory``.
 
-    Raises `PdfInvalidError` on malformed bytes (narrowly catching PyMuPDF's
-    own `FileDataError` / `EmptyFileError` family so unrelated runtime errors
-    like `MemoryError` propagate as 500s — "no silent fallbacks" per spec).
+    Raises ``PdfInvalidError`` on malformed bytes (narrowly catching PyMuPDF's
+    own ``FileDataError`` / ``EmptyFileError`` family so unrelated runtime
+    errors like ``MemoryError`` propagate as 500s — "no silent fallbacks" per
+    spec).
     """
     try:
         pymupdf: Any = importlib.import_module("pymupdf")
@@ -198,250 +103,22 @@ def _default_pdf_preflight(pdf_bytes: bytes) -> int:
         doc.close()
 
 
-def _default_converter_factory(config: DoclingConfig) -> _DoclingConverterLike:
-    """Build a real Docling-backed converter adapter honoring `config`.
-
-    Imports of Docling are lazy (`importlib.import_module`) so:
-
-    1. Module load does not pay the Docling startup cost.
-    2. Unit tests that inject their own `converter_factory` never trigger
-       any Docling code path, even indirectly.
-    3. Environments without Docling installed (e.g., CI before PDFX-E001-F002
-       lands) can still import this module — the ImportError is only raised
-       when someone actually invokes the default factory.
-
-    The returned object conforms to `_DoclingConverterLike` via a small
-    adapter class that wraps Docling's real types and exposes the subset
-    this parser consumes.
-    """
-    try:
-        base_models: Any = importlib.import_module("docling.datamodel.base_models")
-        pipeline_options_mod: Any = importlib.import_module(
-            "docling.datamodel.pipeline_options",
-        )
-        document_converter_mod: Any = importlib.import_module(
-            "docling.document_converter",
-        )
-    except ImportError as exc:
-        _log.error(
-            "parser_dependency_unavailable",
-            dependency="docling",
-            detail=(
-                "docling is not installed; DoclingDocumentParser's default "
-                "converter factory cannot build a real Docling pipeline. "
-                "Docling becomes a pinned runtime dependency in PDFX-E001-F002. "
-                "Until then, unit tests must inject a fake `converter_factory` "
-                "via DoclingDocumentParser(converter_factory=...)."
-            ),
-        )
-        raise PdfParserUnavailableError(dependency="docling") from exc
-
-    input_format: Any = base_models.InputFormat
-    pdf_pipeline_options_cls: Any = pipeline_options_mod.PdfPipelineOptions
-    table_structure_options_cls: Any = pipeline_options_mod.TableStructureOptions
-    table_former_mode: Any = pipeline_options_mod.TableFormerMode
-    # Tesseract via CLI — not EasyOCR. `EasyOcrOptions` triggered
-    # `ImportError: EasyOCR is not installed` on any runtime OCR path because
-    # `easyocr` is not a Docling base dependency (it is a heavy torch/opencv
-    # extra that would undo the CUDA-bloat work tracked in issue #139).
-    # `TesseractCliOcrOptions` shells out to the system `tesseract` binary and
-    # needs no Python bindings — the Dockerfile ships `tesseract-ocr` +
-    # `tesseract-ocr-eng` via apt. See docs/decisions.md ADR-013 and issue #106.
-    tesseract_cli_ocr_options_cls: Any = pipeline_options_mod.TesseractCliOcrOptions
-    document_converter_cls: Any = document_converter_mod.DocumentConverter
-    pdf_format_option_cls: Any = document_converter_mod.PdfFormatOption
-
-    # OCR mode mapping, per PDFX-E003-F002 scope:
-    #   - "off":   do_ocr=False               (skip OCR entirely)
-    #   - "auto":  do_ocr=True, force_full_page_ocr=False
-    #              (Docling auto-detects the absence of a text layer and
-    #               runs OCR on pages that lack one)
-    #   - "force": do_ocr=True, force_full_page_ocr=True
-    #              (OCR every page even when a text layer is present)
-    do_ocr: bool = config.ocr != "off"
-    force_full_page_ocr: bool = config.ocr == "force"
-    mode: Any = (
-        table_former_mode.ACCURATE if config.table_mode == "accurate" else table_former_mode.FAST
-    )
-
-    pipeline_options: Any = pdf_pipeline_options_cls()
-    pipeline_options.do_ocr = do_ocr
-    pipeline_options.do_table_structure = True
-    pipeline_options.table_structure_options = table_structure_options_cls(
-        do_cell_matching=True,
-        mode=mode,
-    )
-    if do_ocr:
-        pipeline_options.ocr_options = tesseract_cli_ocr_options_cls(
-            force_full_page_ocr=force_full_page_ocr,
-        )
-
-    real_converter: Any = document_converter_cls(
-        format_options={
-            input_format.PDF: pdf_format_option_cls(
-                pipeline_options=pipeline_options,
-            ),
-        },
-    )
-    return _RealDoclingConverterAdapter(real_converter)
-
-
-class _RealDoclingConverterAdapter:
-    """Adapts Docling's real `DocumentConverter` to `_DoclingConverterLike`.
-
-    Lives alongside `_default_converter_factory` so all knowledge of Docling's
-    public surface stays in one place. The class methods are the single place
-    where Docling's actual types are read; everywhere else in the parser the
-    code only ever touches our local Protocols.
-    """
-
-    def __init__(self, real_converter: Any) -> None:
-        self._real_converter: Any = real_converter
-
-    def convert(self, pdf_bytes: bytes) -> _DoclingDocumentLike:
-        base_models: Any = importlib.import_module("docling.datamodel.base_models")
-        document_stream_cls: Any = base_models.DocumentStream
-        source: Any = document_stream_cls(name="input.pdf", stream=io.BytesIO(pdf_bytes))
-        result: Any = self._real_converter.convert(source)
-        return _RealDoclingDocumentAdapter(result.document)
-
-
-class _RealDoclingDocumentAdapter:
-    """Adapts Docling's `DoclingDocument` to `_DoclingDocumentLike`.
-
-    Implements `iter_text_items` by walking Docling's text-bearing node items
-    and translating each provenance entry into a simple flat item that
-    exposes bottom-left-origin coordinates. Docling's `BoundingBox` carries a
-    `coord_origin` field (`CoordOrigin.TOPLEFT` or `CoordOrigin.BOTTOMLEFT`) —
-    TOPLEFT is in fact Docling's *default* for most pipeline outputs — so the
-    adapter cannot assume one origin. When a prov bbox reports TOPLEFT
-    coordinates (via `coord_origin`), the adapter flips it to BOTTOMLEFT with
-    `bbox.to_bottom_left_origin(page_height=...)` before unpacking, using the
-    owning page's height from `doc.pages[page_no].size`; boxes already in
-    BOTTOMLEFT are unpacked as-is. This matches our canonical `BoundingBox`
-    convention (origin bottom-left, `y0 <= y1`) and matches PyMuPDF, which
-    the annotator uses downstream without further transformation. (GH issue
-    #133.)
-
-    Reading order (GH issue #150): the traversal delegates to Docling's
-    public `DoclingDocument.iterate_items()` API, which walks the document
-    hierarchy in visual READING order (top-to-bottom, left-to-right per
-    page, respecting column and table structure). Iterating `.texts`
-    directly — as an earlier revision did — returns items in Docling's
-    implementation-dependent STORAGE order, which on multi-column / table-
-    heavy layouts interleaves columns incorrectly and causes downstream
-    span-resolution failures (LangExtract reports `hallucinated_offsets`
-    for values that are in fact present in the source PDF). The fallback
-    to `.texts` is retained only for documents whose shape predates
-    `iterate_items()` (e.g., minimal test doubles in other features' fakes);
-    real Docling-produced documents always expose `iterate_items()`.
-    """
-
-    def __init__(self, docling_document: Any) -> None:
-        self._docling_document: Any = docling_document
-
-    @property
-    def page_count(self) -> int:
-        pages: Any = self._docling_document.pages
-        return len(pages)
-
-    def iter_text_items(self) -> Iterable[_DoclingTextItemLike]:
-        pages: Any = getattr(self._docling_document, "pages", None) or {}
-        for text_item in self._iter_reading_order():
-            item: Any = text_item
-            text_value: Any = getattr(item, "text", None)
-            provs: Any = getattr(item, "prov", None) or []
-            if not text_value or not provs:
-                continue
-            prov: Any = provs[0]
-            page_no: int = int(prov.page_no)
-            raw_bbox: Any = prov.bbox
-            # Docling's `CoordOrigin` is a `str, Enum` whose members stringify
-            # to "CoordOrigin.TOPLEFT" / "CoordOrigin.BOTTOMLEFT" (standard
-            # `Enum.__str__`). Match on `str(origin).endswith("TOPLEFT")` so
-            # the check accepts both the real enum's string form and plain-
-            # string test doubles like "TOPLEFT".
-            origin: Any = getattr(raw_bbox, "coord_origin", None)
-            needs_flip: bool = origin is not None and str(origin).endswith("TOPLEFT")
-            if needs_flip:
-                # Direct indexing: if `page_no` is missing from `doc.pages`,
-                # raise KeyError with the offending page number instead of
-                # silently returning None and blowing up later on `.size`.
-                page: Any = pages[page_no]
-                page_height: float = float(page.size.height)
-                bbox: Any = raw_bbox.to_bottom_left_origin(page_height=page_height)
-            else:
-                bbox = raw_bbox
-            yield _FlatDoclingTextItem(
-                text=str(text_value),
-                page_number=page_no,
-                bbox_x0=float(bbox.l),
-                bbox_y0=float(bbox.b),
-                bbox_x1=float(bbox.r),
-                bbox_y1=float(bbox.t),
-            )
-
-    def _iter_reading_order(self) -> Iterable[Any]:
-        """Yield every Docling node item in visual reading order.
-
-        Uses `DoclingDocument.iterate_items()` when available — this is
-        Docling's public reading-order traversal API (Docling >= 2.x) and
-        yields `(item, level)` tuples for every node in the document tree,
-        in top-to-bottom / left-to-right / per-column visual order. The
-        caller filters down to text-bearing items by testing `.text` and
-        `.prov` attributes, so non-text nodes (tables, pictures) are
-        ignored without a type check against Docling's own class hierarchy
-        — preserving this file's containment of Docling's public types.
-
-        When `iterate_items()` is not available (legacy documents or test
-        doubles that predate this API), the adapter falls back to iterating
-        `.texts` directly, which is Docling's internal storage order. That
-        fallback is imperfect on multi-column layouts but keeps the adapter
-        robust against shape drift. Real Docling-produced documents always
-        expose `iterate_items()`.
-        """
-        iterate_items: Any = getattr(self._docling_document, "iterate_items", None)
-        if callable(iterate_items):
-            iterator: Any = iterate_items()
-            for pair in iterator:
-                item: Any = pair[0]
-                yield item
-            return
-        yield from getattr(self._docling_document, "texts", None) or []
-
-
-@dataclass(frozen=True)
-class _FlatDoclingTextItem:
-    """Plain-data implementation of `_DoclingTextItemLike`.
-
-    The real-Docling adapter yields instances of this class to bridge
-    Docling's own types into the parser's Protocol shape. It is a frozen
-    dataclass so callers cannot mutate a yielded item while the parser is
-    still walking the document.
-    """
-
-    text: str
-    page_number: int
-    bbox_x0: float
-    bbox_y0: float
-    bbox_x1: float
-    bbox_y1: float
-
-
 class DoclingDocumentParser:
-    """Concrete `DocumentParser` backed by Docling.
+    """Concrete ``DocumentParser`` backed by Docling.
 
-    Usage:
+    Usage::
+
         parser = DoclingDocumentParser()  # uses real Docling via lazy import
         parsed = await parser.parse(pdf_bytes, DoclingConfig(...))
 
-    In unit tests, pass a fake `converter_factory` to avoid any real Docling
-    code path:
+    In unit tests, pass a fake ``converter_factory`` to avoid any real Docling
+    code path::
+
         parser = DoclingDocumentParser(converter_factory=fake_factory)
 
-    The parser is stateless: every call to `parse` constructs a fresh
+    The parser is stateless: every call to ``parse`` constructs a fresh
     converter via the factory, converts synchronously on a worker thread,
-    and translates the result into a `ParsedDocument`. No caching, no
+    and translates the result into a ``ParsedDocument``. No caching, no
     shared mutable state between calls.
     """
 
@@ -453,7 +130,7 @@ class DoclingDocumentParser:
         max_pdf_pages: int = 200,
     ) -> None:
         self._converter_factory: DoclingConverterFactory = (
-            converter_factory if converter_factory is not None else _default_converter_factory
+            converter_factory if converter_factory is not None else default_converter_factory
         )
         self._pdf_preflight: PdfPreflight = (
             pdf_preflight if pdf_preflight is not None else _default_pdf_preflight
@@ -488,7 +165,7 @@ class DoclingDocumentParser:
                 actual=preflight_page_count,
             )
 
-        def _build_and_convert() -> _DoclingDocumentLike:
+        def _build_and_convert() -> DoclingDocumentLike:
             converter = self._converter_factory(docling_config)
             return converter.convert(pdf_bytes)
 
@@ -502,7 +179,7 @@ class DoclingDocumentParser:
         return parsed
 
     @staticmethod
-    def _to_parsed_document(document: _DoclingDocumentLike) -> ParsedDocument:
+    def _to_parsed_document(document: DoclingDocumentLike) -> ParsedDocument:
         blocks: list[TextBlock] = []
         per_page_index: dict[int, int] = {}
         for item in document.iter_text_items():

--- a/apps/backend/app/features/extraction/parsing/pdf_preflight.py
+++ b/apps/backend/app/features/extraction/parsing/pdf_preflight.py
@@ -1,0 +1,25 @@
+"""Public Protocol for the PDF preflight step used by ``DoclingDocumentParser``."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PdfPreflight(Protocol):
+    """Validates raw PDF bytes and returns the page count, *before* Docling runs.
+
+    Must raise ``PdfInvalidError`` for bytes that are not a valid PDF and
+    ``PdfPasswordProtectedError`` for encrypted PDFs. On success, returns the
+    PDF's page count so the parser can enforce ``max_pdf_pages`` *before*
+    triggering Docling's full conversion pipeline (which includes OCR and is
+    the expensive cost the page-count cap is meant to defend against —
+    PDFX-E003-F004 technical constraint).
+
+    The default implementation (``_default_pdf_preflight`` in
+    ``docling_document_parser.py``) uses PyMuPDF (``fitz``); unit tests inject
+    a trivial preflight (a plain function satisfies the Protocol structurally)
+    that returns a chosen page count without loading PyMuPDF.
+    """
+
+    def __call__(self, pdf_bytes: bytes) -> int: ...

--- a/apps/backend/architecture/import-linter-contracts.ini
+++ b/apps/backend/architecture/import-linter-contracts.ini
@@ -176,17 +176,29 @@ forbidden_modules =
     app.features.extraction.skills
 
 # ═════════════════════════════════════════════════════════════════════════
-# C3 - Docling containment (PDFX-E007-F004).
+# C3 - Docling containment (PDFX-E007-F004, issue #159 refactor).
 # Docling pulls a heavy ML runtime (torch, torchvision, transformers).
-# Containment to a single file keeps the rest of the codebase cheap to
-# import and ensures a future parser swap touches one file, not dozens.
-# The only file permitted to reach into docling is
-# `parsing/docling_document_parser.py`. Today the parser uses lazy
-# `importlib.import_module` instead of a static `import docling`, so
-# import-linter sees no edge yet. The ignore_imports carve-out is
-# proactive: when someone switches to a static import, the contract
-# stays green. Dynamic import containment is enforced by the AST-scan
-# test in `test_dynamic_import_containment.py`, not by import-linter.
+# Containment to a small, named set of files keeps the rest of the codebase
+# cheap to import and ensures a future parser swap touches a handful of
+# files in one package, not dozens across the service.
+#
+# The containment boundary is the `parsing/` package, with three files
+# that are permitted to reach Docling types:
+#   1. `parsing/_real_docling_converter_adapter.py` — the lazy-importer
+#      that builds the real `DocumentConverter` and the adapter class
+#      that wraps it.
+#   2. `parsing/_real_docling_document_adapter.py` — the wrapper around
+#      `DoclingDocument` that presents `DoclingDocumentLike`.
+#   3. `parsing/docling_document_parser.py` — the public coordinator
+#      class and the `_default_pdf_preflight` function (the latter
+#      touches pymupdf, NOT docling — see C4).
+#
+# Today the adapters use lazy `importlib.import_module` instead of a
+# static `import docling`, so import-linter sees no edge yet. The
+# ignore_imports carve-outs are proactive: when someone switches to a
+# static import, the contract stays green. Dynamic import containment is
+# enforced by the AST-scan test in `test_dynamic_import_containment.py`,
+# not by import-linter.
 #
 # source_modules = app (not just app.features.extraction) so that
 # app.api, app.core, and every other module outside the feature are
@@ -194,7 +206,7 @@ forbidden_modules =
 # ═════════════════════════════════════════════════════════════════════════
 
 [importlinter:contract:c3-docling-containment]
-name = C3: docling may only be imported in parsing/docling_document_parser
+name = C3: docling may only be imported in parsing/_real_docling_*_adapter or docling_document_parser
 type = forbidden
 source_modules =
     app
@@ -202,6 +214,8 @@ forbidden_modules =
     docling
 ignore_imports =
     app.features.extraction.parsing.docling_document_parser -> docling
+    app.features.extraction.parsing._real_docling_converter_adapter -> docling
+    app.features.extraction.parsing._real_docling_document_adapter -> docling
 unmatched_ignore_imports_alerting = warn
 
 # ═════════════════════════════════════════════════════════════════════════

--- a/apps/backend/tests/unit/architecture/test_dynamic_import_containment.py
+++ b/apps/backend/tests/unit/architecture/test_dynamic_import_containment.py
@@ -30,7 +30,15 @@ _APP_ROOT: Final[Path] = BACKEND_DIR / "app"
 _EXTRACTION_ROOT: Final[Path] = _APP_ROOT / "features" / "extraction"
 
 _CONTAINED_PACKAGES: Final[dict[str, frozenset[str]]] = {
-    "docling": frozenset({"docling_document_parser.py"}),
+    # Docling containment expanded from a single file to the set of
+    # parsing/* files introduced by the issue #159 refactor.
+    "docling": frozenset(
+        {
+            "docling_document_parser.py",
+            "_real_docling_converter_adapter.py",
+            "_real_docling_document_adapter.py",
+        },
+    ),
     "pymupdf": frozenset({"pdf_annotator.py", "docling_document_parser.py"}),
     "fitz": frozenset({"pdf_annotator.py", "docling_document_parser.py"}),
     "langextract": frozenset({"extraction_engine.py", "ollama_gemma_provider.py"}),

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -704,10 +704,12 @@ def test_only_docling_adapter_files_reference_docling() -> None:
         parsing_dir / "_real_docling_document_adapter.py",
     }
 
-    # Only keep expected entries that actually touch `docling` at import time.
-    # Files in the expected set that don't touch `docling` (e.g. the document
-    # adapter only receives `Any`-typed objects) are fine — we only assert
-    # no EXTRA files appear.
+    # Allow the expected files to reference `docling` but require that no
+    # other file does — this is a no-extras guarantee, not a filter. Expected
+    # files that don't touch `docling` (e.g. the document adapter only
+    # receives `Any`-typed objects, so its source has no `docling.*` string
+    # reachable by AST walk) are fine; the invariant is that `matches` has
+    # no file outside the expected allow-list.
     extra = matches - expected
     assert extra == set(), (
         f"docling imports must be confined to {sorted(expected)}, extra: {sorted(extra)}"

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -19,12 +19,19 @@ from typing import Any
 
 import pytest
 
+from app.features.extraction.parsing import (
+    _real_docling_converter_adapter as converter_adapter_mod,
+)
 from app.features.extraction.parsing import docling_document_parser as parser_mod
+from app.features.extraction.parsing._real_docling_converter_adapter import (
+    default_converter_factory,
+)
+from app.features.extraction.parsing._real_docling_document_adapter import (
+    RealDoclingDocumentAdapter,
+)
 from app.features.extraction.parsing.docling_config import DoclingConfig
 from app.features.extraction.parsing.docling_document_parser import (
     DoclingDocumentParser,
-    _default_converter_factory,
-    _RealDoclingDocumentAdapter,
 )
 from app.features.extraction.parsing.document_parser import DocumentParser
 from app.features.extraction.parsing.parsed_document import ParsedDocument
@@ -536,7 +543,7 @@ def test_default_factory_auto_mode_enables_ocr_without_forcing_full_page(
 ) -> None:
     _install_fake_docling_modules(monkeypatch)
 
-    _default_converter_factory(DoclingConfig(ocr="auto", table_mode="fast"))
+    default_converter_factory(DoclingConfig(ocr="auto", table_mode="fast"))
     pipeline_options = _extract_pipeline_options()
 
     assert pipeline_options.do_ocr is True
@@ -550,7 +557,7 @@ def test_default_factory_force_mode_sets_force_full_page_ocr(
 ) -> None:
     _install_fake_docling_modules(monkeypatch)
 
-    _default_converter_factory(DoclingConfig(ocr="force", table_mode="accurate"))
+    default_converter_factory(DoclingConfig(ocr="force", table_mode="accurate"))
     pipeline_options = _extract_pipeline_options()
 
     assert pipeline_options.do_ocr is True
@@ -564,7 +571,7 @@ def test_default_factory_off_mode_disables_ocr_and_skips_ocr_options(
 ) -> None:
     _install_fake_docling_modules(monkeypatch)
 
-    _default_converter_factory(DoclingConfig(ocr="off", table_mode="fast"))
+    default_converter_factory(DoclingConfig(ocr="off", table_mode="fast"))
     pipeline_options = _extract_pipeline_options()
 
     assert pipeline_options.do_ocr is False
@@ -577,7 +584,7 @@ def test_default_factory_raises_domain_error_when_docling_not_installed(
     """Missing Docling must surface as a DomainError, not a generic RuntimeError.
 
     Regression guard for issue #153: CLAUDE.md forbids `RuntimeError` inside the
-    extraction pipeline. The lazy-import fallback in `_default_converter_factory`
+    extraction pipeline. The lazy-import fallback in `default_converter_factory`
     previously raised `RuntimeError`, which surfaced as an opaque 500 instead of
     a structured `PdfParserUnavailableError` response.
     """
@@ -592,10 +599,10 @@ def test_default_factory_raises_domain_error_when_docling_not_installed(
             raise ImportError(name)
         return real_import_module(name, *args, **kwargs)
 
-    monkeypatch.setattr(parser_mod.importlib, "import_module", failing_import)
+    monkeypatch.setattr(converter_adapter_mod.importlib, "import_module", failing_import)
 
     with pytest.raises(PdfParserUnavailableError) as excinfo:
-        _default_converter_factory(DoclingConfig(ocr="auto", table_mode="fast"))
+        default_converter_factory(DoclingConfig(ocr="auto", table_mode="fast"))
 
     assert excinfo.value.params is not None
     assert excinfo.value.params.model_dump() == {"dependency": "docling"}
@@ -685,21 +692,34 @@ def _collect_files_referencing_docling() -> set[Path]:
     return matches
 
 
-def test_only_docling_document_parser_references_docling() -> None:
+def test_only_docling_adapter_files_reference_docling() -> None:
     matches = _collect_files_referencing_docling()
-    expected = _EXTRACTION_ROOT / "parsing" / "docling_document_parser.py"
+    # Issue #159 split the monolithic parser into multiple single-class files
+    # inside the parsing/ package. The Docling containment boundary is now the
+    # set of files below; any other file importing `docling` is a regression.
+    parsing_dir = _EXTRACTION_ROOT / "parsing"
+    expected = {
+        parsing_dir / "docling_document_parser.py",
+        parsing_dir / "_real_docling_converter_adapter.py",
+        parsing_dir / "_real_docling_document_adapter.py",
+    }
 
-    assert matches == {expected}, (
-        f"docling imports must be confined to {expected}, found: {sorted(matches)}"
+    # Only keep expected entries that actually touch `docling` at import time.
+    # Files in the expected set that don't touch `docling` (e.g. the document
+    # adapter only receives `Any`-typed objects) are fine — we only assert
+    # no EXTRA files appear.
+    extra = matches - expected
+    assert extra == set(), (
+        f"docling imports must be confined to {sorted(expected)}, extra: {sorted(extra)}"
     )
 
 
 # ---------------------------------------------------------------------------
-# Coordinate-origin normalization in _RealDoclingDocumentAdapter
+# Coordinate-origin normalization in RealDoclingDocumentAdapter
 # (regression for GH issue #133)
 #
 # Docling's `CoordOrigin` defaults to TOPLEFT. The adapter must normalize any
-# TOPLEFT bbox to BOTTOMLEFT before yielding a `_FlatDoclingTextItem`, because
+# TOPLEFT bbox to BOTTOMLEFT before yielding a `FlatDoclingTextItem`, because
 # downstream `BoundingBox` enforces `y0 <= y1` in a BOTTOMLEFT convention. The
 # fakes below mirror the shape of Docling's real types (`prov.bbox.l/.t/.r/.b/
 # .coord_origin` with a `to_bottom_left_origin(page_height=...)` method) so the
@@ -777,7 +797,7 @@ class _FakeDoclingPageItem:
 
 @dataclass
 class _FakeRawDoclingDocument:
-    """Fake shape matching what `_RealDoclingDocumentAdapter` reads from a live
+    """Fake shape matching what `RealDoclingDocumentAdapter` reads from a live
     DoclingDocument: `.texts` (list of text nodes in STORAGE order), `.pages`
     (dict keyed by page_no to a PageItem carrying `.size.height`), and
     `iterate_items()` which yields `(item, level)` tuples in READING order
@@ -803,7 +823,7 @@ def test_adapter_normalizes_top_left_origin_bbox_to_bottom_left() -> None:
     """Issue #133: a TOPLEFT-origin prov bbox must emerge as BOTTOMLEFT coords.
 
     Given a 1000-pt-tall page with a TOPLEFT bbox (t=100, b=300), the adapter
-    must y-flip against page height so the `_FlatDoclingTextItem` reports
+    must y-flip against page height so the `FlatDoclingTextItem` reports
     `bbox_y0 < bbox_y1` (900, 700 is invalid — we want 700, 900 in the item).
     """
     raw_doc = _FakeRawDoclingDocument(
@@ -826,7 +846,7 @@ def test_adapter_normalizes_top_left_origin_bbox_to_bottom_left() -> None:
         ],
         pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     items = list(adapter.iter_text_items())
 
@@ -865,7 +885,7 @@ def test_adapter_passes_through_bottom_left_origin_bbox_unchanged() -> None:
         ],
         pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     items = list(adapter.iter_text_items())
 
@@ -906,7 +926,7 @@ def test_adapter_normalization_yields_valid_bounding_box_invariant() -> None:
         ],
         pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     items = list(adapter.iter_text_items())
 
@@ -951,7 +971,7 @@ def test_adapter_raises_key_error_when_prov_page_no_missing_from_pages() -> None
         ],
         pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     with pytest.raises(KeyError) as excinfo:
         list(adapter.iter_text_items())
@@ -959,7 +979,7 @@ def test_adapter_raises_key_error_when_prov_page_no_missing_from_pages() -> None
 
 
 # ---------------------------------------------------------------------------
-# Reading-order traversal in _RealDoclingDocumentAdapter
+# Reading-order traversal in RealDoclingDocumentAdapter
 # (regression for GH issue #150)
 #
 # Docling's `document.texts` is an implementation-dependent STORAGE order that
@@ -1043,7 +1063,7 @@ def test_iter_text_items_returns_reading_order_for_multi_column_layout() -> None
         # `iterate_items()` carries READING order (interleaved across columns).
         iterate_order=[a_top, b_top, a_bottom, b_bottom],
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     items = list(adapter.iter_text_items())
 
@@ -1081,7 +1101,7 @@ def test_iter_text_items_uses_iterate_items_and_ignores_texts_order() -> None:
         pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
         iterate_order=[node_one, node_two],
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     items = list(adapter.iter_text_items())
 
@@ -1116,7 +1136,7 @@ def test_iter_text_items_falls_back_to_texts_when_iterate_items_missing() -> Non
         texts=[node],
         pages={1: _FakeDoclingPageItem(size=_FakeDoclingPageSize(height=1000.0))},
     )
-    adapter = _RealDoclingDocumentAdapter(raw_doc)
+    adapter = RealDoclingDocumentAdapter(raw_doc)
 
     items = list(adapter.iter_text_items())
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,15 @@ entire app, not just the extraction feature) so that `app.api`, `app.core`,
 and every other module are also forbidden from importing Docling, PyMuPDF,
 LangExtract, or httpx outside the designated files.
 
+C3 (Docling) permits three files inside `app/features/extraction/parsing/`:
+`docling_document_parser.py` (the public coordinator),
+`_real_docling_converter_adapter.py` (lazy-imports Docling to build the real
+`DocumentConverter`), and `_real_docling_document_adapter.py` (wraps
+`DoclingDocument`). The boundary expanded from a single filename to the
+package after issue #159 split the parser to honor CLAUDE.md's
+one-class-per-file rule; every Docling-touching line still lives behind
+exactly these three allow-listed files.
+
 C1 (feature independence) is an `independence` contract with a single module,
 which is vacuously true in import-linter. The real enforcement is the AST
 scan in `test_dynamic_import_containment.py::test_extraction_does_not_import_from_sibling_features`.


### PR DESCRIPTION
## Summary
- Honors CLAUDE.md Sacred Rule #1 (one class per file) by splitting two files that had accumulated multi-class violations.
- `app/api/health_router.py`: two OpenAPI response schemas moved into `app/api/schemas/{ready_response,not_ready_response}.py`.
- `app/features/extraction/parsing/docling_document_parser.py`: eight classes + one function + one type alias split into seven new sibling files inside the `parsing/` package.
- Import-linter contract C3 (Docling containment) updated from "one filename" to "three filenames inside one package" — boundary still holds.
- Behavior unchanged. Pure mechanical refactor + contract-tracking update.

## Split layout

### Health-router schemas (new dir `apps/backend/app/api/schemas/`)
- `ready_response.py` — `ReadyResponse`
- `not_ready_response.py` — `NotReadyResponse`

### Docling parser (inside `apps/backend/app/features/extraction/parsing/`)
- `_docling_text_item_like.py` → `DoclingTextItemLike` Protocol
- `_docling_document_like.py` → `DoclingDocumentLike` Protocol
- `_docling_converter_like.py` → `DoclingConverterLike` Protocol
- `pdf_preflight.py` → `PdfPreflight` public Protocol
- `_flat_docling_text_item.py` → `FlatDoclingTextItem` frozen dataclass
- `_real_docling_document_adapter.py` → `RealDoclingDocumentAdapter`
- `_real_docling_converter_adapter.py` → `RealDoclingConverterAdapter` + `default_converter_factory` + `DoclingConverterFactory` alias
- `docling_document_parser.py` (rewritten) → `DoclingDocumentParser` + `_default_pdf_preflight`

### Class renames
Dropped leading underscore on cross-module types — the privacy signal is now in the underscore-prefixed *filename*, not the symbol name, since pyright strict treats leading-underscore names as module-private across imports. `_default_converter_factory` → `default_converter_factory` for the same reason.

## C3 import-linter contract
Previously allowed `docling` imports in exactly one file. Now allows them in three files, all inside `parsing/`:
- `docling_document_parser.py`
- `_real_docling_converter_adapter.py`
- `_real_docling_document_adapter.py`

The `ignore_imports` list and the contract name/description are both updated. The AST-scan test `_CONTAINED_PACKAGES["docling"]` is extended to the same three filenames, and the sibling `test_only_docling_*_reference_docling` assertion is widened and renamed.

## Test plan
- [x] `task check` — full sweep green: ruff, pyright strict, import-linter (all 11 contracts including the updated C3), skills-validate, unit tests, integration, contract, error-contracts.
- [x] All existing `DoclingDocumentParser` tests (including the 5 real-Docling integration tests under `@pytest.mark.slow`) still pass against the new layout.
- [x] Health-router tests still pass.
- [x] Docs/architecture.md C3 paragraph rewritten to describe the new three-file boundary.

Closes #159