### PR TITLE
docs(arch): disambiguate C2 header bullets for coordinates and extraction (#236)

### DIFF
--- a/apps/backend/architecture/import-linter-contracts.ini
+++ b/apps/backend/architecture/import-linter-contracts.ini
@@ -59,10 +59,10 @@ modules =
 #         extraction} -> {parsing, intelligence, skills} -> schemas
 #
 # With these cross-edges inside the mid tier:
-#   - coordinates may import extraction, parsing, schemas (not annotation,
-#     intelligence, skills).
-#   - extraction may import parsing, intelligence, skills, schemas (not
-#     coordinates, annotation).
+#   - coordinates may import extraction, parsing, schemas; may NOT import
+#     annotation, intelligence, skills. (C2d enforces the "may NOT" side.)
+#   - extraction may import parsing, intelligence, skills, schemas; may NOT
+#     import coordinates, annotation. (C2c enforces the "may NOT" side.)
 #   - annotation may import schemas only.
 #   - parsing, intelligence, skills may import schemas only and must be
 #     independent of each other.


### PR DESCRIPTION
## Summary

- Rewrite the C2 header's two mid-tier "may import" bullets so each one names both the "may import" and "may NOT import" sides explicitly, and points to the enforcing contract (C2c / C2d).
- Eliminates the ambiguity flagged in #236: the previous parenthetical phrasing (e.g. `coordinates may import extraction, parsing, schemas (not annotation, intelligence, skills)`) required readers to cross-reference C2d to confirm which edges were actually forbidden.
- Documentation-only; contract bodies are untouched.

## Test plan

- [x] `task check:arch` — 11 contracts kept, 0 broken
- [x] `task check` — all green (734 unit + 96 integration + 20 contract + 25 error-contract tests pass; ruff, pyright, skills:validate, errors:check all pass)

Closes #236