### PR TITLE
docs(spec): list pdf_preflight.py and _duplicate_key_safe_loader.py in folder tree (closes #235)

### DIFF
--- a/docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-design.md
+++ b/docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-design.md
@@ -106,6 +106,7 @@ apps/backend/app/features/extraction/
 ├── parsing/                            # Docling abstraction
 │   ├── document_parser.py              # DocumentParser protocol
 │   ├── docling_document_parser.py      # DoclingDocumentParser — concrete impl
+│   ├── pdf_preflight.py                # PdfPreflight Protocol — pre-Docling validation hook (page count, password/invalid detection) and test seam
 │   ├── parsed_document.py              # ParsedDocument (list[TextBlock])
 │   ├── text_block.py                   # TextBlock (text, page_number, bbox, block_id)
 │   └── bounding_box.py                 # BoundingBox internal value object
@@ -125,7 +126,8 @@ apps/backend/app/features/extraction/
 │   ├── skill.py                        # Skill domain object
 │   ├── skill_loader.py                 # SkillLoader — load by name+version
 │   ├── skill_manifest.py               # SkillManifest — startup-validated registry
-│   └── skill_yaml_schema.py            # SkillYamlSchema — pydantic validator
+│   ├── skill_yaml_schema.py            # SkillYamlSchema — pydantic validator
+│   └── _duplicate_key_safe_loader.py   # DuplicateKeyDetectingSafeLoader — PyYAML SafeLoader subclass rejecting duplicate mapping keys (closes #208 partial, PR #221)
 │
 ├── coordinates/                        # Coordinate matching layer
 │   ├── offset_index.py                 # OffsetIndex — char offset → block


### PR DESCRIPTION
## Summary

Section 4's folder tree in the design spec is cited in CLAUDE.md as the contract-grade source of truth for the extraction feature's folder structure. Two files shipped to `main` were missing from it:

- **`parsing/pdf_preflight.py`** — `PdfPreflight` Protocol; pre-Docling validation hook (page count, password/invalid detection) and the test seam that lets unit tests swap in a trivial preflight without loading PyMuPDF.
- **`skills/_duplicate_key_safe_loader.py`** — `DuplicateKeyDetectingSafeLoader` (added by PR #221, closes #208 partial), a PyYAML `SafeLoader` subclass that rejects duplicate mapping keys at parse time.

Both are now listed with one-line role descriptions. Surgical addition — the rest of Section 4 and adjacent sections are untouched, and no other part of the spec contradicts the updated tree.

## Test plan

- [x] `task check` passes locally (full pipeline — ruff, format, pyright strict, import-linter 11/0, unit+integration+contract, error-contracts)
- [x] Both added files exist at the paths listed in the tree
- [x] No overlap with the in-flight PR #248 change (which adds `extraction/_validating_langextract_adapter.py` to a different section)