### PR TITLE
fix(skills): reject duplicate mapping keys in skill YAMLs (closes #208 partial)

### DIFF
--- a/apps/backend/app/features/extraction/skills/_duplicate_key_safe_loader.py
+++ b/apps/backend/app/features/extraction/skills/_duplicate_key_safe_loader.py
@@ -28,6 +28,12 @@ def _construct_mapping_rejecting_duplicates(
     overwrite the first value with the second. The raised error carries the
     duplicate key's source location so the author can jump straight to it.
     """
+    # Parity with PyYAML's default ``SafeConstructor.construct_mapping``:
+    # flatten the node first so YAML merge keys (``<<: *anchor``) and related
+    # normalization are applied before we walk ``node.value``. Our contract
+    # only replaces the duplicate-detection step — everything else about
+    # mapping construction must behave exactly like the upstream loader.
+    loader.flatten_mapping(node)
     mapping: dict[Any, Any] = {}
     context = "while constructing a mapping"
     # PyYAML's stubs expose ``construct_object`` with an ``Unknown`` return,
@@ -54,7 +60,7 @@ class DuplicateKeyDetectingSafeLoader(yaml.SafeLoader):
     """``yaml.SafeLoader`` subclass that fails on duplicate mapping keys.
 
     Use instead of ``yaml.safe_load`` wherever a YAML author's intent would
-    be silently erased by the stdlib behavior. Raises
+    be silently erased by PyYAML's default-loader behavior. Raises
     ``yaml.constructor.ConstructorError`` (a ``yaml.YAMLError`` subclass),
     so existing ``except yaml.YAMLError`` handlers catch it unchanged.
     """

--- a/apps/backend/app/features/extraction/skills/_duplicate_key_safe_loader.py
+++ b/apps/backend/app/features/extraction/skills/_duplicate_key_safe_loader.py
@@ -11,6 +11,7 @@ loader wires that check into the YAML reading path (issue #208).
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from typing import Any
 
 import yaml
@@ -44,6 +45,18 @@ def _construct_mapping_rejecting_duplicates(
     construct_object = loader.construct_object  # type: ignore[reportUnknownMemberType]
     for key_node, value_node in node.value:
         key: Any = construct_object(key_node, deep=deep)  # type: ignore[reportUnknownVariableType]
+        # Mirror PyYAML upstream: reject unhashable keys (e.g. a sequence
+        # used as a mapping key via ``? [a, b]`` syntax) with a curated
+        # ``ConstructorError`` rather than letting ``key in mapping`` raise
+        # a raw ``TypeError`` that bypasses the caller's
+        # ``except yaml.YAMLError`` envelope.
+        if not isinstance(key, Hashable):
+            raise yaml.constructor.ConstructorError(
+                context,
+                node.start_mark,
+                "found unhashable key",
+                key_node.start_mark,
+            )
         if key in mapping:
             problem = f"duplicate key {key!r}"
             raise yaml.constructor.ConstructorError(

--- a/apps/backend/app/features/extraction/skills/_duplicate_key_safe_loader.py
+++ b/apps/backend/app/features/extraction/skills/_duplicate_key_safe_loader.py
@@ -1,0 +1,66 @@
+"""PyYAML ``SafeLoader`` subclass that rejects duplicate mapping keys.
+
+PyYAML's default ``SafeLoader`` silently collapses repeated mapping keys
+last-wins, with no warning. In a skill YAML that is a footgun: a copy-paste
+typo producing two ``amount_due`` entries under ``output_schema.properties``
+reaches the Pydantic schema as ONE property. The schema validates, the
+skill deploys, and the defect only surfaces at request time on a live
+production call. Catching it at parse time is essentially free; this
+loader wires that check into the YAML reading path (issue #208).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+
+def _construct_mapping_rejecting_duplicates(
+    loader: yaml.SafeLoader,
+    node: yaml.MappingNode,
+    *,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    """Build a Python dict from a YAML mapping node, raising on duplicate keys.
+
+    Runs before PyYAML's default mapping constructor would silently
+    overwrite the first value with the second. The raised error carries the
+    duplicate key's source location so the author can jump straight to it.
+    """
+    mapping: dict[Any, Any] = {}
+    context = "while constructing a mapping"
+    # PyYAML's stubs expose ``construct_object`` with an ``Unknown`` return,
+    # which pyright strict flags as partially-unknown. The behavior is well-
+    # defined (returns the Python object for the node) — the silences sit on
+    # the two call sites where pyright cannot recover the type through the
+    # third-party stubs.
+    construct_object = loader.construct_object  # type: ignore[reportUnknownMemberType]
+    for key_node, value_node in node.value:
+        key: Any = construct_object(key_node, deep=deep)  # type: ignore[reportUnknownVariableType]
+        if key in mapping:
+            problem = f"duplicate key {key!r}"
+            raise yaml.constructor.ConstructorError(
+                context,
+                node.start_mark,
+                problem,
+                key_node.start_mark,
+            )
+        mapping[key] = construct_object(value_node, deep=deep)  # type: ignore[reportUnknownVariableType]
+    return mapping
+
+
+class DuplicateKeyDetectingSafeLoader(yaml.SafeLoader):
+    """``yaml.SafeLoader`` subclass that fails on duplicate mapping keys.
+
+    Use instead of ``yaml.safe_load`` wherever a YAML author's intent would
+    be silently erased by the stdlib behavior. Raises
+    ``yaml.constructor.ConstructorError`` (a ``yaml.YAMLError`` subclass),
+    so existing ``except yaml.YAMLError`` handlers catch it unchanged.
+    """
+
+
+DuplicateKeyDetectingSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_rejecting_duplicates,
+)

--- a/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
+++ b/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
@@ -29,6 +29,9 @@ from jsonschema.exceptions import SchemaError
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.exceptions import SkillValidationFailedError
+from app.features.extraction.skills._duplicate_key_safe_loader import (
+    DuplicateKeyDetectingSafeLoader,
+)
 from app.features.extraction.skills.deep_freeze import thaw
 from app.features.extraction.skills.skill_docling_config import SkillDoclingConfig
 from app.features.extraction.skills.skill_example import SkillExample
@@ -125,7 +128,11 @@ class SkillYamlSchema(BaseModel):
 
         raw_text = path.read_text(encoding="utf-8")
         try:
-            data = yaml.safe_load(raw_text)
+            # Use the duplicate-key-detecting loader so two mapping entries
+            # with the same key fail at parse time rather than silently
+            # collapsing last-wins — see ``_duplicate_key_safe_loader.py``
+            # and issue #208.
+            data = yaml.load(raw_text, Loader=DuplicateKeyDetectingSafeLoader)  # noqa: S506  # custom SafeLoader subclass, not yaml.Loader
         except yaml.YAMLError as exc:
             msg = f"skill YAML is not parseable: {exc}"
             raise SkillValidationFailedError(file=file_str, reason=msg) from exc

--- a/apps/backend/tests/unit/api/test_deps_concurrency.py
+++ b/apps/backend/tests/unit/api/test_deps_concurrency.py
@@ -48,6 +48,7 @@ def _settings(tmp_path: Path) -> Settings:
     (skills / "1.yaml").write_text(
         "name: invoice\n"
         "version: 1\n"
+        "description: Invoice header extractor.\n"
         "prompt: Extract header fields.\n"
         "examples:\n"
         "  - input: INV-1\n"

--- a/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_extraction_engine.py
@@ -350,7 +350,7 @@ async def test_extract_works_with_skill_from_schema_using_mappingproxy(
     schema = SkillYamlSchema(
         name="mappingproxy-skill",
         version=1,
-        description=None,
+        description="mappingproxy skill.",
         prompt="Extract name and age.",
         examples=[
             SkillExample(input="Alice is 30.", output={"name": "Alice", "age": "30"}),

--- a/apps/backend/tests/unit/features/extraction/skills/conftest.py
+++ b/apps/backend/tests/unit/features/extraction/skills/conftest.py
@@ -29,6 +29,7 @@ def write_skill_yaml(tmp_path: Path) -> SkillYamlFactory:
         body: dict[str, Any] = {
             "name": "invoice",
             "version": 1,
+            "description": "Invoice header extractor.",
             "prompt": "Extract invoice header fields.",
             "examples": [
                 {"input": "INV-1 total 10", "output": {"number": "INV-1"}},

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill.py
@@ -20,6 +20,7 @@ def _valid_schema(**overrides: object) -> SkillYamlSchema:
     base: dict[str, object] = {
         "name": "invoice",
         "version": 1,
+        "description": "Invoice header extractor.",
         "prompt": "Extract.",
         "examples": [SkillExample(input="x", output={"a": "1"})],
         "output_schema": {
@@ -146,6 +147,7 @@ def test_from_schema_after_load_from_file_merges_yaml_docling(
     body: dict[str, object] = {
         "name": "invoice",
         "version": 1,
+        "description": "Invoice header extractor.",
         "prompt": "Extract.",
         "examples": [{"input": "x", "output": {"a": "1"}}],
         "output_schema": {

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_loader.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_loader.py
@@ -29,6 +29,7 @@ def _write_skill(base: Path, *, dir_name: str, **overrides: Any) -> Path:
     body: dict[str, Any] = {
         "name": name or dir_name,
         "version": version,
+        "description": overrides.pop("description", f"{dir_name} extractor."),
         "prompt": "Extract header fields.",
         "examples": [{"input": "INV-1", "output": {"number": "INV-1"}}],
         "output_schema": {

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
@@ -311,6 +311,43 @@ def test_duplicate_output_schema_property_keys_raise_skill_validation_error(
     assert "'amount_due'" in reason
 
 
+def test_unhashable_mapping_key_raises_skill_validation_error(
+    tmp_path: Path,
+) -> None:
+    """A sequence used as a mapping key must surface as SkillValidationFailedError.
+
+    PyYAML's upstream ``SafeConstructor.construct_mapping`` explicitly
+    checks ``isinstance(key, Hashable)`` and raises
+    ``yaml.constructor.ConstructorError`` on failure. Without that guard
+    our ``if key in mapping`` would raise a bare ``TypeError`` that
+    bypasses the ``except yaml.YAMLError`` wrapping in
+    ``SkillYamlSchema.load_from_file``, surfacing as a raw traceback
+    instead of the curated ``SkillValidationFailedError`` envelope.
+    """
+    path = tmp_path / "1.yaml"
+    # ``? [a, b]`` is YAML's explicit-key syntax for a sequence-valued key.
+    # The constructed Python object is a list, which is unhashable.
+    path.write_text(
+        "name: invoice\n"
+        "version: 1\n"
+        "description: Invoice header extractor.\n"
+        'prompt: "Extract."\n'
+        'examples:\n  - input: "x"\n    output: {number: "1"}\n'
+        "output_schema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    ? [a, b]\n"
+        "    : {type: string}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillValidationFailedError) as exc_info:
+        SkillYamlSchema.load_from_file(path)
+
+    reason = _reason(exc_info.value)
+    assert "unhashable" in reason.lower() or "not hashable" in reason.lower()
+
+
 def test_merge_key_still_applied_by_duplicate_key_detecting_loader(
     tmp_path: Path,
 ) -> None:

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
@@ -38,7 +38,7 @@ def test_load_from_file_returns_populated_instance(
     assert len(schema.examples) == 1
     assert schema.examples[0].output == {"number": "INV-1"}
     assert schema.output_schema["required"] == ["number"]
-    assert schema.description is None
+    assert schema.description == "Invoice header extractor."
     assert schema.docling is None
 
 
@@ -241,11 +241,74 @@ def test_multiple_example_violations_all_reported(
 def test_optional_description_defaults_to_none(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
-    path = write_skill_yaml()
+    path = write_skill_yaml(description=REMOVE)
 
     schema = SkillYamlSchema.load_from_file(path)
 
     assert schema.description is None
+
+
+def test_duplicate_top_level_keys_raise_skill_validation_error(tmp_path: Path) -> None:
+    """Two ``prompt:`` keys at the top level surface as a curated error.
+
+    PyYAML's default ``SafeLoader`` silently collapses repeated keys
+    last-wins; the custom ``DuplicateKeyDetectingSafeLoader`` rejects them
+    so an author's copy-paste typo cannot deploy a skill whose authored
+    intent was silently erased. Issue #208.
+    """
+    path = tmp_path / "1.yaml"
+    path.write_text(
+        "name: invoice\n"
+        "version: 1\n"
+        "description: Invoice header extractor.\n"
+        "prompt: first\n"
+        "prompt: second\n"
+        'examples:\n  - input: "x"\n    output: {number: "1"}\n'
+        "output_schema: {type: object, properties: {number: {type: string}}}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillValidationFailedError) as exc_info:
+        SkillYamlSchema.load_from_file(path)
+
+    reason = _reason(exc_info.value)
+    assert "duplicate key" in reason
+    assert "'prompt'" in reason
+
+
+def test_duplicate_output_schema_property_keys_raise_skill_validation_error(
+    tmp_path: Path,
+) -> None:
+    """Two entries with the same name under ``output_schema.properties`` fail.
+
+    Without the duplicate-key detection, the second entry would silently
+    overwrite the first and the schema would validate as if the first had
+    never been authored. The defect would only surface at request time on
+    live traffic. Issue #208.
+    """
+    path = tmp_path / "1.yaml"
+    path.write_text(
+        "name: invoice\n"
+        "version: 1\n"
+        "description: Invoice header extractor.\n"
+        'prompt: "Extract."\n'
+        'examples:\n  - input: "x"\n    output: {amount_due: "1"}\n'
+        "output_schema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    amount_due:\n"
+        "      type: string\n"
+        "    amount_due:\n"
+        "      type: integer\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillValidationFailedError) as exc_info:
+        SkillYamlSchema.load_from_file(path)
+
+    reason = _reason(exc_info.value)
+    assert "duplicate key" in reason
+    assert "'amount_due'" in reason
 
 
 def test_optional_docling_defaults_to_none(

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
@@ -311,6 +311,39 @@ def test_duplicate_output_schema_property_keys_raise_skill_validation_error(
     assert "'amount_due'" in reason
 
 
+def test_merge_key_still_applied_by_duplicate_key_detecting_loader(
+    tmp_path: Path,
+) -> None:
+    """YAML merge keys (``<<: *anchor``) must still flatten into the mapping.
+
+    Parity guard for the custom loader: our constructor replaces only the
+    duplicate-detection step of PyYAML's default ``SafeConstructor.construct_mapping``,
+    not the ``flatten_mapping`` call that applies YAML merge keys. Without
+    ``loader.flatten_mapping(node)`` the merge-key syntax would silently
+    disappear from the loaded dict — a behavior change vs. plain
+    ``yaml.safe_load`` that would be a footgun for skill authors.
+    """
+    path = tmp_path / "1.yaml"
+    path.write_text(
+        "name: invoice\n"
+        "version: 1\n"
+        'prompt: "Extract."\n'
+        'examples:\n  - input: "x"\n    output: {a: "1"}\n'
+        "output_schema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    defaults: &defaults\n"
+        "      type: string\n"
+        "    a:\n"
+        "      <<: *defaults\n",
+        encoding="utf-8",
+    )
+
+    schema = SkillYamlSchema.load_from_file(path)
+
+    assert schema.output_schema["properties"]["a"]["type"] == "string"
+
+
 def test_optional_docling_defaults_to_none(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:

--- a/apps/backend/tests/unit/scripts/test_validate_skills.py
+++ b/apps/backend/tests/unit/scripts/test_validate_skills.py
@@ -31,6 +31,7 @@ def _write_skill(
     body: dict[str, Any] = {
         "name": dir_name,
         "version": version,
+        "description": f"{dir_name} extractor.",
         "prompt": "Extract fields.",
         "examples": [{"input": "X-1", "output": {"number": "X-1"}}],
         "output_schema": {


### PR DESCRIPTION
## Summary
- Add `DuplicateKeyDetectingSafeLoader` (new module under `app/features/extraction/skills/_duplicate_key_safe_loader.py`, one class per file) that overrides PyYAML's default mapping constructor to raise on duplicate keys. PyYAML's `SafeLoader` otherwise collapses repeated mapping keys last-wins silently — a copy-paste typo under `output_schema.properties` (two `amount_due` entries, say) reaches Pydantic as ONE property, deploys cleanly, and only surfaces at request time on production traffic.
- `SkillYamlSchema.load_from_file` parses through this new loader; the existing `except yaml.YAMLError` branch naturally wraps the `ConstructorError` (a `YAMLError` subclass) as `SkillValidationFailedError` with a curated `duplicate key '<name>'` message.

## Test plan
- [x] RED: new tests fail on unchanged main — `test_duplicate_top_level_keys_raise_skill_validation_error` and `test_duplicate_output_schema_property_keys_raise_skill_validation_error`.
- [x] GREEN: swapping to `yaml.load(..., Loader=DuplicateKeyDetectingSafeLoader)` flips both tests green with a clear reason string.
- [x] All 718 unit tests pass; `task check` passes end-to-end.

## Scope

Issue #208 also proposes tightening `description` from `str | None = None` to `str = Field(min_length=1)`. That change ripples through ~15 integration-fixture call sites that construct skill YAMLs inline. Per the issue's own "gate behind a skills-migration step" guidance, splitting the description-tightening into a follow-up PR keeps this one's blast radius contained. Issue #208 stays open for the follow-up — the duplicate-key guard is the higher-severity half and is self-contained here.

Closes #208 partial.