### PR TITLE
fix(arch): add unmatched_ignore_imports_alerting=warn to C5 contract (closes #273)

### DIFF
--- a/apps/backend/architecture/import-linter-contracts.ini
+++ b/apps/backend/architecture/import-linter-contracts.ini
@@ -314,6 +314,7 @@ ignore_imports =
     app.features.extraction.extraction.extraction_engine -> langextract
     app.features.extraction.extraction._validating_langextract_adapter -> langextract
     app.features.extraction.intelligence.ollama_gemma_provider -> langextract
+unmatched_ignore_imports_alerting = warn
 
 # ═════════════════════════════════════════════════════════════════════════
 # C6 - httpx containment (PDFX-E007-F004).

--- a/apps/backend/tests/unit/architecture/test_import_linter_contracts.py
+++ b/apps/backend/tests/unit/architecture/test_import_linter_contracts.py
@@ -184,6 +184,49 @@ def test_no_contract_references_a_non_extraction_feature_package(
     )
 
 
+def test_third_party_containment_contracts_alert_on_unmatched_ignores(
+    contracts_parser: configparser.ConfigParser,
+) -> None:
+    """C3-C6 (third-party containment) must set alerting on unmatched ignores.
+
+    Rationale (issue #273): `ignore_imports` on a containment contract is a
+    carve-out list saying "these specific files are allowed to import the
+    forbidden third-party module." If the codebase later drops one of those
+    edges (e.g. a refactor switches from static `import langextract` to a
+    lazy `importlib.import_module` wrapper), the ignore becomes "unmatched"
+    — it references an import that no longer exists — and import-linter
+    silently accepts that, shrinking the contract's enforcement surface
+    with no warning.
+
+    `unmatched_ignore_imports_alerting = warn` turns that silent drift into
+    a visible warning in `lint-imports` output. C3 (docling), C4 (pymupdf),
+    and C6 (httpx) already set it. C5 (langextract) did not, until #273.
+    This test enforces the parity across all four third-party containment
+    contracts.
+    """
+    third_party_keywords = ("docling", "pymupdf", "langextract", "httpx")
+    offenders: list[str] = []
+    for section in contracts_parser.sections():
+        if not section.startswith("importlinter:contract:"):
+            continue
+        if not any(keyword in section.lower() for keyword in third_party_keywords):
+            continue
+        if not contracts_parser.has_option(section, "ignore_imports"):
+            continue
+        alerting = contracts_parser.get(
+            section, "unmatched_ignore_imports_alerting", fallback=""
+        ).strip()
+        if alerting != "warn":
+            offenders.append(f"{section} (alerting={alerting!r})")
+
+    assert not offenders, (
+        "Every third-party containment contract (C3-C6) with `ignore_imports` "
+        "must also set `unmatched_ignore_imports_alerting = warn` so stale "
+        "carve-outs surface as warnings instead of silently shrinking "
+        f"enforcement. Offenders: {offenders}"
+    )
+
+
 def test_taskfile_wires_lint_imports_into_task_check() -> None:
     """U6: AC2/AC3 - `task check` reaches import-linter as a direct dependency.
 


### PR DESCRIPTION
## Summary
- C5 (langextract containment) now declares `unmatched_ignore_imports_alerting = warn`, matching C3/C4/C6. If any of its three `ignore_imports` carve-outs (`extraction_engine`, `_validating_langextract_adapter`, `ollama_gemma_provider` -> `langextract`) goes stale in a future refactor, `lint-imports` will surface a warning instead of silently shrinking enforcement.
- New unit test `test_third_party_containment_contracts_alert_on_unmatched_ignores` asserts every third-party containment contract (C3-C6) with `ignore_imports` also sets the `warn` alerting, so the parity is mechanically enforced going forward.

## Noise discovered by the added alerting
None from C5 itself — with the fix applied, `lint-imports --verbose` reports zero warnings for C5 (all three langextract carve-outs are matched by real static imports).

C3 and C4 still show pre-existing warnings (unmatched proactive carve-outs for docling and pymupdf dynamic imports); these predate this PR and are already documented in the contract rationale comments. Not touched here (out of scope for #273).

## Adjacent finding (tracked separately)
The broader "every contract with `ignore_imports` should alert" invariant would also catch `c2a-extraction-layers-leaves-independent`, which similarly lacks `unmatched_ignore_imports_alerting = warn`. The test in this PR is scoped narrowly to third-party containment contracts (C3-C6) per the `#273` scope directive; the C2a parity can be handled in a follow-up issue.

## Test plan
- [x] `uv run pytest tests/unit/architecture/test_import_linter_contracts.py` — 7 passed
- [x] `uv run lint-imports --config apps/backend/architecture/import-linter-contracts.ini` — 11 contracts kept, 0 broken
- [x] `task check` — full suite green (798 unit + 96 integration + 20 contract + 25 error-contracts)