### PR TITLE
fix(extraction): narrow timeout catch to asyncio.timeout() expiries

### DIFF
--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -138,10 +138,27 @@ class ExtractionService:
         skill_version: str,
         output_mode: OutputMode,
     ) -> ExtractionResult:
-        """Execute the pipeline under the end-to-end timeout budget."""
+        """Execute the pipeline under the end-to-end timeout budget.
+
+        ``asyncio.timeout`` is bound to ``budget_cm`` so we can distinguish
+        "the outer timeout expired" from "a downstream library raised a
+        built-in ``TimeoutError`` for unrelated reasons" (e.g. an internal
+        socket or sub-operation timeout that bubbles up before the pipeline
+        budget is exhausted). ``budget_cm.expired()`` is True **only** when
+        the raised ``TimeoutError`` was caused by this specific
+        ``asyncio.timeout(...)`` firing — so we only remap in that case.
+        Unrelated ``TimeoutError`` instances propagate as-is and the
+        middleware exception handler surfaces them via the default mapping
+        (rather than a misleading 504 with a fake ``budget_seconds``).
+        """
         t0 = time.monotonic()
+        # Bind the Timeout context manager to a local before entering ``async
+        # with`` so the ``except TimeoutError`` branch below can query
+        # ``budget_cm.expired()`` even though the exception unbinds the
+        # ``as`` target in the suite's local scope.
+        budget_cm = asyncio.timeout(self._timeout_seconds)
         try:
-            async with asyncio.timeout(self._timeout_seconds):
+            async with budget_cm:
                 # 1. Resolve skill
                 skill = self._skill_manifest.lookup(skill_name, skill_version)
 
@@ -205,6 +222,13 @@ class ExtractionService:
                     annotated_pdf_bytes=annotated_pdf,
                 )
         except TimeoutError:
+            # Only remap to IntelligenceTimeoutError when *this* timeout
+            # context caused the raise. Unrelated inner TimeoutErrors
+            # (e.g. a parser/annotator/library's own timeout) propagate
+            # as-is — remapping them would hide the real failing component
+            # and report a bogus ``budget_seconds`` the pipeline never hit.
+            if not budget_cm.expired():
+                raise
             raise IntelligenceTimeoutError(
                 budget_seconds=self._timeout_seconds,
             ) from None

--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -152,10 +152,11 @@ class ExtractionService:
         (rather than a misleading 504 with a fake ``budget_seconds``).
         """
         t0 = time.monotonic()
-        # Bind the Timeout context manager to a local before entering ``async
-        # with`` so the ``except TimeoutError`` branch below can query
-        # ``budget_cm.expired()`` even though the exception unbinds the
-        # ``as`` target in the suite's local scope.
+        # Bind the ``asyncio.timeout`` context manager to a local before
+        # entering ``async with`` so the ``except TimeoutError`` branch below
+        # can query ``budget_cm.expired()`` and tell whether this specific
+        # pipeline timeout expired or whether the TimeoutError came from an
+        # unrelated inner component.
         budget_cm = asyncio.timeout(self._timeout_seconds)
         try:
             async with budget_cm:

--- a/apps/backend/tests/unit/features/extraction/test_extraction_service.py
+++ b/apps/backend/tests/unit/features/extraction/test_extraction_service.py
@@ -761,3 +761,65 @@ async def test_extraction_service_releases_semaphore_on_error() -> None:
     # ExtractionOverloadedError instead of succeeding.
     result = await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
     assert isinstance(result, ExtractionResult)
+
+
+_INNER_TIMEOUT_MSG = "parser-internal-timeout"
+
+
+class _InnerTimeoutParser:
+    """Parser that raises a built-in TimeoutError unrelated to budget expiry.
+
+    Models a downstream library (e.g. a socket-layer, sub-operation, or
+    third-party helper) raising the Python 3.11+ unified ``TimeoutError``
+    WITHOUT the outer ``asyncio.timeout(...)`` budget being exhausted.
+    The service must not remap this to ``IntelligenceTimeoutError`` —
+    that error code is specifically reserved for budget-exhaustion (504).
+    """
+
+    async def parse(self, _pdf_bytes: bytes, _docling_config: Any) -> ParsedDocument:
+        raise TimeoutError(_INNER_TIMEOUT_MSG)
+
+
+async def test_timeout_error_from_parser_does_not_map_to_intelligence_timeout() -> None:
+    """Regression: inner TimeoutError must NOT be remapped to IntelligenceTimeoutError.
+
+    Before the fix, the bare ``except TimeoutError`` around the pipeline
+    caught any built-in ``TimeoutError`` — including ones raised by a
+    parser or annotator before the ``asyncio.timeout`` budget expired —
+    and remapped them to ``IntelligenceTimeoutError`` with the full
+    ``extraction_timeout_seconds`` as the reported budget. That hides
+    the real failing component and surfaces a misleading 504.
+    """
+    # Generous budget so there is no ambiguity: zero seconds elapse before
+    # the parser raises, so the ``asyncio.timeout(...)`` budget is nowhere
+    # near exhausted.
+    settings = _build_settings(extraction_timeout_seconds=60.0)
+    service = _build_service(parser=_InnerTimeoutParser(), settings=settings)
+
+    with pytest.raises(TimeoutError) as excinfo:
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    # The raised error is the original inner TimeoutError, not an
+    # IntelligenceTimeoutError. ``IntelligenceTimeoutError`` is a
+    # DomainError; the bare built-in ``TimeoutError`` has no ``params``.
+    assert not isinstance(excinfo.value, IntelligenceTimeoutError)
+    assert str(excinfo.value) == _INNER_TIMEOUT_MSG
+
+
+async def test_extraction_service_timeout_budget_seconds_matches_configured() -> None:
+    """Legitimate budget exhaustion still reports configured budget_seconds.
+
+    Complements the regression test above: confirms the happy-path mapping
+    survives — when the outer ``asyncio.timeout`` genuinely expires, we DO
+    raise ``IntelligenceTimeoutError`` and its ``params.budget_seconds``
+    matches the configured ``extraction_timeout_seconds``.
+    """
+    engine = _FakeEngine(sleep_seconds=0.5)
+    settings = _build_settings(extraction_timeout_seconds=0.05)
+    service = _build_service(engine=engine, settings=settings)
+
+    with pytest.raises(IntelligenceTimeoutError) as excinfo:
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    assert excinfo.value.params is not None
+    assert excinfo.value.params.model_dump() == {"budget_seconds": 0.05}


### PR DESCRIPTION
## Summary

- Fixes `apps/backend/app/features/extraction/service.py:207`: the bare `except TimeoutError` wrapping the pipeline caught **any** built-in `TimeoutError` — including ones raised by a parser, annotator, or downstream library BEFORE the `asyncio.timeout(self._timeout_seconds)` budget expired — and remapped every one of them to `IntelligenceTimeoutError` with the full configured `extraction_timeout_seconds` as the reported `budget_seconds`. That hid the real failing component and surfaced a misleading 504.
- Fix: bind `asyncio.timeout(...)` to a local `budget_cm` and check `budget_cm.expired()` inside the `except`. `Timeout.expired()` is `True` iff **this** timeout context caused the raise — so unrelated inner `TimeoutError`s now propagate as-is and the middleware exception handler surfaces them via the default mapping. `IntelligenceTimeoutError.params.budget_seconds` is now only reported for genuine budget-exhaustion.
- Reproducer: inject a fake parser whose `parse()` raises `TimeoutError("parser-internal-timeout")` immediately. Before the fix, the service raised `IntelligenceTimeoutError` with `budget_seconds == extraction_timeout_seconds` (e.g. 60.0) even though zero seconds had elapsed. After the fix, the original `TimeoutError` propagates.

## Why approach (A) — `cm.expired()` — over the wall-clock fallback (B)

`asyncio.timeout(...)` as a context manager returns a `Timeout` object whose `.expired()` returns `True` **only** when its own internal cancellation caused the `TimeoutError`. This is the authoritative signal — no drift from clock skew, no ambiguity when the budget is close to elapsed but the raise came from elsewhere. Approach (B) (comparing `time.monotonic()` to the budget) would require picking an elapsed-vs-budget threshold that is necessarily fuzzy; (A) is exact and Pythonic.

## Test plan

- [x] Red: `test_timeout_error_from_parser_does_not_map_to_intelligence_timeout` failed before the fix (service remapped to `IntelligenceTimeoutError`) and passes after.
- [x] Green: legitimate budget exhaustion still maps correctly — `test_extraction_service_timeout_budget_seconds_matches_configured` verifies `params.budget_seconds == extraction_timeout_seconds` when the outer `asyncio.timeout` genuinely expires.
- [x] Pre-existing `test_extraction_service_timeout_raises_intelligence_timeout_error`, `test_extraction_service_parser_timeout_raises_intelligence_timeout_error`, and `test_extraction_service_timeout_with_blocking_thread_raises` still pass (all 23 unit tests green).
- [x] `task check` passes (lint, format, types, import-linter contracts, unit, integration, contract, errors).