### PR TITLE
ci(dependabot): serialise auto-merge workflow per PR (closes #209)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -57,6 +57,17 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialise runs on the same PR so two events firing close together
+# (e.g. a `synchronize` from the lockfile-sync workflow's push AND a
+# server-side `update-branch` call) cannot produce two competing
+# `gh pr merge --auto --squash` invocations. `cancel-in-progress` is
+# false so an in-flight auto-merge enablement completes rather than
+# being killed by a follow-up event on the same PR — mirrors the
+# serialisation used by `dependabot-lockfile-sync.yml`. Issue #209.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/apps/backend/tests/unit/architecture/test_dependabot_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_dependabot_workflow_hygiene.py
@@ -57,10 +57,23 @@ def test_dependabot_pr_workflow_declares_concurrency_block(workflow_name: str) -
     )
 
     group = concurrency_block.get("group", "")
-    assert "github.event.pull_request.number" in group, (
-        f"{workflow_name}'s concurrency group must include "
-        "`github.event.pull_request.number` so runs are serialised per PR, "
-        f"got: {group!r}"
+    # Assert the FULL ``${{ ... }}`` interpolation, not just a substring.
+    # A bare ``group: github.event.pull_request.number`` without the
+    # ``${{ }}`` wrapping is a literal string that would serialise ALL PRs
+    # into one shared group rather than per-PR — the substring match would
+    # let that through. Require the interpolation syntax AND
+    # ``${{ github.workflow }}`` so cross-workflow collisions cannot share
+    # the same group either.
+    assert "${{ github.event.pull_request.number }}" in group, (
+        f"{workflow_name}'s concurrency group must interpolate "
+        "`${{ github.event.pull_request.number }}` (the full GitHub "
+        "Actions expression, including `${{ }}`) so runs are serialised "
+        f"per PR and not as a shared literal. Got: {group!r}"
+    )
+    assert "${{ github.workflow }}" in group, (
+        f"{workflow_name}'s concurrency group must also interpolate "
+        "`${{ github.workflow }}` so different workflows on the same PR "
+        f"use distinct groups and do not cross-collide. Got: {group!r}"
     )
 
     cancel_in_progress = concurrency_block.get("cancel-in-progress")

--- a/apps/backend/tests/unit/architecture/test_dependabot_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_dependabot_workflow_hygiene.py
@@ -14,10 +14,9 @@ from typing import Any, Final
 import pytest
 import yaml
 
-from ._linter_subprocess import BACKEND_DIR
+from ._linter_subprocess import REPO_ROOT
 
-_REPO_ROOT: Final[Path] = BACKEND_DIR.parent.parent
-_WORKFLOWS_DIR: Final[Path] = _REPO_ROOT / ".github" / "workflows"
+_WORKFLOWS_DIR: Final[Path] = REPO_ROOT / ".github" / "workflows"
 
 # Dependabot workflows that act on an individual PR. Every one of these must
 # be serialised by PR number so two events on the same PR cannot race — see
@@ -41,6 +40,11 @@ def test_dependabot_pr_workflow_declares_concurrency_block(workflow_name: str) -
     """
     workflow_path = _WORKFLOWS_DIR / workflow_name
     workflow: dict[str, Any] = yaml.safe_load(workflow_path.read_text())
+
+    assert isinstance(workflow, dict), (
+        f"{workflow_path} did not parse to a YAML mapping — "
+        "got a non-mapping or null value, likely malformed YAML."
+    )
 
     assert "concurrency" in workflow, (
         f"{workflow_name} lacks a top-level `concurrency:` block. "

--- a/apps/backend/tests/unit/architecture/test_dependabot_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_dependabot_workflow_hygiene.py
@@ -1,0 +1,67 @@
+"""Workflow-file hygiene checks that apply to every Dependabot CI path.
+
+Static assertions about `.github/workflows/*.yml` that catch drift in the
+rules CLAUDE.md codifies for Dependabot handling. Kept here (in the backend
+test tree) so they run inside the canonical `task check` gate rather than
+relying on GitHub-side linting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+import pytest
+import yaml
+
+from ._linter_subprocess import BACKEND_DIR
+
+_REPO_ROOT: Final[Path] = BACKEND_DIR.parent.parent
+_WORKFLOWS_DIR: Final[Path] = _REPO_ROOT / ".github" / "workflows"
+
+# Dependabot workflows that act on an individual PR. Every one of these must
+# be serialised by PR number so two events on the same PR cannot race — see
+# issue #209 for the incident-flavoured rationale.
+_DEPENDABOT_PR_WORKFLOWS: Final[tuple[str, ...]] = (
+    "dependabot-automerge.yml",
+    "dependabot-lockfile-sync.yml",
+)
+
+
+@pytest.mark.parametrize("workflow_name", _DEPENDABOT_PR_WORKFLOWS)
+def test_dependabot_pr_workflow_declares_concurrency_block(workflow_name: str) -> None:
+    """Each Dependabot-PR workflow must serialise runs per PR number.
+
+    Without a ``concurrency:`` block scoped to ``pull_request.number``, two
+    events firing close together on the same PR (a ``synchronize`` from a
+    lockfile-sync push plus a ``synchronize`` from a server-side
+    ``update-branch`` call, for example) produce two competing workflow
+    runs. ``cancel-in-progress`` is deliberately false — a partial run must
+    finish rather than be killed mid-way.
+    """
+    workflow_path = _WORKFLOWS_DIR / workflow_name
+    workflow: dict[str, Any] = yaml.safe_load(workflow_path.read_text())
+
+    assert "concurrency" in workflow, (
+        f"{workflow_name} lacks a top-level `concurrency:` block. "
+        "Two events firing close together on the same Dependabot PR could race."
+    )
+
+    concurrency_block = workflow["concurrency"]
+    assert isinstance(concurrency_block, dict), (
+        f"{workflow_name}'s `concurrency:` must be a mapping with `group` and `cancel-in-progress`."
+    )
+
+    group = concurrency_block.get("group", "")
+    assert "github.event.pull_request.number" in group, (
+        f"{workflow_name}'s concurrency group must include "
+        "`github.event.pull_request.number` so runs are serialised per PR, "
+        f"got: {group!r}"
+    )
+
+    cancel_in_progress = concurrency_block.get("cancel-in-progress")
+    assert cancel_in_progress is False, (
+        f"{workflow_name}'s `cancel-in-progress` must be false — a partial "
+        "run (e.g. a lockfile-sync mid-push) must complete rather than be "
+        f"killed. Got: {cancel_in_progress!r}"
+    )


### PR DESCRIPTION
## Summary
- Add a top-level `concurrency:` block to `.github/workflows/dependabot-automerge.yml` mirroring the serialisation already in `dependabot-lockfile-sync.yml`. Two events firing close together on the same Dependabot PR (`synchronize` from the lockfile-sync push plus a server-side `update-branch` call) would otherwise fire two competing `gh pr merge --auto --squash` invocations in parallel.
- Add `tests/unit/architecture/test_dependabot_workflow_hygiene.py` as a regression guard: parametrised over every Dependabot-PR workflow, it asserts each one declares a concurrency group scoped to `pull_request.number` with `cancel-in-progress: false`.

## Test plan
- [x] RED: new meta-test fails on the unmodified automerge file with a clear "lacks a top-level `concurrency:` block" message; sibling lockfile-sync file passes.
- [x] GREEN: adding the block flips both parametrisations green.
- [x] `task check` passes end-to-end.

Closes #209.