### PR TITLE
fix(api): honour DomainError http_status in access log exception branch (closes #238)

### DIFF
--- a/apps/backend/app/api/access_log_middleware.py
+++ b/apps/backend/app/api/access_log_middleware.py
@@ -6,6 +6,8 @@ import structlog
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
+from app.exceptions.base import DomainError
+
 _logger = structlog.get_logger(__name__)
 
 
@@ -22,12 +24,19 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             # diagnosing a disconnect storm otherwise have no per-request record of
             # the failed requests. We re-raise unchanged so the exception handler
             # middleware (or the ASGI server) can do its normal job (issue #147).
+            # If the raised exception is a DomainError, record its declared
+            # ``http_status`` so the access log matches the response the
+            # exception handler will actually emit (e.g., 404 for a
+            # NotFoundError) — protects SRE dashboards filtering on
+            # ``status_code >= 500`` from mislabeling 4xx domain errors as
+            # server errors (issue #238).
             duration_ms = (time.perf_counter() - start) * 1000
+            status_code = exc.http_status if isinstance(exc, DomainError) else 500
             _logger.info(
                 "http_request",
                 method=request.method,
                 path=request.url.path,
-                status_code=500,
+                status_code=status_code,
                 duration_ms=round(duration_ms, 2),
                 error=type(exc).__name__,
             )

--- a/apps/backend/tests/unit/api/test_access_log_middleware.py
+++ b/apps/backend/tests/unit/api/test_access_log_middleware.py
@@ -8,6 +8,7 @@ from starlette.types import Receive, Scope, Send
 from structlog.testing import capture_logs
 
 from app.api.access_log_middleware import AccessLogMiddleware
+from app.exceptions import SkillNotFoundError
 
 
 class _SentinelError(Exception):
@@ -51,6 +52,69 @@ async def test_access_log_middleware_emits_log_on_unhandled_exception() -> None:
     # distinguish failure modes (CancelledError on client disconnect vs.
     # real bugs) from the access log alone (issue #147).
     assert log["error"] == "_SentinelError"
+
+
+async def test_access_log_middleware_logs_domain_error_http_status_on_exception() -> None:
+    """When call_next raises a DomainError, the logged status_code must match
+    the error's ``http_status`` (e.g., 404 for SkillNotFoundError), not the
+    hardcoded 500 fallback. Protects SRE dashboards filtering ``status_code >=
+    500`` from mislabeling 4xx domain errors as server errors if a future
+    middleware reshuffle puts error mapping outside ``call_next`` (issue #238)."""
+
+    async def _noop_asgi_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        return None
+
+    async def _call_next_raising(_request: StarletteRequest) -> Response:
+        raise SkillNotFoundError(name="missing", version="1")
+
+    middleware = AccessLogMiddleware(_noop_asgi_app)
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/extract",
+        "headers": [],
+    }
+    request = StarletteRequest(scope)  # type: ignore[arg-type] -- only Starlette attrs used
+
+    with capture_logs() as cap_logs, pytest.raises(SkillNotFoundError):
+        await middleware.dispatch(request, _call_next_raising)
+
+    http_events = [e for e in cap_logs if e.get("event") == "http_request"]
+    assert len(http_events) == 1
+    log = http_events[0]
+    assert log["status_code"] == SkillNotFoundError.http_status == 404
+    assert log["error"] == "SkillNotFoundError"
+
+
+async def test_access_log_middleware_logs_500_for_non_domain_exception() -> None:
+    """Non-DomainError exceptions (including asyncio.CancelledError and other
+    BaseException subclasses) fall back to ``status_code=500`` so operators
+    still get a per-request record of the failure (issue #147 contract)."""
+
+    async def _noop_asgi_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        return None
+
+    boom_message = "boom"
+
+    async def _call_next_raising(_request: StarletteRequest) -> Response:
+        raise _SentinelError(boom_message)
+
+    middleware = AccessLogMiddleware(_noop_asgi_app)
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/_raise",
+        "headers": [],
+    }
+    request = StarletteRequest(scope)  # type: ignore[arg-type] -- only Starlette attrs used
+
+    with capture_logs() as cap_logs, pytest.raises(_SentinelError):
+        await middleware.dispatch(request, _call_next_raising)
+
+    http_events = [e for e in cap_logs if e.get("event") == "http_request"]
+    assert len(http_events) == 1
+    assert http_events[0]["status_code"] == 500
+    assert http_events[0]["error"] == "_SentinelError"
 
 
 async def test_access_log_middleware_reraises_original_exception() -> None:


### PR DESCRIPTION
## Summary

- `AccessLogMiddleware`'s `except BaseException` branch hardcoded `status_code=500` in the emitted `http_request` log — so any future middleware reshuffle that let a `DomainError` propagate past `call_next` would produce an access log saying 500 while the HTTP response carried the error's mapped 4xx/5xx status.
- Fix: check `isinstance(exc, DomainError)` and use `exc.http_status` when true; otherwise keep the 500 fallback (preserves issue #147's contract for `CancelledError` and other `BaseException` subclasses).
- TDD: added a failing unit test that raises `SkillNotFoundError` from `call_next` and asserts the logged status is 404, plus a companion test confirming non-DomainError exceptions still log 500. Both pass after the fix.

## Why not an integration test per the issue's acceptance criteria

The issue asked for "integration test: raise a DomainError inside a handler, assert access log's recorded status matches the response status." In FastAPI, DomainErrors are caught by `@app.exception_handler(DomainError)` **inside** `call_next`, so the middleware sees a `Response` (with the correct status) — never an exception. The buggy branch is only reachable when a DomainError escapes `call_next`, which requires a middleware-order change that doesn't exist today. Direct middleware-dispatch unit tests exercise exactly the reachable bug scenario; a route-level integration test would only cover the happy path that already worked.

## Test plan

- [x] `task check` passes locally (ruff, format, pyright strict, import-linter 11/0, unit+integration+contract, error-contracts)
- [x] New `test_access_log_middleware_logs_domain_error_http_status_on_exception` passes (404, not 500)
- [x] New `test_access_log_middleware_logs_500_for_non_domain_exception` passes (preserves legacy behaviour)
- [x] Existing tests for re-raise, success-path log, and the `_SentinelError` 500-fallback still green