### PR TITLE
fix(docker): add tini as PID 1 for signal forwarding (closes #213)

### DIFF
--- a/apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py
@@ -1,0 +1,166 @@
+"""Hygiene checks on `infra/docker/backend.Dockerfile`.
+
+Static assertions about the backend runtime image's Dockerfile — kept in
+the backend test tree so they run inside the canonical `task check` gate.
+Catches drift of hardening invariants the repo has agreed to across PRs
+so a future copy-paste does not silently regress the posture.
+
+Issue #213: without an `init`-style process at PID 1 (tini / dumb-init),
+signals sent to the container (`docker stop` → SIGTERM) are handled only
+by uvicorn itself. Sub-processes that Docling / PyMuPDF / OCR tooling
+spawn during extraction may not be reaped or forwarded signals, leaving
+zombies behind and slowing graceful shutdown. The fix is to install
+`tini` in the runtime stage and set it as the `ENTRYPOINT` so it becomes
+PID 1 and forwards signals to uvicorn while reaping zombies.
+
+Issue #139 / #192 added the apt-get layer hygiene convention: every
+`apt-get install` in the runtime stage must pair with
+`--no-install-recommends` and finish with
+`rm -rf /var/lib/apt/lists/*` in the *same* RUN so the apt cache does
+not bloat the image layer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Final
+
+from ._linter_subprocess import REPO_ROOT
+
+_BACKEND_DOCKERFILE: Final[Path] = REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
+
+
+def _read_dockerfile() -> str:
+    return _BACKEND_DOCKERFILE.read_text()
+
+
+def _runtime_stage_text(dockerfile: str) -> str:
+    """Return the substring of `dockerfile` starting at the runtime `FROM` line.
+
+    The runtime stage is the *second* `FROM` directive. The builder stage
+    also installs apt packages but is discarded at the end of the multi-stage
+    build, so its hygiene does not affect the shipped image. Scoping these
+    assertions to the runtime stage keeps them focused on the final layers.
+    """
+    from_lines = [m.start() for m in re.finditer(r"(?m)^FROM ", dockerfile)]
+    assert len(from_lines) >= 2, (
+        f"expected at least two FROM directives (builder + runtime); "
+        f"found {len(from_lines)} in backend.Dockerfile"
+    )
+    return dockerfile[from_lines[1] :]
+
+
+def _collapse_backslash_continuations(text: str) -> str:
+    """Join lines that end in a backslash continuation into a single logical line.
+
+    Dockerfile RUN directives commonly span multiple physical lines via
+    trailing backslashes — ``RUN apt-get update \\`` then indented
+    ``&& apt-get install ...`` on the next line. For regex-based hygiene
+    checks we want to see each RUN as a single logical line, so collapse
+    the escape + newline + leading whitespace into a single space.
+    """
+    return re.sub(r"\\\n\s*", " ", text)
+
+
+def test_runtime_stage_installs_tini_with_no_install_recommends() -> None:
+    """Runtime stage must install `tini` via apt with `--no-install-recommends`.
+
+    tini is the PID 1 init wrapper: it reaps orphaned zombie processes and
+    forwards signals to its single child (uvicorn). Without it, a `docker
+    stop` leaves Docling / PyMuPDF / OCR sub-processes zombied and
+    potentially unkilled. `--no-install-recommends` keeps the package cost
+    to just tini itself (see #192 image-size budget).
+    """
+    runtime = _collapse_backslash_continuations(_runtime_stage_text(_read_dockerfile()))
+    assert re.search(
+        r"apt-get install[^\n]*--no-install-recommends[^\n]*\btini\b",
+        runtime,
+    ), (
+        "runtime stage in infra/docker/backend.Dockerfile does not install tini via "
+        "`apt-get install --no-install-recommends ... tini ...`. Issue #213 requires "
+        "tini as PID 1 for signal forwarding and zombie reaping."
+    )
+
+
+def test_runtime_stage_entrypoint_is_tini_exec_wrapper() -> None:
+    """Runtime stage must set `ENTRYPOINT ["/usr/bin/tini", "--"]`.
+
+    Exec-form JSON array is mandatory so Docker does not wrap in /bin/sh,
+    which would insert a shell as PID 1 and defeat the point of tini. The
+    `--` sentinel tells tini to treat the remaining CMD argv literally,
+    even if a CMD element starts with a dash.
+    """
+    dockerfile = _read_dockerfile()
+    runtime = _runtime_stage_text(dockerfile)
+    assert re.search(
+        r'(?m)^ENTRYPOINT\s*\[\s*"/usr/bin/tini"\s*,\s*"--"\s*\]',
+        runtime,
+    ), (
+        'runtime stage missing `ENTRYPOINT ["/usr/bin/tini", "--"]`. Issue #213 '
+        "requires tini as exec-form ENTRYPOINT so it becomes PID 1 and forwards "
+        "SIGTERM / SIGINT to uvicorn while reaping zombies."
+    )
+
+
+def test_runtime_stage_cmd_preserved_for_uvicorn() -> None:
+    """Runtime stage's CMD must still start uvicorn on 0.0.0.0:8000.
+
+    tini is added as an ENTRYPOINT wrapper; the existing CMD (the uvicorn
+    argv) must be preserved so compose / k8s overrides still work and the
+    healthcheck on :8000 still answers.
+    """
+    runtime = _runtime_stage_text(_read_dockerfile())
+    assert re.search(
+        r'(?m)^CMD\s*\[\s*"uvicorn"\s*,\s*"app\.main:app"[^\]]*"--host"\s*,\s*"0\.0\.0\.0"'
+        r'[^\]]*"--port"\s*,\s*"8000"',
+        runtime,
+    ), (
+        'runtime CMD must remain `["uvicorn", "app.main:app", "--host", '
+        '"0.0.0.0", "--port", "8000"]` (exec form). Issue #213 adds tini only as '
+        "ENTRYPOINT — CMD must not change."
+    )
+
+
+def test_every_apt_install_run_has_layer_hygiene() -> None:
+    """Every `apt-get install` RUN in the runtime stage must pair with
+    `--no-install-recommends` and `rm -rf /var/lib/apt/lists/*` in the *same*
+    RUN directive.
+
+    Splitting the cache cleanup into a separate RUN would leave the apt
+    lists in a prior layer and bloat the image. This is the #139 / #192
+    image-size hygiene convention. Guarding it here prevents future
+    `apt-get install foo` additions from silently breaking it.
+    """
+    runtime = _runtime_stage_text(_read_dockerfile())
+
+    # Collect each `RUN ...` block, honoring backslash line continuations.
+    run_blocks: list[str] = []
+    lines = runtime.splitlines()
+    i = 0
+    while i < len(lines):
+        if lines[i].lstrip().startswith("RUN "):
+            block_lines: list[str] = [lines[i]]
+            while block_lines[-1].rstrip().endswith("\\") and i + 1 < len(lines):
+                i += 1
+                block_lines.append(lines[i])
+            run_blocks.append("\n".join(block_lines))
+        i += 1
+
+    offenders: list[str] = []
+    for block in run_blocks:
+        if "apt-get install" not in block:
+            continue
+        if "--no-install-recommends" not in block:
+            offenders.append(
+                "missing --no-install-recommends in:\n" + block,
+            )
+        if "rm -rf /var/lib/apt/lists/*" not in block:
+            offenders.append(
+                "missing `rm -rf /var/lib/apt/lists/*` in same RUN:\n" + block,
+            )
+
+    assert not offenders, (
+        "runtime stage apt-get hygiene violations (issue #139 / #192):\n"
+        + "\n---\n".join(offenders)
+    )

--- a/apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py
@@ -36,7 +36,11 @@ _BACKEND_DOCKERFILE: Final[Path] = REPO_ROOT / "infra" / "docker" / "backend.Doc
 
 
 def _read_dockerfile() -> str:
-    return _BACKEND_DOCKERFILE.read_text()
+    # Explicit encoding="utf-8" guards against platforms whose default text
+    # encoding is not UTF-8 (e.g., Windows cp1252): the Dockerfile contains
+    # box-drawing glyphs and em-dashes in its section banners, which would
+    # raise UnicodeDecodeError under a non-UTF-8 default.
+    return _BACKEND_DOCKERFILE.read_text(encoding="utf-8")
 
 
 def _runtime_stage_text(dockerfile: str) -> str:

--- a/apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py
@@ -6,12 +6,16 @@ Catches drift of hardening invariants the repo has agreed to across PRs
 so a future copy-paste does not silently regress the posture.
 
 Issue #213: without an `init`-style process at PID 1 (tini / dumb-init),
-signals sent to the container (`docker stop` → SIGTERM) are handled only
-by uvicorn itself. Sub-processes that Docling / PyMuPDF / OCR tooling
-spawn during extraction may not be reaped or forwarded signals, leaving
-zombies behind and slowing graceful shutdown. The fix is to install
-`tini` in the runtime stage and set it as the `ENTRYPOINT` so it becomes
-PID 1 and forwards signals to uvicorn while reaping zombies.
+the bare `uvicorn` runs as PID 1 — the kernel installs no default signal
+handlers for PID 1, so `docker stop` SIGTERM can be silently dropped
+unless uvicorn explicitly handles it. Additionally, any sub-process
+spawned by Docling / PyMuPDF / OCR tooling whose parent dies before
+reaping it is re-parented to PID 1; uvicorn does not reap, so zombies
+accumulate. The fix is to install `tini` in the runtime stage and set it
+as the `ENTRYPOINT` so it becomes PID 1: it forwards SIGTERM / SIGINT to
+its direct child (uvicorn) and reaps adopted orphan processes. tini does
+NOT propagate signals to grandchildren — that remains uvicorn's
+responsibility via its own worker-shutdown path.
 
 Issue #139 / #192 added the apt-get layer hygiene convention: every
 `apt-get install` in the runtime stage must pair with
@@ -66,11 +70,11 @@ def _collapse_backslash_continuations(text: str) -> str:
 def test_runtime_stage_installs_tini_with_no_install_recommends() -> None:
     """Runtime stage must install `tini` via apt with `--no-install-recommends`.
 
-    tini is the PID 1 init wrapper: it reaps orphaned zombie processes and
-    forwards signals to its single child (uvicorn). Without it, a `docker
-    stop` leaves Docling / PyMuPDF / OCR sub-processes zombied and
-    potentially unkilled. `--no-install-recommends` keeps the package cost
-    to just tini itself (see #192 image-size budget).
+    tini is the PID 1 init wrapper: it reaps adopted orphan processes and
+    forwards signals to its direct child (uvicorn). Without it, a `docker
+    stop` may leave orphan Docling / PyMuPDF / OCR sub-processes that no one
+    reaps (uvicorn does not reap as PID 1). `--no-install-recommends` keeps
+    the package cost to just tini itself (see #192 image-size budget).
     """
     runtime = _collapse_backslash_continuations(_runtime_stage_text(_read_dockerfile()))
     assert re.search(
@@ -104,21 +108,24 @@ def test_runtime_stage_entrypoint_is_tini_exec_wrapper() -> None:
 
 
 def test_runtime_stage_cmd_preserved_for_uvicorn() -> None:
-    """Runtime stage's CMD must still start uvicorn on 0.0.0.0:8000.
+    """Runtime stage's CMD must remain the exact uvicorn argv on 0.0.0.0:8000.
 
     tini is added as an ENTRYPOINT wrapper; the existing CMD (the uvicorn
-    argv) must be preserved so compose / k8s overrides still work and the
-    healthcheck on :8000 still answers.
+    argv) must be preserved verbatim so compose / k8s overrides still work
+    and the healthcheck on :8000 still answers. The regex enforces the
+    exact array — no extra elements, no reordering — so a future PR cannot
+    silently insert `--workers 4` or similar without an explicit test
+    update.
     """
     runtime = _runtime_stage_text(_read_dockerfile())
     assert re.search(
-        r'(?m)^CMD\s*\[\s*"uvicorn"\s*,\s*"app\.main:app"[^\]]*"--host"\s*,\s*"0\.0\.0\.0"'
-        r'[^\]]*"--port"\s*,\s*"8000"',
+        r'(?m)^CMD\s*\[\s*"uvicorn"\s*,\s*"app\.main:app"\s*,\s*"--host"\s*,'
+        r'\s*"0\.0\.0\.0"\s*,\s*"--port"\s*,\s*"8000"\s*\]\s*$',
         runtime,
     ), (
-        'runtime CMD must remain `["uvicorn", "app.main:app", "--host", '
-        '"0.0.0.0", "--port", "8000"]` (exec form). Issue #213 adds tini only as '
-        "ENTRYPOINT — CMD must not change."
+        'runtime CMD must remain exactly `["uvicorn", "app.main:app", "--host", '
+        '"0.0.0.0", "--port", "8000"]` (exec form, no extra args). Issue #213 '
+        "adds tini only as ENTRYPOINT — CMD must not change."
     )
 
 

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -48,12 +48,24 @@ FROM ${PYTHON_IMAGE}
 # language data; add more `tesseract-ocr-<lang>` packages here if the service
 # ever needs to OCR non-English PDFs, and set `TESSDATA_PREFIX` accordingly.
 #
-# `tini` is the PID 1 init wrapper (issue #213). Without it, signals sent to
-# the container (e.g. `docker stop` → SIGTERM) are handled only by uvicorn —
-# sub-processes that Docling / PyMuPDF / OCR tooling spawn during extraction
-# would not receive the signal nor be reaped as zombies. tini is a tiny
-# (~10 KB) binary; apt's Debian-stable package is kept to just the binary via
-# `--no-install-recommends`, respecting the #139 / #192 image-size budget.
+# `tini` is the PID 1 init wrapper (issue #213). It does two things the
+# bare `uvicorn` PID 1 cannot:
+#   1. Forwards `docker stop` SIGTERM / SIGINT to its direct child (uvicorn).
+#      A bare PID 1 has no default signal handlers in the kernel and can
+#      silently drop signals unless the program installs handlers itself.
+#      tini does NOT forward signals to grandchildren — sub-processes that
+#      Docling / PyMuPDF / OCR tooling spawn during extraction are signaled
+#      only via uvicorn's own worker-shutdown path, not by tini directly.
+#      (Tini's `-g` flag would forward to the entire process group, but we
+#      deliberately do not enable it: graceful shutdown should let in-flight
+#      OCR/Docling subprocesses finish or time out via uvicorn's teardown,
+#      not be killed mid-run.)
+#   2. Reaps adopted orphan processes. Any sub-process whose parent dies
+#      before reaping it is re-parented to PID 1; uvicorn does not reap, so
+#      without tini those zombies accumulate.
+# tini is a tiny (~10 KB) binary; apt's Debian-stable package is kept to
+# just the binary via `--no-install-recommends`, respecting the
+# #139 / #192 image-size budget.
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         tesseract-ocr \
@@ -85,8 +97,10 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
 # Exec-form ENTRYPOINT so Docker does not wrap it in /bin/sh (which would
 # insert a shell as PID 1 and defeat the point of tini). The `--` sentinel
 # tells tini to treat the remaining CMD argv literally, even if a CMD
-# element starts with a dash. tini forwards SIGTERM / SIGINT to uvicorn and
-# reaps orphaned zombie processes (issue #213). CMD is preserved as-is so
-# compose / k8s overrides of the uvicorn argv keep working.
+# element starts with a dash. tini forwards SIGTERM / SIGINT to its direct
+# child (uvicorn) and reaps orphan processes adopted by PID 1 (issue #213);
+# see the runtime-stage comment block above for why we do NOT enable tini's
+# `-g` process-group forwarding. CMD is preserved as-is so compose / k8s
+# overrides of the uvicorn argv keep working.
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -47,10 +47,18 @@ FROM ${PYTHON_IMAGE}
 # the image-size work in issue #139). `tesseract-ocr-eng` supplies the English
 # language data; add more `tesseract-ocr-<lang>` packages here if the service
 # ever needs to OCR non-English PDFs, and set `TESSDATA_PREFIX` accordingly.
+#
+# `tini` is the PID 1 init wrapper (issue #213). Without it, signals sent to
+# the container (e.g. `docker stop` → SIGTERM) are handled only by uvicorn —
+# sub-processes that Docling / PyMuPDF / OCR tooling spawn during extraction
+# would not receive the signal nor be reaped as zombies. tini is a tiny
+# (~10 KB) binary; apt's Debian-stable package is kept to just the binary via
+# `--no-install-recommends`, respecting the #139 / #192 image-size budget.
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         tesseract-ocr \
         tesseract-ocr-eng \
+        tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Run as non-root user
@@ -74,4 +82,11 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
 
+# Exec-form ENTRYPOINT so Docker does not wrap it in /bin/sh (which would
+# insert a shell as PID 1 and defeat the point of tini). The `--` sentinel
+# tells tini to treat the remaining CMD argv literally, even if a CMD
+# element starts with a dash. tini forwards SIGTERM / SIGINT to uvicorn and
+# reaps orphaned zombie processes (issue #213). CMD is preserved as-is so
+# compose / k8s overrides of the uvicorn argv keep working.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Install `tini` in the backend Dockerfile runtime stage (appended to the existing tesseract `apt-get install ... --no-install-recommends ... && rm -rf /var/lib/apt/lists/*` RUN so the layer stays cache-clean and under the #192 image-size budget).
- Set `ENTRYPOINT ["/usr/bin/tini", "--"]` in exec form so tini becomes PID 1 inside the container and forwards SIGTERM / SIGINT to uvicorn while reaping zombie child processes spawned by Docling / PyMuPDF / OCR.
- Add `apps/backend/tests/unit/architecture/test_dockerfile_hygiene.py` with four parametrized static assertions: `tini` is installed with `--no-install-recommends`, the `ENTRYPOINT` is exactly `["/usr/bin/tini", "--"]`, the existing uvicorn CMD is preserved, and every runtime-stage `apt-get install` RUN keeps the #139 / #192 hygiene convention (`--no-install-recommends` + same-layer apt cache cleanup).

## Test plan
- [x] RED: `test_runtime_stage_installs_tini_with_no_install_recommends` and `test_runtime_stage_entrypoint_is_tini_exec_wrapper` fail on unchanged `main` — verified before editing the Dockerfile.
- [x] GREEN: after adding the tini install and `ENTRYPOINT`, all four hygiene tests flip green; full `apps/backend/tests/unit/architecture/` suite (37 tests) passes.
- [x] `task check` passes end-to-end from `apps/backend/` (lint + types + skills + unit + integration + contract + errors).
- [ ] Manual `docker build` + `docker stop` timing not verified locally — no Docker daemon available in the sandboxed worktree. The static guarantees above enforce the acceptance criteria for tini installation, PID 1 wrapping, and CMD preservation. Image size increase for `tini` on Debian-stable is ~10 KB (well under the 5 MB budget from #192). `docker-compose.yml` healthcheck unchanged and still targets the same `:8000/health` endpoint, so it continues to pass.

Closes #213.