### PR TITLE
chore(gitignore): exclude .claude/worktrees/ from tracking (closes #267)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,13 @@ htmlcov/
 .DS_Store
 Thumbs.db
 
+# Claude Code / superpowers tooling — worktrees are generated workspace
+# state (can reach tens of gigabytes) and must never be tracked. Tracked
+# files under .claude/ (settings, hooks) stay tracked; only the worktrees/
+# subtree is excluded. A stray `git add .` otherwise drags the entire
+# generated tree into the index (issue #267).
+.claude/worktrees/
+
 # Docker
 *.log
 infra/compose/docker-compose.override.yml


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore` so a stray `git add .` can't stage the superpowers-generated parallel-agent worktrees (can exceed 30GB).
- Only the `worktrees/` subtree is excluded — tracked `.claude/` files (settings, hooks) continue to be versioned.
- Verified with `git check-ignore -v`: a file under `.claude/worktrees/testdir/file.txt` resolves to the new `.gitignore:38` entry.

## Test plan

- [x] `task check` passes locally (full pipeline green)
- [x] `git check-ignore -v .claude/worktrees/<anything>` resolves to the new entry
- [x] Running `git status` in a clone with `.claude/worktrees/` present no longer lists it as untracked