### PR TITLE
feat(cors): narrow allow_methods and allow_headers via Settings knobs (closes #211)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,6 +2,15 @@
 APP_ENV=development
 LOG_LEVEL=info
 CORS_ORIGINS=["http://localhost:5173"]
+# CORS methods the API accepts as cross-origin requests. Defaults to the
+# actual route surface (GET for /health, /ready, /openapi.json; POST for
+# /api/v1/extract). Narrow further in deployments that need it; do NOT
+# widen to ["*"] with allow_credentials=true.
+CORS_METHODS=["GET","POST"]
+# CORS request-headers the API accepts. Defaults to the narrow allowlist the
+# application actually consumes. Widen explicitly in deployments that send
+# additional headers; again, do NOT fall back to ["*"] with credentials.
+CORS_HEADERS=["Authorization","Content-Type","X-Request-Id"]
 # Maximum string length for a single structlog *value* before the redaction
 # filter truncates it (the top-level `event` value is preserved; key names are
 # not affected). Protects against accidentally logging huge payloads (PDF

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -6,7 +6,7 @@ CORS_ORIGINS=["http://localhost:5173"]
 # actual route surface (GET for /health, /ready, /openapi.json; POST for
 # /api/v1/extract). Narrow further in deployments that need it; do NOT
 # widen to ["*"] with allow_credentials=true.
-CORS_METHODS=["GET","POST"]
+CORS_METHODS=["GET","HEAD","POST"]
 # CORS request-headers the API accepts. Defaults to the narrow allowlist the
 # application actually consumes. Widen explicitly in deployments that send
 # additional headers; again, do NOT fall back to ["*"] with credentials.

--- a/apps/backend/app/api/middleware.py
+++ b/apps/backend/app/api/middleware.py
@@ -73,6 +73,8 @@ def configure_middleware(
     cors_origins: list[str],
     *,
     max_upload_bytes: int,
+    cors_methods: list[str],
+    cors_headers: list[str],
 ) -> None:
     """Attach all middleware to the FastAPI app.
 
@@ -88,6 +90,10 @@ def configure_middleware(
     middleware to the front of the stack. See the module docstring for why
     flipping these calls breaks CORS preflight, request-id propagation,
     or the upload-size guard (issue #112).
+
+    ``cors_methods`` and ``cors_headers`` are required keyword-only so the
+    call site must source them from ``Settings`` — no hidden wildcards
+    (issue #211).
     """
     app.add_middleware(
         UploadSizeLimitMiddleware,
@@ -101,6 +107,6 @@ def configure_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=cors_methods,
+        allow_headers=cors_headers,
     )

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     # previously accepted any verb and any request header (including
     # ``Authorization``) regardless of how tightly operators scoped
     # ``cors_origins`` — see issue #211.
-    cors_methods: list[str] = ["GET", "POST"]
+    cors_methods: list[str] = ["GET", "HEAD", "POST"]
     cors_headers: list[str] = ["Authorization", "Content-Type", "X-Request-Id"]
 
     log_max_value_length: int = 500

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -34,6 +34,14 @@ class Settings(BaseSettings):
     app_env: str = "development"
     log_level: str = "info"
     cors_origins: list[str] = ["http://localhost:5173"]
+    # CORS method / header allowlists. Default to the current route surface
+    # (GET for /health, /ready, /openapi.json etc.; POST for /api/v1/extract)
+    # plus the minimum headers the app consumes. Hardcoding ``["*"]`` here
+    # previously accepted any verb and any request header (including
+    # ``Authorization``) regardless of how tightly operators scoped
+    # ``cors_origins`` — see issue #211.
+    cors_methods: list[str] = ["GET", "POST"]
+    cors_headers: list[str] = ["Authorization", "Content-Type", "X-Request-Id"]
 
     log_max_value_length: int = 500
     log_redacted_keys: list[str] = [

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -178,6 +178,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         application,
         cors_origins=resolved_settings.cors_origins,
         max_upload_bytes=resolved_settings.max_pdf_bytes,
+        cors_methods=resolved_settings.cors_methods,
+        cors_headers=resolved_settings.cors_headers,
     )
     register_exception_handlers(application)
 

--- a/apps/backend/tests/unit/api/test_middleware.py
+++ b/apps/backend/tests/unit/api/test_middleware.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
 
 from app.api.access_log_middleware import AccessLogMiddleware
 from app.api.middleware import configure_middleware
@@ -159,6 +160,83 @@ def test_cors_methods_and_headers_are_narrowed_not_wildcarded() -> None:
     assert cors_mw.kwargs["allow_headers"] == ["Authorization", "Content-Type"], (
         "allow_headers must reflect the caller's list verbatim, "
         f"not a wildcard. Got: {cors_mw.kwargs['allow_headers']!r}"
+    )
+
+
+def test_cors_preflight_rejects_disallowed_method() -> None:
+    """A preflight for a verb NOT in ``cors_methods`` must not advertise it.
+
+    The unit-level check above (``test_cors_methods_and_headers_are_narrowed_not_wildcarded``)
+    verifies that ``configure_middleware`` forwards the caller's list into
+    ``CORSMiddleware.kwargs`` — it does not observe the behaviour of the
+    middleware itself. This test drives a real OPTIONS preflight through
+    Starlette's ``CORSMiddleware`` via ``TestClient`` and asserts that a
+    ``DELETE`` verb (absent from the allowlist) does NOT appear in
+    ``Access-Control-Allow-Methods``, so browsers will correctly block the
+    follow-up request. Together with the unit assertion, this closes the
+    plumbing-vs-behaviour gap the Copilot reviewer flagged on issue #211.
+    """
+    app = FastAPI()
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=1024,
+        cors_methods=["GET", "POST"],
+        cors_headers=["Content-Type"],
+    )
+    client = TestClient(app)
+
+    response = client.options(
+        "/nowhere",
+        headers={
+            "Origin": "http://localhost",
+            "Access-Control-Request-Method": "DELETE",
+        },
+    )
+
+    # Starlette's CORSMiddleware either short-circuits with 400 or responds
+    # without an ``Access-Control-Allow-Methods`` header containing DELETE.
+    # Either shape is acceptable; what matters is that DELETE is not
+    # advertised as allowed.
+    allow_methods = response.headers.get("access-control-allow-methods", "")
+    assert "DELETE" not in allow_methods, (
+        "Preflight for a disallowed verb must not surface that verb in "
+        f"Access-Control-Allow-Methods. Got: {allow_methods!r}"
+    )
+
+
+def test_cors_preflight_allows_listed_method() -> None:
+    """A preflight for a verb IN ``cors_methods`` is accepted by the middleware.
+
+    Companion to ``test_cors_preflight_rejects_disallowed_method`` — without
+    this positive case, a regression that disabled CORS handling entirely
+    would satisfy the negative test trivially. The observable signal is
+    ``Access-Control-Allow-Origin`` echoing the request Origin, which
+    ``CORSMiddleware`` emits only when the preflight passes its verb + header
+    + origin check.
+    """
+    app = FastAPI()
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=1024,
+        cors_methods=["GET", "POST"],
+        cors_headers=["Content-Type"],
+    )
+    client = TestClient(app)
+
+    response = client.options(
+        "/nowhere",
+        headers={
+            "Origin": "http://localhost",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    allow_origin = response.headers.get("access-control-allow-origin", "")
+    assert allow_origin == "http://localhost", (
+        "Preflight for an allowed verb must echo the request Origin in "
+        f"Access-Control-Allow-Origin. Got: {allow_origin!r}"
     )
 
 

--- a/apps/backend/tests/unit/api/test_middleware.py
+++ b/apps/backend/tests/unit/api/test_middleware.py
@@ -29,6 +29,14 @@ from app.api.middleware import configure_middleware
 from app.api.request_id_middleware import RequestIdMiddleware
 from app.api.upload_size_limit_middleware import UploadSizeLimitMiddleware
 
+# Minimal CORS allowlists for the registration-order tests. These tests do
+# not care what the actual allowed methods/headers are — only the middleware
+# stacking order is under test — but ``configure_middleware`` now requires
+# both keyword args so the call site cannot silently re-introduce a wildcard
+# default (issue #211).
+_TEST_CORS_METHODS = ["GET", "POST"]
+_TEST_CORS_HEADERS = ["Content-Type"]
+
 
 def test_configure_middleware_registers_expected_execution_order() -> None:
     """Runtime order is CORS -> RequestId -> AccessLog -> UploadSizeLimit.
@@ -40,7 +48,13 @@ def test_configure_middleware_registers_expected_execution_order() -> None:
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=50 * 1024 * 1024)
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=50 * 1024 * 1024,
+        cors_methods=_TEST_CORS_METHODS,
+        cors_headers=_TEST_CORS_HEADERS,
+    )
 
     registered_classes = [m.cls for m in app.user_middleware]
     assert registered_classes == [
@@ -68,7 +82,13 @@ def test_upload_size_limit_is_innermost_so_it_runs_before_route_dispatch() -> No
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=1024)
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=1024,
+        cors_methods=_TEST_CORS_METHODS,
+        cors_headers=_TEST_CORS_HEADERS,
+    )
 
     classes = [m.cls for m in app.user_middleware]
     upload_index = classes.index(UploadSizeLimitMiddleware)
@@ -98,11 +118,47 @@ def test_cors_is_outermost_so_preflight_bypasses_inner_middleware() -> None:
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=50 * 1024 * 1024)
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=50 * 1024 * 1024,
+        cors_methods=_TEST_CORS_METHODS,
+        cors_headers=_TEST_CORS_HEADERS,
+    )
 
     assert app.user_middleware[0].cls is CORSMiddleware, (
         "CORSMiddleware must be registered first (outermost) so preflight "
         "OPTIONS requests are handled before any other middleware sees them."
+    )
+
+
+def test_cors_methods_and_headers_are_narrowed_not_wildcarded() -> None:
+    """CORS ``allow_methods`` and ``allow_headers`` must honour explicit lists.
+
+    Hardcoding ``["*"]`` in ``configure_middleware`` accepted any verb and
+    any header (including ``Authorization``), regardless of how carefully
+    an operator scoped ``cors_origins``. ``configure_middleware`` now takes
+    keyword-only ``cors_methods`` / ``cors_headers`` and forwards them to
+    ``CORSMiddleware`` verbatim. Issue #211.
+    """
+    app = FastAPI()
+
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=50 * 1024 * 1024,
+        cors_methods=["GET", "POST"],
+        cors_headers=["Authorization", "Content-Type"],
+    )
+
+    cors_mw = next(m for m in app.user_middleware if m.cls is CORSMiddleware)
+    assert cors_mw.kwargs["allow_methods"] == ["GET", "POST"], (
+        "allow_methods must reflect the caller's list verbatim, "
+        f"not a wildcard. Got: {cors_mw.kwargs['allow_methods']!r}"
+    )
+    assert cors_mw.kwargs["allow_headers"] == ["Authorization", "Content-Type"], (
+        "allow_headers must reflect the caller's list verbatim, "
+        f"not a wildcard. Got: {cors_mw.kwargs['allow_headers']!r}"
     )
 
 
@@ -118,7 +174,13 @@ def test_request_id_runs_before_access_log_so_log_has_correlation_id() -> None:
     """
     app = FastAPI()
 
-    configure_middleware(app, cors_origins=["http://localhost"], max_upload_bytes=50 * 1024 * 1024)
+    configure_middleware(
+        app,
+        cors_origins=["http://localhost"],
+        max_upload_bytes=50 * 1024 * 1024,
+        cors_methods=_TEST_CORS_METHODS,
+        cors_headers=_TEST_CORS_HEADERS,
+    )
 
     classes = [m.cls for m in app.user_middleware]
     request_id_index = classes.index(RequestIdMiddleware)


### PR DESCRIPTION
## Summary
- Add `cors_methods` and `cors_headers` fields to `Settings` with safe defaults scoped to the real route contract: methods `["GET", "POST"]`, headers `["Authorization", "Content-Type", "X-Request-Id"]`.
- Change `configure_middleware` to accept both as required keyword-only args and forward them to `CORSMiddleware`. Hardcoding `["*"]` accepted any verb and any header (including `Authorization`) regardless of how tightly operators scoped `cors_origins`.
- Update `main.py` to source both from the resolved `Settings`.
- Document `CORS_METHODS` / `CORS_HEADERS` in `.env.example` next to `CORS_ORIGINS` with a "do NOT widen to `["*"]` with credentials" warning.

## Test plan
- [x] RED: new test `test_cors_methods_and_headers_are_narrowed_not_wildcarded` fails with `TypeError: unexpected keyword argument 'cors_methods'` on unchanged `configure_middleware`.
- [x] GREEN: after signature + Settings + main.py changes, the new test and all four existing middleware-ordering tests pass under the required keyword args.
- [x] All 36 tests across `tests/unit/api/test_middleware.py` + `tests/unit/core/test_config.py` pass.
- [x] `task check` passes end-to-end.

Closes #211.