### PR TITLE
fix(logging): centralize stdlib logger suppression (closes #210)

### DIFF
--- a/apps/backend/app/core/logging.py
+++ b/apps/backend/app/core/logging.py
@@ -39,14 +39,19 @@ def silence_stdlib_logger(logger_name: str, level: int) -> None:
        module (the pattern the parser used to have at import time before
        issue #210).
 
-    Cap semantics: this never *reduces* an existing stricter explicit level.
-    If the logger has already been configured to a higher numeric level than
-    ``level`` (i.e. emits less, e.g. ``ERROR`` when ``level`` is ``WARNING``),
-    we leave it alone. We only raise the floor when the logger is at NOTSET
-    (the default for a fresh logger) or at a lower numeric level than the
-    requested cap. This guards against the silent-volume-increase failure
-    mode where a noisy third party was already aggressively suppressed by
-    something earlier in startup and our default cap would walk it back.
+    Cap semantics: this never *reduces* the EFFECTIVE log threshold of the
+    target logger. If the effective level is already numerically higher than
+    ``level`` (stricter — emits less) — whether explicitly set on the target
+    or inherited from an ancestor — we leave the logger alone. We only raise
+    the floor when the effective level is below ``level``.
+
+    The check runs against ``logger.getEffectiveLevel()`` rather than the
+    raw ``logger.level``. Example of why this matters: if the root logger
+    is at ERROR and the target is NOTSET (so its effective level is ERROR
+    inherited), naïvely calling ``setLevel(WARNING)`` on the target would
+    *lower* the effective threshold (ERROR → WARNING) and increase log
+    volume, contradicting the cap intent. Reading the effective level
+    catches both explicit and inherited state in one check.
 
     Args:
         logger_name: The stdlib logger name to suppress
@@ -55,11 +60,11 @@ def silence_stdlib_logger(logger_name: str, level: int) -> None:
             (e.g. ``logging.WARNING``, ``logging.ERROR``).
     """
     logger = logging.getLogger(logger_name)
-    # `logger.level` is the explicitly-set level (NOTSET = 0 if unset). We
-    # use it (not `getEffectiveLevel`) so an unset child whose *effective*
-    # level is inherited from a parent still gets capped — the parent's
-    # level was meant for the parent's tree, not as a per-child override.
-    if logger.level < level:
+    # Use `getEffectiveLevel()` so inheritance from ancestors counts as a
+    # pre-existing stricter level — otherwise setting an explicit level on
+    # a NOTSET child could silently lower the effective threshold inherited
+    # from the root/ancestor (Copilot-review feedback on PR #224).
+    if logger.getEffectiveLevel() < level:
         logger.setLevel(level)
 
 

--- a/apps/backend/app/core/logging.py
+++ b/apps/backend/app/core/logging.py
@@ -39,13 +39,28 @@ def silence_stdlib_logger(logger_name: str, level: int) -> None:
        module (the pattern the parser used to have at import time before
        issue #210).
 
+    Cap semantics: this never *reduces* an existing stricter explicit level.
+    If the logger has already been configured to a higher numeric level than
+    ``level`` (i.e. emits less, e.g. ``ERROR`` when ``level`` is ``WARNING``),
+    we leave it alone. We only raise the floor when the logger is at NOTSET
+    (the default for a fresh logger) or at a lower numeric level than the
+    requested cap. This guards against the silent-volume-increase failure
+    mode where a noisy third party was already aggressively suppressed by
+    something earlier in startup and our default cap would walk it back.
+
     Args:
         logger_name: The stdlib logger name to suppress
             (e.g. ``"docling"``, ``"httpx"``, ``"httpcore"``).
         level: The numeric level to cap the logger at
             (e.g. ``logging.WARNING``, ``logging.ERROR``).
     """
-    logging.getLogger(logger_name).setLevel(level)
+    logger = logging.getLogger(logger_name)
+    # `logger.level` is the explicitly-set level (NOTSET = 0 if unset). We
+    # use it (not `getEffectiveLevel`) so an unset child whose *effective*
+    # level is inherited from a parent still gets capped — the parent's
+    # level was meant for the parent's tree, not as a per-child override.
+    if logger.level < level:
+        logger.setLevel(level)
 
 
 def configure_logging(

--- a/apps/backend/app/core/logging.py
+++ b/apps/backend/app/core/logging.py
@@ -1,4 +1,14 @@
-"""Structured logging configuration with structlog."""
+"""Structured logging configuration with structlog.
+
+This module is the ONE and ONLY place in `app/` that is permitted to call
+`logging.getLogger`. CLAUDE.md forbids the pattern everywhere else because
+direct stdlib `logging` calls bypass the structlog processor chain (and the
+redaction filter installed by `configure_logging`). The `silence_stdlib_logger`
+helper below gives feature code a structured way to request suppression of a
+noisy third-party logger without reaching for `logging.getLogger` directly —
+new suppressions are wired from `configure_logging` below rather than from
+individual feature modules at import time (issue #210).
+"""
 
 import logging
 import sys
@@ -6,6 +16,36 @@ import sys
 import structlog
 
 from app.core.log_redaction_filter import LogRedactionFilter
+
+
+def silence_stdlib_logger(logger_name: str, level: int) -> None:
+    """Cap a third-party stdlib logger at `level` (defense against noisy deps).
+
+    Why this helper exists: Docling, httpx, httpcore, SQLAlchemy and similar
+    third-party libraries emit INFO/DEBUG logs through the stdlib ``logging``
+    module. Without suppression they would flood our service's structured
+    log stream. The obvious fix is
+    ``logging.getLogger(name).setLevel(level)``, but CLAUDE.md bans
+    ``logging.getLogger`` outside this module — the architecture test
+    ``test_only_core_logging_py_uses_logging_getlogger`` enforces that.
+
+    Centralising the call here gives three wins at once:
+
+    1. Every suppression is visible in one file — easy to audit.
+    2. Feature modules never call ``logging.getLogger`` directly, so the
+       CLAUDE.md rule holds by construction.
+    3. Suppression is driven by ``configure_logging`` at application
+       startup, not as a module-import side effect of an unrelated feature
+       module (the pattern the parser used to have at import time before
+       issue #210).
+
+    Args:
+        logger_name: The stdlib logger name to suppress
+            (e.g. ``"docling"``, ``"httpx"``, ``"httpcore"``).
+        level: The numeric level to cap the logger at
+            (e.g. ``logging.WARNING``, ``logging.ERROR``).
+    """
+    logging.getLogger(logger_name).setLevel(level)
 
 
 def configure_logging(
@@ -85,12 +125,18 @@ def configure_logging(
     root_logger.addHandler(handler)
     root_logger.setLevel(log_level.upper())
 
-    # Silence noisy third-party loggers
+    # Silence noisy third-party loggers.
+    #
+    # "docling" is listed here (not at Docling-parser module-import time, where
+    # it used to live) so issue #210's invariant holds: only this file calls
+    # `logging.getLogger`. The parser module no longer needs to import
+    # `logging` at all.
     noisy_loggers = {
         "uvicorn.access": logging.WARNING,
         "sqlalchemy.engine": logging.WARNING,
         "httpx": logging.WARNING,
         "httpcore": logging.WARNING,
+        "docling": logging.WARNING,
     }
     for logger_name, level in noisy_loggers.items():
-        logging.getLogger(logger_name).setLevel(level)
+        silence_stdlib_logger(logger_name, level)

--- a/apps/backend/app/features/extraction/parsing/docling_document_parser.py
+++ b/apps/backend/app/features/extraction/parsing/docling_document_parser.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import logging
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -47,11 +46,12 @@ if TYPE_CHECKING:
 
 _log = structlog.get_logger(__name__)
 
-# Docling's own logs must not flood service stdout. Setting the level here is
-# cheap (it only installs a filter on the root docling logger) and safe to do
-# unconditionally even when docling is not installed — Python's logging
-# module creates the logger on demand without importing the package.
-logging.getLogger("docling").setLevel(logging.WARNING)
+# Docling's own logs are capped at WARNING by `configure_logging` in
+# `app.core.logging` (via the `silence_stdlib_logger` helper). This module
+# deliberately does NOT reach into the stdlib logging module directly —
+# CLAUDE.md forbids that pattern outside `app/core/logging.py`, and the
+# architecture test `test_only_core_logging_py_uses_logging_getlogger`
+# enforces it (issue #210).
 
 
 def _default_pdf_preflight(pdf_bytes: bytes) -> int:

--- a/apps/backend/tests/unit/architecture/test_logging_getlogger_containment.py
+++ b/apps/backend/tests/unit/architecture/test_logging_getlogger_containment.py
@@ -32,30 +32,88 @@ _APP_ROOT: Final[Path] = BACKEND_DIR / "app"
 _ALLOWED_FILE: Final[Path] = _APP_ROOT / "core" / "logging.py"
 
 
-def _file_calls_logging_getlogger(py_file: Path) -> bool:
-    """Return True iff the file invokes ``logging.getLogger(...)`` as a real call.
+def _collect_logging_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Walk import nodes and return (logging-module aliases, getLogger aliases).
 
-    Parses the file's AST and looks for any ``Call`` node whose function is
-    the attribute access ``logging.getLogger``. This deliberately skips:
+    Always seeds the module-alias set with the canonical name ``"logging"``
+    so a fully-qualified ``logging.getLogger`` call without a matching
+    ``import logging`` (e.g. injected via dynamic mechanisms) is still
+    treated as a binding to the stdlib module.
+    """
+    logging_module_aliases: set[str] = {"logging"}
+    getlogger_direct_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "logging":
+                    logging_module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "logging":
+            for alias in node.names:
+                if alias.name == "getLogger":
+                    getlogger_direct_aliases.add(alias.asname or alias.name)
+    return logging_module_aliases, getlogger_direct_aliases
+
+
+def _call_invokes_getlogger(
+    node: ast.Call,
+    logging_module_aliases: set[str],
+    getlogger_direct_aliases: set[str],
+) -> bool:
+    """Return True iff ``node`` is a ``logging.getLogger``-equivalent call.
+
+    Recognises both syntactic shapes:
+    - ``<module-alias>.getLogger(...)`` — the standard form (or its
+      ``import logging as lg; lg.getLogger(...)`` aliased variant).
+    - ``<getLogger-alias>(...)`` — the ``from logging import getLogger``
+      bare-name form (or its ``... as gl`` aliased variant).
+    """
+    func = node.func
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "getLogger"
+        and isinstance(func.value, ast.Name)
+        and func.value.id in logging_module_aliases
+    ):
+        return True
+    return isinstance(func, ast.Name) and func.id in getlogger_direct_aliases
+
+
+def _file_calls_logging_getlogger(py_file: Path) -> bool:
+    """Return True iff the file invokes ``logging.getLogger(...)`` in any form.
+
+    Parses the file's AST in two passes:
+
+    1. **Binding pass** -- walk ``Import`` and ``ImportFrom`` nodes to build
+       the set of local names that resolve to the stdlib ``logging`` module
+       and the set that resolve directly to ``logging.getLogger``. This
+       handles aliased imports such as ``import logging as lg`` or
+       ``from logging import getLogger as gl``.
+
+    2. **Call pass** -- walk ``Call`` nodes and flag two violation shapes:
+       - ``<logging-alias>.getLogger(...)`` (e.g. ``logging.getLogger`` or
+         ``lg.getLogger`` after ``import logging as lg``).
+       - ``<getLogger-alias>(...)`` (e.g. ``getLogger`` or ``gl`` after
+         ``from logging import getLogger as gl``).
+
+    This deliberately skips:
 
     - Matches inside comments or docstrings (the rule text itself mentions
       the forbidden pattern and must not self-trigger the assertion).
-    - Other ``getLogger`` calls that are not on the top-level ``logging``
+    - Other ``getLogger`` calls that are not bound to the stdlib ``logging``
       module (e.g. ``structlog.stdlib.get_logger`` is unrelated).
+
+    ``encoding="utf-8"`` is explicit so the gate behaves identically across
+    platforms whose default text encoding is not UTF-8 (e.g. Windows
+    cp1252). ``filename=str(py_file)`` is passed to ``ast.parse`` so any
+    ``SyntaxError`` reports the offending file path.
     """
-    tree = ast.parse(py_file.read_text())
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if (
-            isinstance(func, ast.Attribute)
-            and func.attr == "getLogger"
-            and isinstance(func.value, ast.Name)
-            and func.value.id == "logging"
-        ):
-            return True
-    return False
+    tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+    module_aliases, getlogger_aliases = _collect_logging_bindings(tree)
+    return any(
+        isinstance(node, ast.Call)
+        and _call_invokes_getlogger(node, module_aliases, getlogger_aliases)
+        for node in ast.walk(tree)
+    )
 
 
 def test_only_core_logging_py_uses_logging_getlogger() -> None:
@@ -93,4 +151,60 @@ def test_central_logging_module_still_calls_logging_getlogger() -> None:
         f"{_ALLOWED_FILE} no longer calls ``logging.getLogger``. If the "
         "helper was relocated, update the allow-list in "
         "``test_only_core_logging_py_uses_logging_getlogger`` accordingly."
+    )
+
+
+def test_detector_catches_aliased_module_import(tmp_path: Path) -> None:
+    """Detector must flag ``import logging as X; X.getLogger(...)`` bypass."""
+    src = tmp_path / "aliased_module.py"
+    src.write_text(
+        "import logging as lg\nlg.getLogger('foo')\n",
+        encoding="utf-8",
+    )
+    assert _file_calls_logging_getlogger(src), (
+        "detector failed to catch `import logging as lg; lg.getLogger(...)` bypass form"
+    )
+
+
+def test_detector_catches_from_import_getlogger(tmp_path: Path) -> None:
+    """Detector must flag ``from logging import getLogger; getLogger(...)`` bypass."""
+    src = tmp_path / "from_import.py"
+    src.write_text(
+        "from logging import getLogger\ngetLogger('foo')\n",
+        encoding="utf-8",
+    )
+    assert _file_calls_logging_getlogger(src), (
+        "detector failed to catch `from logging import getLogger; getLogger(...)` bypass form"
+    )
+
+
+def test_detector_catches_from_import_getlogger_aliased(tmp_path: Path) -> None:
+    """Detector must flag ``from logging import getLogger as gl; gl(...)`` bypass."""
+    src = tmp_path / "from_import_aliased.py"
+    src.write_text(
+        "from logging import getLogger as gl\ngl('foo')\n",
+        encoding="utf-8",
+    )
+    assert _file_calls_logging_getlogger(src), (
+        "detector failed to catch `from logging import getLogger as gl; gl(...)` bypass form"
+    )
+
+
+def test_detector_does_not_flag_unrelated_getlogger(tmp_path: Path) -> None:
+    """Detector must NOT flag a ``getLogger`` call bound to a non-logging module.
+
+    Guards against false positives from third-party libraries that also
+    expose a ``getLogger`` name (the rule is about the stdlib ``logging``
+    module specifically, not any callable named ``getLogger``).
+    """
+    src = tmp_path / "unrelated.py"
+    src.write_text(
+        "import structlog\n"
+        "structlog.stdlib.get_logger('foo')\n"
+        "def getLogger(name): return name\n"
+        "getLogger('bar')\n",
+        encoding="utf-8",
+    )
+    assert not _file_calls_logging_getlogger(src), (
+        "detector raised a false positive on a non-logging `getLogger` symbol"
     )

--- a/apps/backend/tests/unit/architecture/test_logging_getlogger_containment.py
+++ b/apps/backend/tests/unit/architecture/test_logging_getlogger_containment.py
@@ -1,0 +1,96 @@
+"""Architecture: stdlib ``logging.getLogger`` is quarantined to a single central file.
+
+CLAUDE.md's forbidden-patterns list states unconditionally:
+"Never use ``logging.getLogger``. Use structlog."
+
+The rule exists because every such call is a stdlib logger boot-up that
+must route through the structlog bridge or else bypass the redaction /
+ProcessorFormatter chain entirely. The one legitimate exception is the
+structlog bootstrap itself in ``app/core/logging.py``, which installs the
+root handler and suppresses noisy third-party loggers via a central helper.
+
+This test is the enforcement gate for issue #210: exactly one file under
+``apps/backend/app/`` is allowed to *call* ``logging.getLogger``, and that
+file is ``app/core/logging.py``. New offenders must route through the
+``silence_stdlib_logger(name, level)`` helper in that file instead of
+grabbing the stdlib logger directly.
+
+The check is AST-based (not a literal substring grep) so that documentation
+strings that MENTION the pattern — including the rule itself — do not get
+flagged. Only real call sites count as violations.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+from ._linter_subprocess import BACKEND_DIR
+
+_APP_ROOT: Final[Path] = BACKEND_DIR / "app"
+_ALLOWED_FILE: Final[Path] = _APP_ROOT / "core" / "logging.py"
+
+
+def _file_calls_logging_getlogger(py_file: Path) -> bool:
+    """Return True iff the file invokes ``logging.getLogger(...)`` as a real call.
+
+    Parses the file's AST and looks for any ``Call`` node whose function is
+    the attribute access ``logging.getLogger``. This deliberately skips:
+
+    - Matches inside comments or docstrings (the rule text itself mentions
+      the forbidden pattern and must not self-trigger the assertion).
+    - Other ``getLogger`` calls that are not on the top-level ``logging``
+      module (e.g. ``structlog.stdlib.get_logger`` is unrelated).
+    """
+    tree = ast.parse(py_file.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "getLogger"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "logging"
+        ):
+            return True
+    return False
+
+
+def test_only_core_logging_py_uses_logging_getlogger() -> None:
+    """Exactly one file under app/ may call ``logging.getLogger``; that file is app/core/logging.py.
+
+    AST-scan the app/ tree for ``logging.getLogger`` call nodes. The only
+    permitted match is ``app/core/logging.py``, which houses the structlog
+    stdlib-bridge bootstrap plus the ``silence_stdlib_logger`` helper used
+    to suppress noisy third-party loggers (docling, httpx, httpcore, ...).
+    """
+    offenders: list[str] = []
+    for py_file in _APP_ROOT.rglob("*.py"):
+        if py_file == _ALLOWED_FILE:
+            continue
+        if _file_calls_logging_getlogger(py_file):
+            offenders.append(str(py_file.relative_to(_APP_ROOT)))
+
+    assert not offenders, (
+        "CLAUDE.md forbids ``logging.getLogger`` outside the central bootstrap "
+        "in ``app/core/logging.py``. Offender(s) must route through "
+        "``silence_stdlib_logger(name, level)`` instead:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+    )
+
+
+def test_central_logging_module_still_calls_logging_getlogger() -> None:
+    """Sanity check: the allow-listed file is actually where the helper lives.
+
+    Guards against a future refactor silently deleting the helper or moving
+    it out of ``app/core/logging.py``. If this assertion fails, the
+    allow-list in ``test_only_core_logging_py_uses_logging_getlogger`` is
+    stale and the quarantine boundary has drifted.
+    """
+    assert _file_calls_logging_getlogger(_ALLOWED_FILE), (
+        f"{_ALLOWED_FILE} no longer calls ``logging.getLogger``. If the "
+        "helper was relocated, update the allow-list in "
+        "``test_only_core_logging_py_uses_logging_getlogger`` accordingly."
+    )

--- a/apps/backend/tests/unit/core/test_logging.py
+++ b/apps/backend/tests/unit/core/test_logging.py
@@ -5,7 +5,7 @@ import logging
 import structlog
 
 from app.core.log_redaction_filter import LogRedactionFilter
-from app.core.logging import configure_logging
+from app.core.logging import configure_logging, silence_stdlib_logger
 
 
 def test_configure_logging_inserts_redaction_filter_into_chain() -> None:
@@ -61,3 +61,45 @@ def test_format_exc_info_runs_before_redaction_filter() -> None:
     fmt_idx = next(i for i, p in enumerate(processors) if p is structlog.processors.format_exc_info)
     redact_idx = next(i for i, p in enumerate(processors) if isinstance(p, LogRedactionFilter))
     assert fmt_idx < redact_idx
+
+
+def test_silence_stdlib_logger_sets_level_on_named_logger() -> None:
+    """Helper sets the level of the named stdlib logger (issue #210).
+
+    Uses a dedicated test-only logger name so the assertion does not interfere
+    with any production logger that other tests rely on.
+    """
+    logger_name = "issue_210_silence_helper_fixture_alpha"
+    # Reset to a known baseline before the helper runs.
+    logging.getLogger(logger_name).setLevel(logging.DEBUG)
+
+    silence_stdlib_logger(logger_name, logging.WARNING)
+
+    assert logging.getLogger(logger_name).level == logging.WARNING
+
+
+def test_silence_stdlib_logger_accepts_arbitrary_level_and_name() -> None:
+    """Helper must be generic: any name + any int level, not hardcoded to docling/WARNING."""
+    logger_name = "issue_210_silence_helper_fixture_beta"
+    logging.getLogger(logger_name).setLevel(logging.DEBUG)
+
+    silence_stdlib_logger(logger_name, logging.ERROR)
+
+    assert logging.getLogger(logger_name).level == logging.ERROR
+
+
+def test_configure_logging_silences_docling_via_helper() -> None:
+    """Docling silencing must be driven from configure_logging, not from the parser module.
+
+    Before issue #210, `docling_document_parser.py` called
+    `logging.getLogger("docling").setLevel(WARNING)` at module import time.
+    That violated the "no `logging.getLogger` outside `app/core/logging.py`"
+    rule. The fix moves the call inside `configure_logging(...)` via the
+    `silence_stdlib_logger` helper so the containment invariant holds.
+    """
+    # Reset first so we are not observing a leftover from a prior test.
+    logging.getLogger("docling").setLevel(logging.DEBUG)
+
+    configure_logging(log_level="info", json_output=False)
+
+    assert logging.getLogger("docling").level == logging.WARNING

--- a/apps/backend/tests/unit/core/test_logging.py
+++ b/apps/backend/tests/unit/core/test_logging.py
@@ -88,6 +88,28 @@ def test_silence_stdlib_logger_accepts_arbitrary_level_and_name() -> None:
     assert logging.getLogger(logger_name).level == logging.ERROR
 
 
+def test_silence_stdlib_logger_does_not_reduce_a_stricter_existing_level() -> None:
+    """Cap semantics: never lower a logger that is already stricter than the cap.
+
+    Earlier the helper unconditionally called ``setLevel(level)``, which
+    would *reduce* an already-stricter level (e.g. ERROR -> WARNING) and
+    silently increase log volume. The new implementation only raises the
+    floor; it leaves stricter explicit levels untouched.
+    """
+    logger_name = "issue_210_silence_helper_fixture_gamma"
+    # Pre-configure the logger to ERROR, which is stricter (numerically
+    # higher) than the WARNING cap we are about to request.
+    logging.getLogger(logger_name).setLevel(logging.ERROR)
+
+    silence_stdlib_logger(logger_name, logging.WARNING)
+
+    # The helper must NOT have walked ERROR back down to WARNING.
+    assert logging.getLogger(logger_name).level == logging.ERROR, (
+        "silence_stdlib_logger reduced an existing stricter level "
+        "(ERROR -> WARNING). It must only raise the floor, never lower it."
+    )
+
+
 def test_configure_logging_silences_docling_via_helper() -> None:
     """Docling silencing must be driven from configure_logging, not from the parser module.
 

--- a/apps/backend/tests/unit/core/test_logging.py
+++ b/apps/backend/tests/unit/core/test_logging.py
@@ -112,6 +112,48 @@ def test_silence_stdlib_logger_does_not_reduce_a_stricter_existing_level() -> No
     )
 
 
+def test_silence_stdlib_logger_does_not_reduce_an_inherited_stricter_level() -> None:
+    """Cap semantics extend to INHERITED effective levels, not just explicit ones.
+
+    Copilot-review feedback on PR #224: the previous implementation compared
+    ``logger.level`` (explicit only), so a NOTSET child whose effective
+    level is inherited from a stricter ancestor (e.g. root at ERROR) would
+    have its explicit level forced to WARNING, silently *lowering* the
+    effective threshold from ERROR to WARNING.
+
+    The fix reads ``logger.getEffectiveLevel()`` instead, so inheritance
+    counts as a pre-existing stricter level.
+    """
+    target_name = "issue_210_silence_helper_fixture_delta"
+    # Clean slate: target must be at NOTSET so its effective level comes
+    # entirely from the ancestor chain.
+    logging.getLogger(target_name).setLevel(logging.NOTSET)
+    # Save and restore the root logger's explicit level so this test does
+    # not leak state into sibling tests in the same pytest session.
+    root_logger = logging.getLogger()
+    original_root_level = root_logger.level
+    root_logger.setLevel(logging.ERROR)
+    try:
+        silence_stdlib_logger(target_name, logging.WARNING)
+
+        target = logging.getLogger(target_name)
+        # Target's explicit level must stay NOTSET — had the helper called
+        # setLevel(WARNING), NOTSET would have been overwritten to WARNING.
+        assert target.level == logging.NOTSET, (
+            "silence_stdlib_logger set an explicit level on a target whose "
+            "effective level was already stricter (inherited ERROR). The cap "
+            f"contract is 'never lower effective threshold'; target.level = {target.level}."
+        )
+        # And the effective level must still reflect the ancestor's ERROR,
+        # not the would-be-lower WARNING.
+        assert target.getEffectiveLevel() == logging.ERROR, (
+            "Effective level was lowered from ERROR (inherited) to something else; "
+            f"got {target.getEffectiveLevel()}."
+        )
+    finally:
+        root_logger.setLevel(original_root_level)
+
+
 def test_configure_logging_silences_docling_via_helper() -> None:
     """Docling silencing must be driven from configure_logging, not from the parser module.
 

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -410,12 +410,20 @@ def contextlib_suppress_cancelled() -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Docling logger is configured at module import time
+# Docling logger suppression is driven from configure_logging (issue #210)
 # ---------------------------------------------------------------------------
 
 
-def test_docling_logger_level_is_raised_at_module_import() -> None:
-    """Module-level side effect: `logging.getLogger("docling").setLevel(WARNING)`.
+def test_docling_logger_level_is_raised_after_configure_logging() -> None:
+    """After `configure_logging()` runs, the docling stdlib logger is capped at WARNING.
+
+    Before issue #210, `docling_document_parser.py` set this at module
+    import time via a direct `logging.getLogger("docling").setLevel(WARNING)`
+    call. That violated CLAUDE.md's "no `logging.getLogger` outside
+    `app/core/logging.py`" rule. The fix moves the call into
+    `configure_logging` via the `silence_stdlib_logger` helper, so the
+    invariant still holds in production (where `configure_logging` runs in
+    `create_app`) but no longer depends on a module-import side effect.
 
     The parser does not redirect stdout/stderr — that would mutate
     process-global file objects and interleave under concurrent requests.
@@ -425,7 +433,15 @@ def test_docling_logger_level_is_raised_at_module_import() -> None:
     """
     import logging as _logging
 
-    assert _logging.getLogger("docling").level >= _logging.WARNING
+    from app.core.logging import configure_logging
+
+    # Reset to a non-target level first so the assertion observes the side
+    # effect of `configure_logging`, not a leftover from a prior test.
+    _logging.getLogger("docling").setLevel(_logging.DEBUG)
+
+    configure_logging(log_level="info", json_output=False)
+
+    assert _logging.getLogger("docling").level == _logging.WARNING
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added `silence_stdlib_logger(logger_name: str, level: int) -> None` helper in `app/core/logging.py`. This is now the ONLY sanctioned site under `app/` that calls `logging.getLogger` — the rule in CLAUDE.md stays absolute everywhere else.
- Threaded the helper through the existing noisy-logger suppression loop in `configure_logging(...)` and added `"docling": WARNING` to that loop, so the docling silencing is driven from `Settings` timing rather than being a module-import side effect.
- Removed `import logging` + module-level `logging.getLogger("docling").setLevel(logging.WARNING)` from `features/extraction/parsing/docling_document_parser.py`.
- Added architecture test `tests/unit/architecture/test_logging_getlogger_containment.py` (AST-based, not literal grep) asserting exactly one file under `app/` calls `logging.getLogger` and that file is `app/core/logging.py`. Renamed the existing docling-parser logger-level test to run after `configure_logging()` instead of at import.

## Test plan
- [x] RED: architecture test fails on unchanged main (docling parser also matches the AST walk).
- [x] GREEN: after moving the docling silencing into `silence_stdlib_logger` and the parser cleanup, the test flips green; grep over `app/` returns exactly one file.
- [x] `task check` passes end-to-end (lint, pyright, import-linter, 726 unit + 96 integration + 20 contract + 25 error-contract tests).

### Parallel-work note
Issue #216 is being fixed in parallel on branch `fix/216-structlog-idempotent` — it adds `structlog.reset_defaults()` at the top of `configure_logging` in this same file. The edits are additive and in different regions; whichever merges first, the other needs only a trivial rebase.

Closes #210.