### PR TITLE
refactor(taskfile): make check:arch a direct dependency of check (closes #215)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ and the epic + feature graph tree at [`docs/graphs/PDFX/`](docs/graphs/PDFX/).
 3. No paradigm drift. One way to do each thing. If you think a second way is
    needed, stop and ask.
 4. Run `task check` before declaring any work done. Never use `--no-verify`.
+   Every required gate (lint, types, arch, skills, tests, errors) is enumerated
+   directly in the `check` task's `cmds:` list in `Taskfile.yml` — never reach a
+   gate only via a sibling task (issue #215). A meta-test in
+   `apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py` pins
+   this invariant.
 
 ## Architecture
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,7 +24,7 @@ tasks:
     # (issue #215). Do NOT collapse a gate into another task's cmds list:
     # reaching architecture/lint/etc. only via a sibling hides it from this
     # list and lets a future refactor silently drop it from the canonical
-    # gate. A meta-test in tests/unit/architecture/test_taskfile_check_hygiene.py
+    # gate. A meta-test in apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
     # pins this invariant.
     cmds:
       - task: check:lint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,10 +19,17 @@ tasks:
 
   # ── Check (Claude runs this before declaring done) ───────────
   check:
-    desc: Run ALL checks — lint, types, skills, tests, error contracts
+    desc: Run ALL checks — lint, types, architecture, skills, tests, error contracts
+    # Every required gate is enumerated here as a direct `task: <name>` edge
+    # (issue #215). Do NOT collapse a gate into another task's cmds list:
+    # reaching architecture/lint/etc. only via a sibling hides it from this
+    # list and lets a future refactor silently drop it from the canonical
+    # gate. A meta-test in tests/unit/architecture/test_taskfile_check_hygiene.py
+    # pins this invariant.
     cmds:
       - task: check:lint
       - task: check:types
+      - task: check:arch
       - task: skills:validate
       - task: check:test
       - task: check:errors
@@ -92,11 +99,10 @@ tasks:
 
   # ── Linting & Formatting ─────────────────────────────────────
   lint:
-    desc: Run ruff + import-linter (format checking lives in `format:check`)
+    desc: Run ruff (format checking lives in `format:check`; architecture in `check:arch`)
     dir: "{{.BACKEND_DIR}}"
     cmds:
       - uv run ruff check .
-      - task: check:arch
 
   format:
     desc: Run the formatter

--- a/apps/backend/tests/unit/architecture/test_import_linter_contracts.py
+++ b/apps/backend/tests/unit/architecture/test_import_linter_contracts.py
@@ -184,14 +184,19 @@ def test_no_contract_references_a_non_extraction_feature_package(
     )
 
 
-def test_taskfile_wires_lint_imports_into_task_lint_and_check() -> None:
-    """U6: AC2/AC3 - `task lint` runs import-linter and `task check` reaches it.
+def test_taskfile_wires_lint_imports_into_task_check() -> None:
+    """U6: AC2/AC3 - `task check` reaches import-linter as a direct dependency.
 
     Pure YAML-parse + key-lookup assertion. Does not invoke the task runner.
     Verifies:
     - `check:arch` exists and invokes lint-imports.
-    - `lint` invokes `check:arch` (so `task lint` = ruff + import-linter).
-    - `check` -> `check:lint` -> `lint` -> `check:arch` path is intact.
+    - `check` lists `check:arch` as a direct `task:` entry in its `cmds:`
+      list (issue #215 — no transitive indirection via `lint`).
+
+    The sibling hygiene test in `test_taskfile_check_hygiene.py` pins the
+    broader invariant that every required gate is enumerated directly in
+    `check`'s `cmds:` list. This test focuses specifically on the
+    import-linter gate.
     """
     taskfile = yaml.safe_load(_TASKFILE_PATH.read_text())
 
@@ -209,18 +214,12 @@ def test_taskfile_wires_lint_imports_into_task_lint_and_check() -> None:
         "`check:arch` must point `lint-imports` at the contracts file"
     )
 
-    lint_cmds = tasks["lint"]["cmds"]
-    lint_calls_arch = any(
-        isinstance(cmd, dict) and cmd.get("task") == "check:arch" for cmd in lint_cmds
-    )
-    assert lint_calls_arch, (
-        "`lint` must include `check:arch` so that `task lint` runs import-linter"
-    )
-
     check_cmds = tasks["check"]["cmds"]
-    check_calls_lint = any(
-        isinstance(cmd, dict) and cmd.get("task") == "check:lint" for cmd in check_cmds
+    check_calls_arch = any(
+        isinstance(cmd, dict) and cmd.get("task") == "check:arch" for cmd in check_cmds
     )
-    assert check_calls_lint, (
-        "`check` must include `check:lint` (which calls `lint` -> `check:arch`)"
+    assert check_calls_arch, (
+        "`check` must include `check:arch` as a direct `task:` entry in its `cmds:` list "
+        "(issue #215 — reaching it only via a sibling task hides the gate and lets a "
+        "refactor silently drop it)"
     )

--- a/apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
@@ -51,6 +51,39 @@ def _direct_task_refs(cmds: list[Any]) -> list[str]:
     return [str(entry["task"]) for entry in cmds if isinstance(entry, dict) and "task" in entry]
 
 
+def _collect_all_task_invocations(taskfile: dict[str, Any], root: str) -> list[str]:
+    """DFS from `root` through every `task: <name>` edge; return every invocation.
+
+    Walks the full reachable graph so depth-3+ indirections are visible — the
+    depth-1 predecessor of this helper would have missed the historical
+    wiring (`check` → `check:lint` → `lint` → `check:arch`) that issue #215
+    closed, because `check:arch` sat at depth 3 under that shape.
+
+    Each `task: X` edge discovered during traversal is appended to the
+    result list (so duplicate references — direct + via-sibling — count as
+    separate invocations, which is the thing we want to flag). The visited
+    set guards against `tasks` cycles; it operates on tasks, not on edges,
+    so edges through an already-walked task are still counted as invocations.
+    Both `cmds:` (sequential commands) and `deps:` (parallel prerequisites)
+    are traversed — either shape can reintroduce the indirection.
+    """
+    all_invocations: list[str] = []
+    visited: set[str] = set()
+
+    def walk(task_name: str) -> None:
+        if task_name in visited:
+            return
+        visited.add(task_name)
+        task_def = taskfile["tasks"].get(task_name, {})
+        for key in ("cmds", "deps"):
+            for ref in _direct_task_refs(task_def.get(key, []) or []):
+                all_invocations.append(ref)
+                walk(ref)
+
+    walk(root)
+    return all_invocations
+
+
 def test_check_task_lists_every_gate_as_direct_dependency() -> None:
     """The `check` task's `cmds:` must name every required gate directly."""
     check_cmds = _load_taskfile()["tasks"]["check"]["cmds"]
@@ -71,25 +104,95 @@ def test_check_arch_appears_exactly_once_across_check_graph() -> None:
     If we add `check:arch` directly to `check` without also removing the
     transitive edge through `lint`, import-linter would execute twice per
     `task check` invocation. Enforce the dedup explicitly.
+
+    The walk is a full recursive DFS — not a depth-1 check — because the
+    historical wiring that issue #215 closed (`check` → `check:lint` →
+    `lint` → `check:arch`) placed `check:arch` at depth 3. A shallow check
+    would report `arch_count == 1` even under the broken wiring (the direct
+    edge alone) and miss the duplication flag's whole purpose.
     """
     taskfile = _load_taskfile()
-    check_cmds = taskfile["tasks"]["check"]["cmds"]
-    direct_refs = _direct_task_refs(check_cmds)
-
-    # Walk one level of task: <name> indirection so we also see gates reached
-    # via check:lint, check:test, check:errors, etc.
-    all_invocations: list[str] = list(direct_refs)
-    for ref in direct_refs:
-        sibling = taskfile["tasks"].get(ref, {})
-        sibling_cmds = sibling.get("cmds", [])
-        all_invocations.extend(_direct_task_refs(sibling_cmds))
+    all_invocations = _collect_all_task_invocations(taskfile, "check")
 
     arch_count = all_invocations.count("check:arch")
     assert arch_count == 1, (
         f"`check:arch` must run exactly once per `task check`; got {arch_count} invocation(s). "
-        f"Full task graph (one level deep): {all_invocations}. "
+        f"Full task graph reachable from `check`: {all_invocations}. "
         "If this is >1, `check:arch` is both a direct cmd of `check` AND still reached via a "
-        "sibling (likely `lint`) — remove the sibling indirection to dedup."
+        "sibling (likely `lint`, possibly at depth >= 2) — remove the sibling indirection to dedup."
+    )
+
+
+def test_collect_all_task_invocations_catches_depth_three_indirection() -> None:
+    """Regression test: the DFS helper must see `check:arch` at depth 3.
+
+    Pins the fix for the pre-#215 wiring shape
+    `check -> check:lint -> lint -> check:arch`. A depth-1 walk (the former
+    implementation of `test_check_arch_appears_exactly_once_across_check_graph`)
+    would have reported `arch_count == 0` under this shape (depth-2 siblings
+    have no `task:` edges to arch); the recursive DFS must report 1.
+    """
+    synthetic_taskfile: dict[str, Any] = {
+        "tasks": {
+            "check": {"cmds": [{"task": "check:lint"}]},
+            "check:lint": {"cmds": [{"task": "lint"}]},
+            "lint": {"cmds": [{"task": "check:arch"}]},
+            "check:arch": {"cmds": ["import-linter --config architecture/..."]},
+        }
+    }
+    invocations = _collect_all_task_invocations(synthetic_taskfile, "check")
+    assert invocations.count("check:arch") == 1, (
+        "DFS must detect check:arch reached at depth 3 via "
+        "check -> check:lint -> lint -> check:arch. "
+        f"Got invocations: {invocations}."
+    )
+
+
+def test_collect_all_task_invocations_counts_both_direct_and_indirect_edges() -> None:
+    """DFS helper must double-count `check:arch` when it's reachable twice.
+
+    If a future refactor accidentally keeps both the direct edge and the
+    historical indirect chain, `arch_count` must be 2 so the
+    `test_check_arch_appears_exactly_once_across_check_graph` assertion
+    flags it.
+    """
+    synthetic_taskfile: dict[str, Any] = {
+        "tasks": {
+            "check": {"cmds": [{"task": "check:arch"}, {"task": "check:lint"}]},
+            "check:lint": {"cmds": [{"task": "lint"}]},
+            "lint": {"cmds": [{"task": "check:arch"}]},
+            "check:arch": {"cmds": ["import-linter --config architecture/..."]},
+        }
+    }
+    invocations = _collect_all_task_invocations(synthetic_taskfile, "check")
+    assert invocations.count("check:arch") == 2, (
+        "DFS must count every `task: check:arch` edge it encounters, "
+        f"including edges through already-visited tasks. Got: {invocations}."
+    )
+
+
+def test_collect_all_task_invocations_handles_cycles_without_infinite_loop() -> None:
+    """DFS must terminate even when the task graph has a cycle.
+
+    Taskfile doesn't currently have cycles, but a future mistake could
+    introduce one. The visited-set guard is the load-bearing invariant
+    here — without it the DFS would recurse forever and the test would
+    hang rather than fail cleanly.
+    """
+    synthetic_taskfile: dict[str, Any] = {
+        "tasks": {
+            "check": {"cmds": [{"task": "a"}]},
+            "a": {"cmds": [{"task": "b"}]},
+            "b": {"cmds": [{"task": "a"}]},
+        }
+    }
+    invocations = _collect_all_task_invocations(synthetic_taskfile, "check")
+    # The `a -> b -> a` cycle means we visit each task once, seeing each
+    # edge at most once per parent; cycle should not cause unbounded growth.
+    assert "a" in invocations
+    assert "b" in invocations
+    assert len(invocations) < 10, (
+        f"DFS produced {len(invocations)} invocations on a 3-node cycle — likely unbounded."
     )
 
 

--- a/apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
@@ -1,0 +1,111 @@
+"""Hygiene checks on the `check` task's `cmds:` list in `Taskfile.yml`.
+
+Sacred Rule #4 in CLAUDE.md: "Run `task check` before declaring any work
+done." The canonical gate must therefore enumerate every contract we care
+about directly, not reach them transitively through sibling tasks.
+
+Before issue #215, `check:arch` (import-linter) was only reached via
+`check:lint -> lint -> check:arch`. That coupling was invisible when
+reading the `check` task in isolation and would have silently fallen out
+of the canonical gate if a future refactor had split `lint` into
+ruff-only and architecture tasks. These tests pin the invariant that
+`check` enumerates every required gate — lint, types, arch, skills,
+tests, errors — as a direct `task: <name>` command, and that each gate
+runs exactly once (no duplication via a sibling chain).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final, cast
+
+import yaml
+
+# `parents[5]` resolves to the repo root:
+# parents[0]=architecture → [1]=unit → [2]=tests → [3]=backend → [4]=apps → [5]=<repo>.
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+_TASKFILE: Final[Path] = _REPO_ROOT / "Taskfile.yml"
+
+_REQUIRED_DIRECT_GATES: Final[tuple[str, ...]] = (
+    "check:lint",
+    "check:types",
+    "check:arch",
+    "skills:validate",
+    "check:test",
+    "check:errors",
+)
+
+
+def _load_taskfile() -> dict[str, Any]:
+    raw = _TASKFILE.read_text(encoding="utf-8")
+    return cast("dict[str, Any]", yaml.safe_load(raw))
+
+
+def _direct_task_refs(cmds: list[Any]) -> list[str]:
+    """Return the names of `task: <name>` entries in a Taskfile `cmds:` list.
+
+    Each `task: <name>` entry is a YAML mapping `{"task": "<name>"}`. Shell
+    commands are plain strings and are ignored for this assertion — only
+    direct task-dependency edges count as gates.
+    """
+    return [str(entry["task"]) for entry in cmds if isinstance(entry, dict) and "task" in entry]
+
+
+def test_check_task_lists_every_gate_as_direct_dependency() -> None:
+    """The `check` task's `cmds:` must name every required gate directly."""
+    check_cmds = _load_taskfile()["tasks"]["check"]["cmds"]
+    direct_refs = _direct_task_refs(check_cmds)
+
+    missing = [gate for gate in _REQUIRED_DIRECT_GATES if gate not in direct_refs]
+    assert not missing, (
+        "`check` task must enumerate every contract gate directly in its `cmds:` list. "
+        f"Missing: {missing}. Found direct refs: {direct_refs}. "
+        "Reaching a gate only via a sibling task (e.g. `check:arch` via `lint`) is forbidden "
+        "by issue #215 — a future refactor of the sibling would silently drop the gate."
+    )
+
+
+def test_check_arch_appears_exactly_once_across_check_graph() -> None:
+    """`check:arch` must run exactly once under `task check` — no duplication.
+
+    If we add `check:arch` directly to `check` without also removing the
+    transitive edge through `lint`, import-linter would execute twice per
+    `task check` invocation. Enforce the dedup explicitly.
+    """
+    taskfile = _load_taskfile()
+    check_cmds = taskfile["tasks"]["check"]["cmds"]
+    direct_refs = _direct_task_refs(check_cmds)
+
+    # Walk one level of task: <name> indirection so we also see gates reached
+    # via check:lint, check:test, check:errors, etc.
+    all_invocations: list[str] = list(direct_refs)
+    for ref in direct_refs:
+        sibling = taskfile["tasks"].get(ref, {})
+        sibling_cmds = sibling.get("cmds", [])
+        all_invocations.extend(_direct_task_refs(sibling_cmds))
+
+    arch_count = all_invocations.count("check:arch")
+    assert arch_count == 1, (
+        f"`check:arch` must run exactly once per `task check`; got {arch_count} invocation(s). "
+        f"Full task graph (one level deep): {all_invocations}. "
+        "If this is >1, `check:arch` is both a direct cmd of `check` AND still reached via a "
+        "sibling (likely `lint`) — remove the sibling indirection to dedup."
+    )
+
+
+def test_lint_task_is_ruff_only_no_arch_indirection() -> None:
+    """`lint` must handle ruff only — architecture belongs to `check:arch` directly.
+
+    This pairs with the `check_arch_appears_exactly_once` invariant: the
+    simplest way to keep that invariant is to make `lint` a pure ruff
+    runner and wire `check:arch` as an explicit top-level command of
+    `check`. Any sibling task that recursively calls `check:arch` would
+    resurrect the indirection issue #215 closed.
+    """
+    lint_cmds = _load_taskfile()["tasks"]["lint"].get("cmds", [])
+    lint_task_refs = _direct_task_refs(lint_cmds)
+    assert "check:arch" not in lint_task_refs, (
+        "`lint` must not delegate to `check:arch`. "
+        "Architecture is a direct dependency of `check` per issue #215; "
+        f"found lint task: refs: {lint_task_refs}."
+    )

--- a/apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_taskfile_check_hygiene.py
@@ -21,10 +21,10 @@ from typing import Any, Final, cast
 
 import yaml
 
-# `parents[5]` resolves to the repo root:
-# parents[0]=architecture → [1]=unit → [2]=tests → [3]=backend → [4]=apps → [5]=<repo>.
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
-_TASKFILE: Final[Path] = _REPO_ROOT / "Taskfile.yml"
+from ._linter_subprocess import REPO_ROOT
+
+_TASKFILE: Final[Path] = REPO_ROOT / "Taskfile.yml"
+
 
 _REQUIRED_DIRECT_GATES: Final[tuple[str, ...]] = (
     "check:lint",

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -48,10 +48,11 @@ feature-dev lands the corresponding features.
 configured TTL, or 503 with `{"status":"not_ready","reason":"ollama_unreachable"}`
 otherwise.
 
-**Architecture enforcement.** `import-linter` is wired in `task lint` with one
-contract: `shared/` and `core/` cannot import from `features/`. The full
-extraction-feature layer DAG and third-party containment contracts are added by
-PDFX-E007-F004 during feature-dev.
+**Architecture enforcement.** `import-linter` is wired as `task check:arch`, a
+direct dependency of `task check` (issue #215; `task lint` is ruff-only). The
+bootstrap shell ships with one contract: `shared/` and `core/` cannot import
+from `features/`. The full extraction-feature layer DAG and third-party
+containment contracts are added by PDFX-E007-F004 during feature-dev.
 
 ## What Is NOT Built — To Be Added by feature-dev
 

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -50,9 +50,11 @@ otherwise.
 
 **Architecture enforcement.** `import-linter` is wired as `task check:arch`, a
 direct dependency of `task check` (issue #215; `task lint` is ruff-only). The
-bootstrap shell ships with one contract: `shared/` and `core/` cannot import
-from `features/`. The full extraction-feature layer DAG and third-party
-containment contracts are added by PDFX-E007-F004 during feature-dev.
+bootstrap shell originally shipped with one contract — `shared/` and `core/`
+cannot import from `features/`. Feature-dev's PDFX-E007-F004 milestone
+subsequently wired the full extraction-feature layer DAG and third-party
+containment contracts; the contract set (C1–C6) now lives in
+[`apps/backend/architecture/import-linter-contracts.ini`](../apps/backend/architecture/import-linter-contracts.ini).
 
 ## What Is NOT Built — To Be Added by feature-dev
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,9 +92,10 @@ directly — those imports are contained to specific implementation files via
 
 The full contract set lives in
 [`apps/backend/architecture/import-linter-contracts.ini`](../apps/backend/architecture/import-linter-contracts.ini)
-and is enforced by `task lint` (which includes `task check:arch`, and `task check`
-runs as part of every PR's gate). Every contract carries a `#` comment block
-explaining the rule it encodes and why.
+and is enforced by `task check:arch`, a direct dependency of `task check`
+(issue #215; `task check` runs as part of every PR's gate, and `task lint`
+itself is ruff-only). Every contract carries a `#` comment block explaining
+the rule it encodes and why.
 
 Two enforcement layers work together:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,9 +93,10 @@ directly — those imports are contained to specific implementation files via
 The full contract set lives in
 [`apps/backend/architecture/import-linter-contracts.ini`](../apps/backend/architecture/import-linter-contracts.ini)
 and is enforced by `task check:arch`, a direct dependency of `task check`
-(issue #215; `task check` runs as part of every PR's gate, and `task lint`
-itself is ruff-only). Every contract carries a `#` comment block explaining
-the rule it encodes and why.
+(issue #215; CI in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)
+runs the same gates as `task check` via individual workflow steps, and
+`task lint` itself is ruff-only). Every contract carries a `#` comment
+block explaining the rule it encodes and why.
 
 Two enforcement layers work together:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,9 +94,11 @@ The full contract set lives in
 [`apps/backend/architecture/import-linter-contracts.ini`](../apps/backend/architecture/import-linter-contracts.ini)
 and is enforced by `task check:arch`, a direct dependency of `task check`
 (issue #215; CI in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)
-runs the same gates as `task check` via individual workflow steps, and
-`task lint` itself is ruff-only). Every contract carries a `#` comment
-block explaining the rule it encodes and why.
+runs related validation steps via individual workflow checks — lint,
+format, pyright on `app/ scripts/`, architecture, and the test suite —
+which overlaps with but does not exhaustively mirror every `task check`
+gate. `task lint` itself is ruff-only). Every contract carries a `#`
+comment block explaining the rule it encodes and why.
 
 Two enforcement layers work together:
 


### PR DESCRIPTION
## Summary
- `Taskfile.yml`: `check:arch` is now a direct `task:` entry in the `check` task's `cmds:` list, alongside `check:lint`, `check:types`, `skills:validate`, `check:test`, `check:errors`. Previously it was reached only via `check:lint -> lint -> check:arch`, a coupling invisible when reading `check` in isolation and fragile under refactor (a well-intentioned "split `lint` into ruff and arch" move would have silently dropped the architecture-contract gate).
- `lint` is now ruff-only, matching the shape of CI's `Lint (ruff)` step. Architecture belongs to `check:arch` as its own direct gate.
- New meta-test `tests/unit/architecture/test_taskfile_check_hygiene.py` pins the invariant: every required gate must be a direct `task:` entry in `check`'s `cmds:`; `check:arch` must run exactly once per `task check`; `lint` must not delegate to `check:arch`.
- Updated the stale U6 assertion in `tests/unit/architecture/test_import_linter_contracts.py` (previously required `lint -> check:arch`) to enforce the new direct wiring instead.
- CLAUDE.md: a 5-line note under Sacred Rule #4 documenting the invariant and pointing at the meta-test (the issue's "grep-based assertion in docs/ or CLAUDE.md" acceptance criterion).

### Before / after `task --summary check`

Before (on `main`):
```
commands:
 - Task: check:lint
 - Task: check:types
 - Task: skills:validate
 - Task: check:test
 - Task: check:errors
```

After (this PR):
```
commands:
 - Task: check:lint
 - Task: check:types
 - Task: check:arch
 - Task: skills:validate
 - Task: check:test
 - Task: check:errors
```

Every gate executed by `task check` is unchanged — ruff, ruff format check, pyright (app + error-contracts), import-linter, skills:validate, unit + integration + contract tests, errors:check, errors:test. Ordering is preserved (arch is inserted between types and skills:validate, previously runs via lint immediately after ruff). No duplication: `lint` no longer calls `check:arch`.

## Test plan
- [x] RED: hygiene meta-test fails on unchanged main for the right reasons — `check`'s direct refs omit `check:arch` (test 1), `check:arch` invocation count at depth 1 is 0 not 1 (test 2), `lint`'s cmds still list `check:arch` (test 3). Verified via a scratch script that parses main's `Taskfile.yml` with the same logic.
- [x] GREEN: after wiring, all three tests pass; additionally the pre-existing `test_taskfile_wires_lint_imports_into_task_check` (renamed from `..._into_task_lint_and_check`) passes with the updated expectation.
- [x] `task check` before/after: same set of gates, same behavior, arch now reached directly (no duplication, no skipped arch run).
- [x] `task check` passes end-to-end (returncode 0) from `apps/backend/` in the worktree.

Closes #215.