### PR TITLE
fix(tests): inline rationale on type:ignore pragmas (closes #239)

### DIFF
--- a/apps/backend/tests/contract/test_degraded_contract.py
+++ b/apps/backend/tests/contract/test_degraded_contract.py
@@ -43,7 +43,7 @@ def test_degraded_ready_503_conforms_to_openapi_schema(tmp_path: Path) -> None:
     """GET /ready 503 response shape matches the declared OpenAPI 503 schema."""
     _write_valid_skill(tmp_path)
     app = create_app(
-        Settings(  # type: ignore[reportCallIssue]
+        Settings(  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
             skills_dir=tmp_path,
             app_env="development",
         ),
@@ -95,7 +95,7 @@ def test_degraded_health_200_conforms_to_openapi_schema(tmp_path: Path) -> None:
     """GET /health returns 200 even in degraded mode — liveness is unaffected."""
     _write_valid_skill(tmp_path)
     app = create_app(
-        Settings(  # type: ignore[reportCallIssue]
+        Settings(  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
             skills_dir=tmp_path,
             app_env="development",
         ),


### PR DESCRIPTION
## Summary

- Adds the canonical `# pydantic-settings loads fields from env` rationale to both `# type: ignore[reportCallIssue]` lines in `tests/contract/test_degraded_contract.py` (lines 46 and 98)
- Brings this file in line with the established convention at `app/main.py:155`, `extraction_engine.py:219`, and `ollama_gemma_provider.py:135`
- CLAUDE.md forbids bare `# type: ignore` without an inline comment — this closes the last two grep-visible offenders

## Test plan

- [x] `task check` passes locally (ruff, format, pyright strict, import-linter, unit+integration+contract suites, error-contracts regeneration clean)
- [x] `grep 'type: ignore' apps/backend/tests/contract/test_degraded_contract.py` shows both lines now carry the inline rationale
- [x] No behavior changes (comment-only diff)