### PR TITLE
ci(workflows): disable checkout credential persistence in ci.yml (closes #212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         working-directory: apps/backend
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # No downstream step pushes or calls an authenticated GH API;
+          # keeping GITHUB_TOKEN in git config is unnecessary attack
+          # surface if a run: step is ever compromised. Issue #212.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
@@ -74,6 +79,11 @@ jobs:
         working-directory: packages/error-contracts
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # No downstream step pushes or calls an authenticated GH API;
+          # keeping GITHUB_TOKEN in git config is unnecessary attack
+          # surface if a run: step is ever compromised. Issue #212.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
@@ -14,10 +14,9 @@ from typing import Any, Final
 
 import yaml
 
-from ._linter_subprocess import BACKEND_DIR
+from ._linter_subprocess import REPO_ROOT
 
-_REPO_ROOT: Final[Path] = BACKEND_DIR.parent.parent
-_CI_WORKFLOW: Final[Path] = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_CI_WORKFLOW: Final[Path] = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 
 def _iter_steps(workflow: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:

--- a/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
@@ -1,0 +1,58 @@
+"""Hygiene checks on `.github/workflows/ci.yml`.
+
+Static assertions about CI workflow steps — kept in the backend test tree
+so they run inside the canonical `task check` gate. Catches drift of
+hardening invariants the repo has agreed to across PRs (#190 SHA-pinning,
+#212 persist-credentials narrowing, etc.) so a future copy-paste does not
+silently regress the posture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+from ._linter_subprocess import BACKEND_DIR
+
+_REPO_ROOT: Final[Path] = BACKEND_DIR.parent.parent
+_CI_WORKFLOW: Final[Path] = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _iter_steps(workflow: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Return (job_name, step_dict) pairs for every step in a workflow document."""
+    return [
+        (job_name, step)
+        for job_name, job_body in (workflow.get("jobs") or {}).items()
+        for step in job_body.get("steps") or []
+    ]
+
+
+def test_ci_checkout_steps_disable_credential_persistence() -> None:
+    """Every `actions/checkout` step in ci.yml must set persist-credentials: false.
+
+    The checkout action's default persists the ephemeral ``GITHUB_TOKEN``
+    into the job's git config for the lifetime of the job. Neither CI job
+    here pushes back to the repo, so leaving the token live is unnecessary
+    attack surface — a compromised `run:` step inherits write access to
+    the repo. Continuation of the supply-chain hardening done in #190.
+    """
+    workflow: dict[str, Any] = yaml.safe_load(_CI_WORKFLOW.read_text())
+
+    offenders: list[str] = []
+    for job_name, step in _iter_steps(workflow):
+        uses = step.get("uses", "")
+        if not uses.startswith("actions/checkout@"):
+            continue
+        with_block = step.get("with") or {}
+        if with_block.get("persist-credentials") is not False:
+            offenders.append(
+                f"job '{job_name}' step '{step.get('name', uses)}' "
+                f"has persist-credentials={with_block.get('persist-credentials')!r}",
+            )
+
+    assert not offenders, (
+        "ci.yml checkout step(s) leave the GITHUB_TOKEN in git config:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+    )


### PR DESCRIPTION
## Summary
- Add `with: { persist-credentials: false }` to both `actions/checkout` steps in `.github/workflows/ci.yml` (`backend-checks` job and `error-contracts` job). Neither job pushes or calls an authenticated GitHub API after checkout, so keeping the ephemeral `GITHUB_TOKEN` in the job's git config is unnecessary attack surface — continuation of the supply-chain hardening from #190.
- Add `tests/unit/architecture/test_ci_workflow_hygiene.py` as a regression guard. It walks every `actions/checkout` step in `ci.yml` and asserts each one pins `persist-credentials: false`. Future checkouts added without the guard fail fast under `task check`.

## Test plan
- [x] RED: meta-test fails on the unmodified ci.yml with `persist-credentials=None` for both `backend-checks` and `error-contracts` jobs.
- [x] GREEN: adding the `with:` blocks flips the meta-test.
- [x] `task check` passes end-to-end (ruff + pyright + arch + unit + integration + contract + error-contracts).

Closes #212.