### PR TITLE
fix(skills): wrap raw pydantic.ValidationError in SkillValidationFailedError (closes #214)

### DIFF
--- a/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
+++ b/apps/backend/app/features/extraction/skills/skill_yaml_schema.py
@@ -26,7 +26,7 @@ from typing import Any, Self
 import yaml
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import SchemaError
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from app.exceptions import SkillValidationFailedError
 from app.features.extraction.skills.deep_freeze import thaw
@@ -142,6 +142,17 @@ class SkillYamlSchema(BaseModel):
                 file=file_str,
                 reason=str(inner_reason),
             ) from exc
+        except ValidationError as exc:
+            # Pydantic raises its own `ValidationError` for field-shape problems
+            # (missing fields, wrong types, failed constraints) BEFORE the
+            # `@model_validator(mode="after")` above ever runs. Without this
+            # branch that exception escapes `load_from_file` unwrapped, and
+            # `SkillLoader`'s broad `except Exception` surfaces it to operators
+            # as an unparseable raw-Pydantic dump. Wrap it here so every
+            # load-time failure reaches the boot-log in the same curated
+            # `file=<path> reason=<human-readable>` shape (issue #214).
+            reason = _format_pydantic_errors(exc)
+            raise SkillValidationFailedError(file=file_str, reason=reason) from exc
 
         if instance.version != filename_version:
             msg = (
@@ -151,6 +162,27 @@ class SkillYamlSchema(BaseModel):
             raise SkillValidationFailedError(file=file_str, reason=msg)
 
         return instance
+
+
+def _format_pydantic_errors(exc: ValidationError) -> str:
+    """Collapse a `pydantic.ValidationError` into one human-readable line.
+
+    Each inner error becomes ``<dotted.loc>: <msg>`` and the items are joined
+    with ``"; "`` so the whole blob is a single log-friendly line. We
+    deliberately DO NOT include the ``type=`` / ``input_value=`` /
+    ``For further information visit https://errors.pydantic.dev/...``
+    trailers that Pydantic's own ``__str__`` appends — those are useful for
+    library debugging but are noise in a curated operator-facing message,
+    and they were the exact signal of "this came from raw Pydantic" that
+    issue #214 called out.
+    """
+    parts: list[str] = []
+    for err in exc.errors():
+        loc_tuple = err.get("loc", ())
+        dotted_loc = ".".join(str(p) for p in loc_tuple) if loc_tuple else "<root>"
+        msg = err.get("msg", "")
+        parts.append(f"{dotted_loc}: {msg}")
+    return "; ".join(parts)
 
 
 def _is_empty_object_schema(schema: dict[str, Any]) -> bool:

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_yaml_schema.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-from pydantic import ValidationError
 
 from app.exceptions import SkillValidationFailedError
 from app.features.extraction.skills import SkillYamlSchema
@@ -42,16 +41,18 @@ def test_load_from_file_returns_populated_instance(
     assert schema.docling is None
 
 
-def test_missing_prompt_raises_pydantic_error(
+def test_missing_prompt_raises_skill_validation_error(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
+    """Missing-required-field Pydantic errors must be wrapped (issue #214)."""
     path = write_skill_yaml(prompt=REMOVE)
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
 
-    errors = exc_info.value.errors()
-    assert any(err["loc"] == ("prompt",) and err["type"].startswith("missing") for err in errors)
+    reason = _reason(exc_info.value)
+    assert "prompt" in reason
+    assert "\n" not in reason
 
 
 def test_invalid_json_schema_raises_skill_validation_error(
@@ -146,59 +147,69 @@ def test_multiple_violations_in_single_example_all_aggregated(
     assert "'b' is a required property" in reason
 
 
-def test_empty_examples_list_raises_pydantic_error(
+def test_empty_examples_list_raises_skill_validation_error(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
+    """Empty examples list must be wrapped (issue #214)."""
     path = write_skill_yaml(examples=[])
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
 
-    assert any(err["loc"] == ("examples",) for err in exc_info.value.errors())
+    reason = _reason(exc_info.value)
+    assert "examples" in reason
 
 
-def test_version_zero_raises_pydantic_error(
+def test_version_zero_raises_skill_validation_error(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
+    """A zero version must be wrapped (issue #214)."""
     path = write_skill_yaml(filename="0.yaml", version=0)
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
 
-    assert any(err["loc"] == ("version",) for err in exc_info.value.errors())
+    reason = _reason(exc_info.value)
+    assert "version" in reason
 
 
-def test_empty_name_raises_pydantic_error(
+def test_empty_name_raises_skill_validation_error(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
+    """An empty name must be wrapped (issue #214)."""
     path = write_skill_yaml(name="")
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
 
-    assert any(err["loc"] == ("name",) for err in exc_info.value.errors())
+    reason = _reason(exc_info.value)
+    assert "name" in reason
 
 
-def test_uppercase_name_raises_pydantic_error(
+def test_uppercase_name_raises_skill_validation_error(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
+    """A name with disallowed characters must be wrapped (issue #214)."""
     path = write_skill_yaml(name="Has-UPPERCASE")
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
 
-    assert any(err["loc"] == ("name",) for err in exc_info.value.errors())
+    reason = _reason(exc_info.value)
+    assert "name" in reason
 
 
-def test_empty_prompt_raises_pydantic_error(
+def test_empty_prompt_raises_skill_validation_error(
     write_skill_yaml: SkillYamlFactory,
 ) -> None:
+    """An empty prompt must be wrapped (issue #214)."""
     path = write_skill_yaml(prompt="")
 
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
 
-    assert any(err["loc"] == ("prompt",) for err in exc_info.value.errors())
+    reason = _reason(exc_info.value)
+    assert "prompt" in reason
 
 
 def test_non_integer_filename_stem_raises(
@@ -337,8 +348,14 @@ def test_docling_rejects_invalid_values_at_load_time(
     path = tmp_path / "1.yaml"
     path.write_text(yaml.safe_dump(body), encoding="utf-8")
 
-    with pytest.raises(ValidationError):
+    # Issue #214: Pydantic `ValidationError` must be wrapped as
+    # `SkillValidationFailedError` with a curated single-line reason so
+    # `SkillLoader`'s aggregate output stays uniform across failure paths.
+    with pytest.raises(SkillValidationFailedError) as exc_info:
         SkillYamlSchema.load_from_file(path)
+
+    reason = _reason(exc_info.value)
+    assert field in reason
 
 
 @pytest.mark.parametrize(
@@ -442,3 +459,67 @@ def test_output_schema_with_one_property_still_loads_successfully(
     schema = SkillYamlSchema.load_from_file(path)
 
     assert schema.output_schema["properties"] == {"only_field": {"type": "string"}}
+
+
+def test_pydantic_field_shape_error_wraps_to_skill_validation_failed_error(
+    write_skill_yaml: SkillYamlFactory,
+) -> None:
+    """Raw `pydantic.ValidationError` must not escape `load_from_file`.
+
+    Issue #214: when Pydantic rejects a field-shape violation before
+    `@model_validator(mode="after")` runs (e.g. a non-integer `version`),
+    the resulting `ValidationError` used to propagate unwrapped past
+    `load_from_file`. Downstream `SkillLoader` caught it under a broad
+    `except Exception` and rendered it as a verbose Pydantic dump instead of
+    the curated `file=<path> reason=<human-readable>` format every other
+    failure path produces.
+
+    This test locks in the wrap: the exception must be
+    `SkillValidationFailedError`, the `file` param must be the offending
+    file path, and the `reason` must be a single human-readable line that
+    names the offending field and the validation message without any raw
+    Pydantic pointer-URL noise.
+    """
+    path = write_skill_yaml(version="abc")
+
+    with pytest.raises(SkillValidationFailedError) as exc_info:
+        SkillYamlSchema.load_from_file(path)
+
+    assert exc_info.value.params is not None
+    dumped = exc_info.value.params.model_dump()
+    assert dumped["file"] == str(path)
+
+    reason = _reason(exc_info.value)
+    # Single human-readable line — no embedded newline breaks.
+    assert "\n" not in reason
+    # Names the offending field so operators know which key to fix.
+    assert "version" in reason
+    # Does NOT include the raw Pydantic traceback pointer noise.
+    # Pydantic v2 `ValidationError.__str__` ends each entry with a
+    # `[type=..., input_value=..., input_type=...]` trailer followed by
+    # `For further information visit https://errors.pydantic.dev/...` —
+    # that's exactly the unparseable dump the fix is meant to suppress.
+    assert "https://errors.pydantic.dev" not in reason
+    assert "For further information visit" not in reason
+
+
+def test_pydantic_validation_error_reason_is_deterministic_single_line(
+    write_skill_yaml: SkillYamlFactory,
+) -> None:
+    """Shape-level failure reasons must follow the `<field_path>: <msg>` format.
+
+    Locks the `reason` formatter so downstream log-parsers, if any, can rely
+    on the `; `-joined `loc: msg` layout rather than Pydantic's free-form
+    multi-line dump. Uses a nested field (`docling.ocr`) to prove the dotted
+    path comes through.
+    """
+    path = write_skill_yaml(docling={"ocr": "banana"})
+
+    with pytest.raises(SkillValidationFailedError) as exc_info:
+        SkillYamlSchema.load_from_file(path)
+
+    reason = _reason(exc_info.value)
+    assert "\n" not in reason
+    # Dotted path for nested field, colon separator, then the message.
+    assert "docling.ocr" in reason
+    assert ":" in reason


### PR DESCRIPTION
## Summary
- Added `except ValidationError` branch to `SkillYamlSchema.load_from_file` so Pydantic field-shape errors (e.g. `version: abc` tripping the `Field(gt=0)` coercion before the `@model_validator(mode="after")` fires) surface as the curated `SkillValidationFailedError` with `file=<path> reason=<single-line>` shape — matching every other load-time failure path in the skill loader.
- Added module-level `_format_pydantic_errors(exc)` helper that joins `"<dotted.loc>: <msg>; …"` entries and deliberately strips Pydantic's `[type=…, input_value=…]` / `For further information visit https://errors.pydantic.dev/…` trailers the issue flagged as operator-hostile.
- Updated existing schema tests that had been documenting the buggy behaviour (raw `ValidationError` escape) to assert the wrapped `SkillValidationFailedError` instead.

## Test plan
- [x] RED: new test `test_pydantic_field_shape_error_wraps_to_skill_validation_failed_error` fails on unchanged main (raw `pydantic_core._pydantic_core.ValidationError` escapes with `https://errors.pydantic.dev/…` noise).
- [x] GREEN: after adding the branch, the test flips green with a curated single-line reason containing the field name and no URL noise.
- [x] New nested-field test `test_pydantic_validation_error_reason_is_deterministic_single_line` (on `docling.ocr`) proves the dotted-path formatter works.
- [x] All 79 skill tests pass; existing `test_skill_loader.py` untouched and still green.
- [x] `task check` passes end-to-end (lint, pyright 0 errors, import-linter 11 contracts kept 0 broken, 723 unit + 96 integration + 20 contract + 25 error-contract tests).

### Parallel-work note
Open PR #221 also edits `skill_yaml_schema.py` to add a `DuplicateKeyDetectingSafeLoader` (closes #208 partial). The two changes are orthogonal — one handles YAML-parse-time dup-keys, this one handles Pydantic-level shape errors — but whichever merges first, the other needs only a trivial rebase.

Closes #214.