### PR TITLE
docs(testing): document all three contract test files (closes #231)

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,7 +24,13 @@ enforcement version. This document provides rationale.
   `app/features/extraction/skills/skill_loader.py` -> `tests/unit/features/extraction/skills/test_skill_loader.py`.
 - Backend integration: `tests/integration/` mirrors the source tree. In-process
   against the FastAPI ASGI app; no external services.
-- Backend contract: `tests/contract/test_schemathesis.py`.
+- Backend contract: `tests/contract/` — three files, one per contract
+  slice: `test_schemathesis.py` (schemathesis conformance across every
+  declared `/api/v1/extract` status code), `test_extract_contract.py`
+  (shape assertions for the OpenAPI spec and `ErrorResponse` envelope),
+  `test_degraded_contract.py` (degraded-mode `/health` + `/ready`
+  response shapes with a stubbed Ollama probe). See
+  [docs/testing.md](testing.md#3-contract-tests) for details.
 
 ## Pydantic Schemas
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,15 +39,18 @@ Three levels, all mandatory for every feature. E2E is optional-slow.
   - `test_schemathesis.py` — schemathesis conformance: loads the live
     OpenAPI spec via `schemathesis.openapi.from_asgi("/openapi.json", app)`
     and calls `schema["/api/v1/extract"]["POST"].validate_response(...)`
-    on a hand-rolled request per declared status code (200, 400, 404,
-    413, 422, 502, 503, 504). Targeted requests rather than
+    on hand-rolled requests covering each declared status code (200,
+    400, 404, 413, 422, 502, 503, 504) — some codes have multiple
+    requests, one per distinct `DomainError` that maps to that code
+    (e.g. 400 covers both `PdfInvalidError` and
+    `PdfPasswordProtectedError`). Targeted requests rather than
     `@schema.parametrize` because schemathesis cannot synthesize valid
     PDFs from `format: binary`.
   - `test_extract_contract.py` — shape assertions for `/api/v1/extract`:
     verifies the OpenAPI spec declares the expected form fields and
     media types (`application/json`, `application/pdf`, `multipart/mixed`
     for the 200 path) and asserts `ErrorResponse` envelope shape for the
-    413 (`PDF_TOO_LARGE`) and 504 (`INTELLIGENCE_TIMEOUT`) happy paths.
+    413 (`PDF_TOO_LARGE`) and 504 (`INTELLIGENCE_TIMEOUT`) error responses.
   - `test_degraded_contract.py` — degraded-mode response shape
     conformance: pins `app.state.ollama_health_probe` to a `FakeProbe`
     so the startup probe fails deterministically, then asserts `/ready`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,30 @@ Three levels, all mandatory for every feature. E2E is optional-slow.
   Heavy pipeline components (Docling, LangExtract, Ollama, PyMuPDF) are
   stubbed via `app.dependency_overrides` so contract tests remain fast
   and deterministic.
-- **Backend:** `tests/contract/test_schemathesis.py`.
+- **Backend:** `tests/contract/` contains three test files, each covering
+  a distinct slice of the contract:
+  - `test_schemathesis.py` — schemathesis conformance: loads the live
+    OpenAPI spec via `schemathesis.openapi.from_asgi("/openapi.json", app)`
+    and calls `schema["/api/v1/extract"]["POST"].validate_response(...)`
+    on a hand-rolled request per declared status code (200, 400, 404,
+    413, 422, 502, 503, 504). Targeted requests rather than
+    `@schema.parametrize` because schemathesis cannot synthesize valid
+    PDFs from `format: binary`.
+  - `test_extract_contract.py` — shape assertions for `/api/v1/extract`:
+    verifies the OpenAPI spec declares the expected form fields and
+    media types (`application/json`, `application/pdf`, `multipart/mixed`
+    for the 200 path) and asserts `ErrorResponse` envelope shape for the
+    413 (`PDF_TOO_LARGE`) and 504 (`INTELLIGENCE_TIMEOUT`) happy paths.
+  - `test_degraded_contract.py` — degraded-mode response shape
+    conformance: pins `app.state.ollama_health_probe` to a `FakeProbe`
+    so the startup probe fails deterministically, then asserts `/ready`
+    returns 503 with the `{status: "not_ready", reason: <enum>}` shape
+    declared in OpenAPI, and `/health` remains 200 (liveness is
+    unaffected by Ollama reachability).
+
+  Shared fixtures (valid skill YAML writer, `Settings` factory with
+  `app_env="development"` so `/openapi.json` is exposed, and the canned
+  `ExtractionResult`) live in `tests/contract/_helpers.py`.
 
 ### Optional — E2E (slow)
 
@@ -75,7 +98,11 @@ Three levels, all mandatory for every feature. E2E is optional-slow.
 
 - Backend unit: `tests/unit/<mirrors source tree>/test_<module>.py`
 - Backend integration: `tests/integration/<mirrors source tree>/test_<module>.py`
-- Backend contract: `tests/contract/test_schemathesis.py`
+- Backend contract: `tests/contract/` — flat directory, one file per
+  contract slice (`test_schemathesis.py`, `test_extract_contract.py`,
+  `test_degraded_contract.py`). See Section 3 above for the per-file
+  role split. New contract tests land in the file whose role they
+  match; add a new file if the slice is genuinely new.
 
 ## Pre-commit / Pre-push / CI
 


### PR DESCRIPTION
## Summary

- `docs/testing.md` and `docs/conventions.md` referenced only `tests/contract/test_schemathesis.py`, hiding `test_extract_contract.py` and `test_degraded_contract.py` from contributors looking up where new contract tests land.
- Updated both docs to reference the `tests/contract/` directory with a one-line role description per file:
  - `test_schemathesis.py` — schemathesis conformance across every declared `/api/v1/extract` status code.
  - `test_extract_contract.py` — shape assertions for the OpenAPI spec + `ErrorResponse` envelope.
  - `test_degraded_contract.py` — degraded-mode `/health` + `/ready` shape with a stubbed Ollama probe.
- `docs/testing.md` also notes the shared `_helpers.py` fixtures so the factoring is discoverable.

## Test plan

- [x] `task check` is green (lint, types, skills, unit + integration + contract, error contracts).
- [x] `docs/testing.md` and `docs/conventions.md` reference all three contract test files with role descriptions.
- [x] No other markdown doc under `docs/` misdescribes the contract tier (historical documents in `docs/bootstrap-decisions.md` and `docs/reshape-plan.md` accurately capture past state and were left alone).

Closes #231