### PR TITLE
fix(parser): swap EasyOCR default for Tesseract CLI (closes #106)

### DIFF
--- a/apps/backend/app/features/extraction/parsing/docling_document_parser.py
+++ b/apps/backend/app/features/extraction/parsing/docling_document_parser.py
@@ -240,7 +240,14 @@ def _default_converter_factory(config: DoclingConfig) -> _DoclingConverterLike:
     pdf_pipeline_options_cls: Any = pipeline_options_mod.PdfPipelineOptions
     table_structure_options_cls: Any = pipeline_options_mod.TableStructureOptions
     table_former_mode: Any = pipeline_options_mod.TableFormerMode
-    easy_ocr_options_cls: Any = pipeline_options_mod.EasyOcrOptions
+    # Tesseract via CLI — not EasyOCR. `EasyOcrOptions` triggered
+    # `ImportError: EasyOCR is not installed` on any runtime OCR path because
+    # `easyocr` is not a Docling base dependency (it is a heavy torch/opencv
+    # extra that would undo the CUDA-bloat work tracked in issue #139).
+    # `TesseractCliOcrOptions` shells out to the system `tesseract` binary and
+    # needs no Python bindings — the Dockerfile ships `tesseract-ocr` +
+    # `tesseract-ocr-eng` via apt. See docs/decisions.md ADR-013 and issue #106.
+    tesseract_cli_ocr_options_cls: Any = pipeline_options_mod.TesseractCliOcrOptions
     document_converter_cls: Any = document_converter_mod.DocumentConverter
     pdf_format_option_cls: Any = document_converter_mod.PdfFormatOption
 
@@ -265,7 +272,7 @@ def _default_converter_factory(config: DoclingConfig) -> _DoclingConverterLike:
         mode=mode,
     )
     if do_ocr:
-        pipeline_options.ocr_options = easy_ocr_options_cls(
+        pipeline_options.ocr_options = tesseract_cli_ocr_options_cls(
             force_full_page_ocr=force_full_page_ocr,
         )
 

--- a/apps/backend/tests/integration/features/extraction/parsing/test_docling_document_parser_integration.py
+++ b/apps/backend/tests/integration/features/extraction/parsing/test_docling_document_parser_integration.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
+import shutil
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,13 @@ pytestmark = pytest.mark.slow
 
 _DOCLING_AVAILABLE = importlib.util.find_spec("docling") is not None
 _PYMUPDF_AVAILABLE = importlib.util.find_spec("pymupdf") is not None
+# Docling's `TesseractCliOcrOptions` path shells out to the `tesseract` binary
+# at OCR time (issue #106, ADR-013). When it is not on `PATH`, Docling raises
+# `RuntimeError: Tesseract is not available, aborting`. Skipping here matches
+# the existing pattern for other optional runtime prerequisites (`docling`,
+# `pymupdf`, fixture PDFs) so `task test:slow` on a dev machine without
+# `brew install tesseract` reports a clear skip reason instead of a failure.
+_TESSERACT_AVAILABLE = shutil.which("tesseract") is not None
 # parents: [0]=parsing [1]=extraction [2]=features [3]=integration [4]=tests
 # so parents[4] is apps/backend/tests, which is where fixtures live.
 _FIXTURES_DIR = Path(__file__).resolve().parents[4] / "fixtures" / "pdfs"
@@ -44,10 +52,17 @@ _SKIP_REASON_DOCLING = (
     "PDFX-E001-F002 pins docling as a runtime dependency."
 )
 _SKIP_REASON_FIXTURE = "PDF fixture not committed yet; add it to apps/backend/tests/fixtures/pdfs/"
+_SKIP_REASON_TESSERACT = (
+    "tesseract binary not on PATH; install it (`brew install tesseract` on "
+    "macOS, `apt-get install tesseract-ocr tesseract-ocr-eng` on Debian) to "
+    "run this slow test. The Docker runtime installs it automatically — see "
+    "infra/docker/backend.Dockerfile and docs/decisions.md ADR-013."
+)
 
 
 @pytest.mark.skipif(not _DOCLING_AVAILABLE, reason=_SKIP_REASON_DOCLING)
 @pytest.mark.skipif(not _NATIVE_FIXTURE.exists(), reason=_SKIP_REASON_FIXTURE)
+@pytest.mark.skipif(not _TESSERACT_AVAILABLE, reason=_SKIP_REASON_TESSERACT)
 @pytest.mark.asyncio
 async def test_real_docling_parses_native_two_page_fixture() -> None:
     from app.features.extraction.parsing.docling_config import DoclingConfig
@@ -66,6 +81,7 @@ async def test_real_docling_parses_native_two_page_fixture() -> None:
 
 @pytest.mark.skipif(not _DOCLING_AVAILABLE, reason=_SKIP_REASON_DOCLING)
 @pytest.mark.skipif(not _SCANNED_FIXTURE.exists(), reason=_SKIP_REASON_FIXTURE)
+@pytest.mark.skipif(not _TESSERACT_AVAILABLE, reason=_SKIP_REASON_TESSERACT)
 @pytest.mark.asyncio
 async def test_real_docling_ocrs_scanned_fixture() -> None:
     from app.features.extraction.parsing.docling_config import DoclingConfig
@@ -84,6 +100,7 @@ async def test_real_docling_ocrs_scanned_fixture() -> None:
 @pytest.mark.skipif(not _DOCLING_AVAILABLE, reason=_SKIP_REASON_DOCLING)
 @pytest.mark.skipif(not _PYMUPDF_AVAILABLE, reason="pymupdf not installed")
 @pytest.mark.skipif(not _NATIVE_FIXTURE.exists(), reason=_SKIP_REASON_FIXTURE)
+@pytest.mark.skipif(not _TESSERACT_AVAILABLE, reason=_SKIP_REASON_TESSERACT)
 @pytest.mark.asyncio
 async def test_real_docling_bboxes_agree_with_pymupdf_on_native_fixture() -> None:
     """Empirically verify that Docling's bbox output lands inside PyMuPDF page rects.
@@ -125,6 +142,7 @@ async def test_real_docling_bboxes_agree_with_pymupdf_on_native_fixture() -> Non
 
 @pytest.mark.skipif(not _DOCLING_AVAILABLE, reason=_SKIP_REASON_DOCLING)
 @pytest.mark.skipif(not _NATIVE_FIXTURE.exists(), reason=_SKIP_REASON_FIXTURE)
+@pytest.mark.skipif(not _TESSERACT_AVAILABLE, reason=_SKIP_REASON_TESSERACT)
 @pytest.mark.asyncio
 async def test_real_docling_parse_does_not_starve_event_loop() -> None:
     import asyncio
@@ -160,6 +178,7 @@ async def test_real_docling_parse_does_not_starve_event_loop() -> None:
 
 @pytest.mark.skipif(not _DOCLING_AVAILABLE, reason=_SKIP_REASON_DOCLING)
 @pytest.mark.skipif(not _NATIVE_FIXTURE.exists(), reason=_SKIP_REASON_FIXTURE)
+@pytest.mark.skipif(not _TESSERACT_AVAILABLE, reason=_SKIP_REASON_TESSERACT)
 @pytest.mark.asyncio
 async def test_real_docling_repeat_parse_is_equivalent() -> None:
     from app.features.extraction.parsing.docling_config import DoclingConfig

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -466,7 +466,7 @@ class _FakeTableStructureOptions:
         self.mode = mode
 
 
-class _FakeEasyOcrOptions:
+class _FakeTesseractCliOcrOptions:
     def __init__(self, *, force_full_page_ocr: bool) -> None:
         self.force_full_page_ocr = force_full_page_ocr
 
@@ -508,7 +508,7 @@ def _install_fake_docling_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     pipeline_options_mod.PdfPipelineOptions = _FakePipelineOptions  # type: ignore[attr-defined]
     pipeline_options_mod.TableStructureOptions = _FakeTableStructureOptions  # type: ignore[attr-defined]
     pipeline_options_mod.TableFormerMode = _FakeTableFormerMode  # type: ignore[attr-defined]
-    pipeline_options_mod.EasyOcrOptions = _FakeEasyOcrOptions  # type: ignore[attr-defined]
+    pipeline_options_mod.TesseractCliOcrOptions = _FakeTesseractCliOcrOptions  # type: ignore[attr-defined]
 
     document_converter_mod = type(sys)("docling.document_converter")
     document_converter_mod.DocumentConverter = _FakeRealDocumentConverter  # type: ignore[attr-defined]
@@ -540,7 +540,7 @@ def test_default_factory_auto_mode_enables_ocr_without_forcing_full_page(
     pipeline_options = _extract_pipeline_options()
 
     assert pipeline_options.do_ocr is True
-    assert isinstance(pipeline_options.ocr_options, _FakeEasyOcrOptions)
+    assert isinstance(pipeline_options.ocr_options, _FakeTesseractCliOcrOptions)
     assert pipeline_options.ocr_options.force_full_page_ocr is False
     assert pipeline_options.table_structure_options.mode == _FakeTableFormerMode.FAST
 
@@ -554,7 +554,7 @@ def test_default_factory_force_mode_sets_force_full_page_ocr(
     pipeline_options = _extract_pipeline_options()
 
     assert pipeline_options.do_ocr is True
-    assert isinstance(pipeline_options.ocr_options, _FakeEasyOcrOptions)
+    assert isinstance(pipeline_options.ocr_options, _FakeTesseractCliOcrOptions)
     assert pipeline_options.ocr_options.force_full_page_ocr is True
     assert pipeline_options.table_structure_options.mode == _FakeTableFormerMode.ACCURATE
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -166,6 +166,59 @@ index — is pinned by
 so a future `uv lock` regen or docling metadata change that reintroduces them
 trips CI rather than bloating the image silently. See issue #139.
 
+## ADR-013: Tesseract CLI as the Default OCR Engine (2026-04-17)
+
+**Status:** Accepted
+**Date:** 2026-04-17
+
+`DoclingDocumentParser._default_converter_factory` configures Docling's
+`TesseractCliOcrOptions` whenever OCR is enabled (the `auto` default, plus
+`force` mode). Previously it configured `EasyOcrOptions`, which crashed every
+real OCR path with `ImportError: EasyOCR is not installed` because `easyocr`
+is not a Docling base dependency (see issue #106). The runtime stage of
+[`infra/docker/backend.Dockerfile`](../infra/docker/backend.Dockerfile) now
+installs `tesseract-ocr` and `tesseract-ocr-eng` via apt so the CLI variant
+finds its binary and English language pack out of the box.
+
+**Rationale:** The service needs a working OCR engine on every deployment; it
+does not need the biggest or most multilingual one. Tesseract via the CLI has
+the smallest footprint of any complete option:
+
+- **Not EasyOCR.** EasyOCR would re-introduce ~1 GB of torch-vision / opencv
+  extras and first-run model downloads on top of the CPU torch wheels already
+  pinned, undoing the Docker image-size work tracked by ADR-012 and issue #139.
+- **Not `TesseractOcrOptions` (Python bindings).** The bindings variant needs
+  `tesserocr`, which pip-builds against `libtesseract-dev` / `libleptonica-dev`
+  / `pkg-config` at install time. That is more system packages, a longer build,
+  and a C-compile step the slim Python base image does not carry by default.
+  The CLI variant only needs the `tesseract` executable and its language
+  data — two apt packages, no build step.
+- **Not RapidOCR.** RapidOCR is genuinely lightweight, but it still ships a
+  set of ONNX models and currently depends on a backend choice
+  (`onnxruntime` / `openvino` / `paddle` / `torch`) we would have to own. The
+  CLI path has one moving part.
+- **Conditional fallback (wrap EasyOCR in try/except ImportError).** Rejected
+  as the permanent shape. It keeps a broken default in the tree, defers the
+  decision to runtime, and makes the "which engine actually runs here?"
+  question context-dependent. One deterministic default is simpler.
+
+**Image size.** The Debian-slim-based runtime layer grows by roughly
+`tesseract-ocr` (~15 MB) + `tesseract-ocr-eng` (~5 MB) + apt cache overhead,
+net of the `rm -rf /var/lib/apt/lists/*` cleanup. This is an order of magnitude
+smaller than the EasyOCR alternative and does not touch the builder stage.
+
+**Adding languages.** OCR on non-English PDFs needs the matching
+`tesseract-ocr-<lang>` package and, if the system path differs, a
+`TESSDATA_PREFIX` env var. Those are runtime-stage Dockerfile edits — the
+parser configuration does not change per language today because
+`DoclingConfig` doesn't expose a language knob.
+
+**Verification.** Integration tests in
+`apps/backend/tests/integration/features/extraction/parsing/test_docling_document_parser_integration.py`
+(opt-in via `task test:slow`) exercise the full Docling + Tesseract path
+against fixture PDFs and replaced the EasyOCR-failure blocker that motivated
+this ADR.
+
 ## Superseded ADRs
 
 - **ADR-002 (offset pagination)** — superseded. There are no paginated

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -38,6 +38,21 @@ RUN uv sync --frozen --no-dev
 # stage's `FROM` line — keeping builder and runtime pinned to the same digest.
 FROM ${PYTHON_IMAGE}
 
+# Install Tesseract OCR so Docling's `TesseractCliOcrOptions` path can shell out
+# to the `tesseract` binary at OCR time (see docs/decisions.md ADR-013 and
+# issue #106). The CLI variant is deliberately chosen over `TesseractOcrOptions`
+# (which requires `tesserocr` Python bindings built against
+# libtesseract-dev/libleptonica-dev) and over EasyOCR (which pulls ~1 GB of
+# torch/opencv extras on top of the CPU torch wheels already pinned — undoing
+# the image-size work in issue #139). `tesseract-ocr-eng` supplies the English
+# language data; add more `tesseract-ocr-<lang>` packages here if the service
+# ever needs to OCR non-English PDFs, and set `TESSDATA_PREFIX` accordingly.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+    && rm -rf /var/lib/apt/lists/*
+
 # Run as non-root user
 RUN groupadd --gid 1000 appuser && \
     useradd --uid 1000 --gid appuser --create-home appuser


### PR DESCRIPTION
## Summary
- Swaps the OCR engine in `_default_converter_factory` from `EasyOcrOptions` to `TesseractCliOcrOptions` so the real OCR path no longer crashes with `ImportError: EasyOCR is not installed`.
- Runtime Dockerfile now installs `tesseract-ocr` + `tesseract-ocr-eng` (~20 MB net). No new Python deps, no lockfile churn.
- Slow integration tests gain a `shutil.which("tesseract")` skipif so dev boxes without the binary skip cleanly instead of erroring.

## Why not the other options
- **EasyOCR (Option a)** would re-add ~1 GB of torch/opencv extras to `uv.lock`, undoing the CUDA-bloat work from #139 (ADR-012).
- **TesseractOcrOptions (Python bindings)** requires `tesserocr` + `libtesseract-dev` + `libleptonica-dev` + `pkg-config` at build time. CLI variant only needs the system binary, which is a drop-in runtime layer.
- **Conditional import fallback** leaves the broken default in-tree and defers the decision to runtime — operators would keep hitting `ImportError` during testing.

Full rationale and rejected-alternative analysis in the new `docs/decisions.md` ADR-013.

## Test plan
- [x] `task check` — full sweep green.
- [x] Integration slow tests: with `tesseract` installed via `brew install tesseract`, the 5 real-Docling tests pass. Without it, they skip cleanly with a clear reason.
- [x] No change to unit tests that inject fake factories — their OCR-options mocks were renamed to match the new class.

Closes #106