### PR TITLE
fix(ci): gate deploy job on DEPLOY_ENABLED var (closes #270)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,14 @@ permissions:
 
 jobs:
   deploy:
+    # Kill switch (#270): the deploy path is not wired up yet — the rollout
+    # story is tracked in issue #121. Until then, skip the job cleanly
+    # (neutral grey in the Actions UI) rather than failing it (red), so
+    # on-call does not habituate to a permanently-red Deploy job and miss
+    # real regressions once the registry push goes live. Operators flip
+    # the repo variable `DEPLOY_ENABLED` to the literal string "true" to
+    # enable. Any other value (unset, "false", "1", empty) skips.
+    if: vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -29,6 +37,10 @@ jobs:
         run: docker build -f infra/docker/backend.Dockerfile -t pdf-data-extraction-backend:${{ github.sha }} .
 
       - name: Push to registry
+        # Placeholder body until issue #121 wires up the registry push.
+        # Exits 0 so that once an operator flips `DEPLOY_ENABLED=true` to
+        # exercise the rest of the pipeline, this step does not re-red the
+        # job. Replace this whole step body with the real push when #121
+        # lands; do not keep the placeholder AND the real push side by side.
         run: |
-          echo "::error::Push to registry not yet implemented — see issue #121 for tracking."
-          exit 1
+          echo "Deploy not yet wired — tracked in #121. Set DEPLOY_ENABLED=true when the registry push is ready, and replace this placeholder with the real push commands."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,5 +42,7 @@ jobs:
         # exercise the rest of the pipeline, this step does not re-red the
         # job. Replace this whole step body with the real push when #121
         # lands; do not keep the placeholder AND the real push side by side.
+        # Emitted as `::notice::` so operators see the message surfaced in
+        # the Actions run UI rather than buried in step logs.
         run: |
-          echo "Deploy not yet wired — tracked in #121. Set DEPLOY_ENABLED=true when the registry push is ready, and replace this placeholder with the real push commands."
+          echo "::notice::Deploy not yet wired — tracked in #121. To enable this job once the registry push is ready, set the repository variable DEPLOY_ENABLED to 'true' (Settings → Secrets and variables → Actions → Variables), then replace this placeholder with the real push commands."

--- a/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
@@ -111,8 +111,8 @@ def test_deploy_job_is_gated_on_deploy_enabled_variable() -> None:
     )
 
 
-def test_deploy_job_has_no_unconditional_exit_one() -> None:
-    """No step in the `deploy` job may carry a raw `exit 1`.
+def test_deploy_job_has_no_literal_exit_one() -> None:
+    """No step in the `deploy` job may carry a literal `exit 1` statement.
 
     The pre-#270 workflow shipped a ``Push to registry`` step whose body
     was ``echo "::error::..."; exit 1`` — a permanent red annotation that
@@ -121,6 +121,14 @@ def test_deploy_job_has_no_unconditional_exit_one() -> None:
     job runs, a forgotten ``exit 1`` in the body would reintroduce the
     red. Keep the body a descriptive placeholder that exits cleanly until
     the real registry push replaces it.
+
+    The check is a literal-match detector, not a conditional-awareness
+    parser: once issue #121 wires up a real push that legitimately exits
+    non-zero on failure, adjust the invariant (e.g. scope to placeholder
+    steps only) rather than trying to teach the static test about bash
+    control flow. Similarly, the regex does not attempt to strip quoted
+    strings, so a contrived ``echo "exit 1"`` inside a ``run:`` block
+    would false-positive — reword the message if it ever happens.
     """
     workflow = _load_deploy_workflow()
     deploy_job = (workflow.get("jobs") or {}).get("deploy")

--- a/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Final
 
+import pytest
 import yaml
 
 from ._linter_subprocess import REPO_ROOT
@@ -30,6 +31,36 @@ def _load_deploy_workflow() -> dict[str, Any]:
         "got a non-mapping or null value, likely malformed YAML."
     )
     return workflow
+
+
+def _strip_shell_inline_comment(line: str) -> str:
+    """Return `line` with any trailing bash-style inline comment removed.
+
+    Bash treats ``#`` as a comment start only when it is at the start of a
+    token — line start or preceded by whitespace — AND outside any single-
+    or double-quoted string. Minimal implementation that covers the shapes
+    that appear in GitHub Actions ``run:`` blocks, so the ``exit 1``
+    detector below does not flag ``echo foo  # exit 1`` as if the comment
+    text were real code.
+    """
+    in_single = False
+    in_double = False
+    prev_was_space = True
+    for idx, ch in enumerate(line):
+        if in_single:
+            if ch == "'":
+                in_single = False
+        elif in_double:
+            if ch == '"' and (idx == 0 or line[idx - 1] != "\\"):
+                in_double = False
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch == "#" and prev_was_space:
+            return line[:idx].rstrip()
+        prev_was_space = ch.isspace()
+    return line
 
 
 def test_deploy_job_is_gated_on_deploy_enabled_variable() -> None:
@@ -88,7 +119,7 @@ def test_deploy_job_has_no_unconditional_exit_one() -> None:
             continue
         # Check every non-blank, non-comment line for a bare `exit 1`.
         for raw_line in run_block.splitlines():
-            line = raw_line.strip()
+            line = _strip_shell_inline_comment(raw_line.strip())
             if not line or line.startswith("#"):
                 continue
             # Match `exit 1` as its own statement OR at the end of a
@@ -107,3 +138,28 @@ def test_deploy_job_has_no_unconditional_exit_one() -> None:
         "that reintroduces the permanent-red regression tracked in #270:\n"
         + "\n".join(f"  - {o}" for o in offenders)
     )
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        # Plain inline comment after code — stripped.
+        ("echo foo  # exit 1", "echo foo"),
+        # No comment — line returned unchanged.
+        ("echo foo", "echo foo"),
+        # `#` embedded inside double-quoted string is not a comment.
+        ('echo "foo # bar"', 'echo "foo # bar"'),
+        # `#` embedded inside single-quoted string is not a comment.
+        ("echo 'foo # bar'", "echo 'foo # bar'"),
+        # `#` not preceded by whitespace (e.g. inside a URL fragment) is
+        # not a comment start.
+        ("curl https://example.com/path#frag", "curl https://example.com/path#frag"),
+        # Real `exit 1` followed by a comment — the code survives.
+        ("exit 1 # intentional failure", "exit 1"),
+        # Full-line comment — returned as empty so the outer `startswith('#')`
+        # guard can drop it. (The strip removes the comment; nothing remains.)
+        ("# exit 1", ""),
+    ],
+)
+def test_strip_shell_inline_comment(line: str, expected: str) -> None:
+    assert _strip_shell_inline_comment(line) == expected

--- a/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
@@ -1,0 +1,109 @@
+"""Hygiene checks on `.github/workflows/deploy.yml`.
+
+Static assertions about the Deploy workflow — kept here so they run inside
+the canonical `task check` gate. Catches drift of the
+"do not habituate on-call to a red Deploy job" invariant (#270): until the
+container-registry push flow from #121 is wired up, the Deploy job must be
+GATED on a repo variable (``DEPLOY_ENABLED``) so GitHub Actions shows it
+as **skipped** (neutral) rather than **failed** (red) on every push to main.
+
+When #121 lands, the operator flips the repo variable to ``"true"`` and
+the existing job runs. No workflow edit should be required for the flip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+from ._linter_subprocess import REPO_ROOT
+
+_DEPLOY_WORKFLOW: Final[Path] = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
+
+
+def _load_deploy_workflow() -> dict[str, Any]:
+    workflow = yaml.safe_load(_DEPLOY_WORKFLOW.read_text())
+    assert isinstance(workflow, dict), (
+        f"{_DEPLOY_WORKFLOW} did not parse to a YAML mapping — "
+        "got a non-mapping or null value, likely malformed YAML."
+    )
+    return workflow
+
+
+def test_deploy_job_is_gated_on_deploy_enabled_variable() -> None:
+    """The `deploy` job must be gated on the ``DEPLOY_ENABLED`` repo variable.
+
+    Until the rollout story from #121 is wired up, the Deploy workflow has
+    nothing meaningful to do — but emitting a red failure on every push to
+    main habituates on-call to ignore the Deploy job, which hides real
+    failures once the registry push is wired up. The kill switch is at the
+    job level (``if: vars.DEPLOY_ENABLED == 'true'``) so GitHub Actions
+    renders the whole job as "skipped" (neutral grey) rather than "failed"
+    (red) while the variable is unset or anything other than the string
+    ``"true"``. Operators flip it to ``"true"`` when the registry path is
+    ready; no workflow edit needed.
+    """
+    workflow = _load_deploy_workflow()
+    deploy_job = (workflow.get("jobs") or {}).get("deploy")
+
+    assert deploy_job is not None, (
+        "deploy.yml must define a `deploy` job — the kill-switch gate "
+        "cannot be enforced against a missing job."
+    )
+
+    assert isinstance(deploy_job, dict), (
+        f"`deploy` job must be a YAML mapping; got {type(deploy_job).__name__}."
+    )
+
+    guard = deploy_job.get("if")
+    assert guard == "vars.DEPLOY_ENABLED == 'true'", (
+        "The `deploy` job must carry `if: vars.DEPLOY_ENABLED == 'true'` "
+        "so it is SKIPPED (neutral) rather than FAILED (red) on every push "
+        "to main until the registry-push path from #121 is wired up. "
+        f"Got: {guard!r}"
+    )
+
+
+def test_deploy_job_has_no_unconditional_exit_one() -> None:
+    """No step in the `deploy` job may carry a raw `exit 1`.
+
+    The pre-#270 workflow shipped a ``Push to registry`` step whose body
+    was ``echo "::error::..."; exit 1`` — a permanent red annotation that
+    fired on every push to main. Gating the job at the ``if:`` level is
+    not enough on its own: once the variable flips to ``"true"`` and the
+    job runs, a forgotten ``exit 1`` in the body would reintroduce the
+    red. Keep the body a descriptive placeholder that exits cleanly until
+    the real registry push replaces it.
+    """
+    workflow = _load_deploy_workflow()
+    deploy_job = (workflow.get("jobs") or {}).get("deploy")
+    assert isinstance(deploy_job, dict), "deploy job missing or malformed."
+
+    offenders: list[str] = []
+    for step in deploy_job.get("steps") or []:
+        run_block = step.get("run")
+        if not isinstance(run_block, str):
+            continue
+        # Check every non-blank, non-comment line for a bare `exit 1`.
+        for raw_line in run_block.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # Match `exit 1` as its own statement OR at the end of a
+            # compound statement (`foo && exit 1`). Do not over-match on
+            # `exit 10` etc.
+            tokens = line.replace(";", " ").replace("&&", " ").split()
+            for idx, tok in enumerate(tokens):
+                if tok == "exit" and idx + 1 < len(tokens) and tokens[idx + 1] == "1":
+                    offenders.append(
+                        f"step '{step.get('name', '<unnamed>')}' contains `exit 1`: {line!r}",
+                    )
+                    break
+
+    assert not offenders, (
+        "deploy.yml `deploy` job steps must not unconditionally `exit 1` — "
+        "that reintroduces the permanent-red regression tracked in #270:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+    )

--- a/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py
@@ -13,6 +13,7 @@ the existing job runs. No workflow edit should be required for the flip.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Final
 
@@ -22,6 +23,18 @@ import yaml
 from ._linter_subprocess import REPO_ROOT
 
 _DEPLOY_WORKFLOW: Final[Path] = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
+
+# Matches `exit 1` as a standalone statement — i.e. surrounded by non-word
+# characters on both sides so it is robust to punctuation-adjacent forms like
+# ``(exit 1)``, ``foo&&exit 1``, or ``exit 1;`` while still excluding
+# legitimate neighbours like ``exit 10`` or ``myexit 1``.
+_EXIT_ONE_RE: Final[re.Pattern[str]] = re.compile(r"(?<!\w)exit[ \t]+1(?!\w)")
+
+# Characters that put the shell back into "command position" — after any of
+# them, an unquoted ``#`` starts a comment. Bash's full grammar also treats
+# ``{``, ``!``, ``<``, ``>``, etc. as command-position openers, but the shapes
+# that appear in GitHub Actions ``run:`` blocks are well-covered by this set.
+_COMMAND_POSITION_TERMINATORS: Final[frozenset[str]] = frozenset(";&|(")
 
 
 def _load_deploy_workflow() -> dict[str, Any]:
@@ -36,16 +49,17 @@ def _load_deploy_workflow() -> dict[str, Any]:
 def _strip_shell_inline_comment(line: str) -> str:
     """Return `line` with any trailing bash-style inline comment removed.
 
-    Bash treats ``#`` as a comment start only when it is at the start of a
-    token — line start or preceded by whitespace — AND outside any single-
-    or double-quoted string. Minimal implementation that covers the shapes
-    that appear in GitHub Actions ``run:`` blocks, so the ``exit 1``
-    detector below does not flag ``echo foo  # exit 1`` as if the comment
-    text were real code.
+    Bash treats ``#`` as a comment start only when it is in "command
+    position" — at line start, or preceded by whitespace or one of the
+    command terminators in :data:`_COMMAND_POSITION_TERMINATORS` — AND
+    outside any single- or double-quoted string. Minimal implementation
+    that covers the shapes that appear in GitHub Actions ``run:`` blocks,
+    so the downstream ``exit 1`` detector does not flag commented-out text
+    (``echo foo  # exit 1``, ``echo ok;# exit 1``) as real code.
     """
     in_single = False
     in_double = False
-    prev_was_space = True
+    prev_char = " "  # line start counts as command-position
     for idx, ch in enumerate(line):
         if in_single:
             if ch == "'":
@@ -57,9 +71,9 @@ def _strip_shell_inline_comment(line: str) -> str:
             in_single = True
         elif ch == '"':
             in_double = True
-        elif ch == "#" and prev_was_space:
+        elif ch == "#" and (prev_char.isspace() or prev_char in _COMMAND_POSITION_TERMINATORS):
             return line[:idx].rstrip()
-        prev_was_space = ch.isspace()
+        prev_char = ch
     return line
 
 
@@ -117,21 +131,14 @@ def test_deploy_job_has_no_unconditional_exit_one() -> None:
         run_block = step.get("run")
         if not isinstance(run_block, str):
             continue
-        # Check every non-blank, non-comment line for a bare `exit 1`.
         for raw_line in run_block.splitlines():
             line = _strip_shell_inline_comment(raw_line.strip())
             if not line or line.startswith("#"):
                 continue
-            # Match `exit 1` as its own statement OR at the end of a
-            # compound statement (`foo && exit 1`). Do not over-match on
-            # `exit 10` etc.
-            tokens = line.replace(";", " ").replace("&&", " ").split()
-            for idx, tok in enumerate(tokens):
-                if tok == "exit" and idx + 1 < len(tokens) and tokens[idx + 1] == "1":
-                    offenders.append(
-                        f"step '{step.get('name', '<unnamed>')}' contains `exit 1`: {line!r}",
-                    )
-                    break
+            if _EXIT_ONE_RE.search(line):
+                offenders.append(
+                    f"step '{step.get('name', '<unnamed>')}' contains `exit 1`: {line!r}",
+                )
 
     assert not offenders, (
         "deploy.yml `deploy` job steps must not unconditionally `exit 1` — "
@@ -159,7 +166,49 @@ def test_deploy_job_has_no_unconditional_exit_one() -> None:
         # Full-line comment — returned as empty so the outer `startswith('#')`
         # guard can drop it. (The strip removes the comment; nothing remains.)
         ("# exit 1", ""),
+        # Command-position `#` after `;` (no whitespace) — bash comment start.
+        ("echo ok;# exit 1", "echo ok;"),
+        # Command-position `#` after `&&` — bash comment start.
+        ("echo ok&&# exit 1", "echo ok&&"),
+        # Command-position `#` after `||` — bash comment start.
+        ("echo ok||# exit 1", "echo ok||"),
+        # Command-position `#` immediately after subshell `(`.
+        ("(# inside subshell", "("),
     ],
 )
 def test_strip_shell_inline_comment(line: str, expected: str) -> None:
     assert _strip_shell_inline_comment(line) == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "should_match"),
+    [
+        # Bare statement.
+        ("exit 1", True),
+        # Trailing semicolon.
+        ("exit 1;", True),
+        # Subshell form — tokenizer would miss this.
+        ("(exit 1)", True),
+        # Punctuation-adjacent `&&` with no spaces — tokenizer would miss.
+        ("foo&&exit 1", True),
+        # `||` fallthrough — tokenizer would miss without `||` splitting.
+        ("cmd||exit 1", True),
+        # Leading whitespace is fine.
+        ("    exit 1", True),
+        # `exit 10` must NOT match — we only object to exit-code 1.
+        ("exit 10", False),
+        # `exit 11` likewise.
+        ("exit 11", False),
+        # `myexit 1` (e.g. a custom function) must NOT match.
+        ("myexit 1", False),
+        # `exit 1a` — suffix prevents match.
+        ("exit 1a", False),
+        # Bare `exit` (no code) is benign.
+        ("exit", False),
+    ],
+)
+def test_exit_one_regex(
+    line: str,
+    should_match: bool,  # noqa: FBT001 -- parametrized expected, not a flag argument
+) -> None:
+    assert bool(_EXIT_ONE_RE.search(line)) is should_match

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -284,6 +284,38 @@ Both layers exist because import-linter cannot express "module X may import
 Y only if X is in this narrow allowlist" without listing every other file in
 `source_modules` (which is unwieldy and brittle).
 
+## ADR-015: Deploy Job Gated on `DEPLOY_ENABLED` Variable (2026-04-19)
+
+**Status:** Accepted
+**Date:** 2026-04-19
+
+The `deploy` job in `.github/workflows/deploy.yml` is gated on
+`if: vars.DEPLOY_ENABLED == 'true'` (a repository variable, not a secret).
+While the registry-push rollout from issue #121 is not yet wired up, the
+job is **skipped** (neutral) rather than **failed** (red) on every push to
+`main`. Operators flip the variable to the literal string `"true"` via
+**Settings → Secrets and variables → Actions → Variables** to enable the
+job without editing the workflow.
+
+**Rationale.** The prior shape — an unconditional `exit 1` in the "Push to
+registry" step — habituated on-call to a permanently-red Deploy badge.
+That pattern silently hides real regressions the moment the push flow
+lands. A skipped job is visually distinct from a failed one in the
+Actions UI and in branch-status checks, so re-enabling the job produces
+actionable red (a legitimate deploy failure) rather than more noise.
+
+**Rejected alternative.** Removing the deploy workflow entirely until #121
+is ready. Rejected because the scaffolding (checkout, image build, the
+job skeleton) is stable; deleting and re-adding it invites copy-paste
+drift when the push step is finally wired. Keeping the job present but
+gated preserves the structure.
+
+**Enforcement.** Two assertions in
+`apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py`
+pin the guard and forbid any step in the `deploy` job from containing a
+raw `exit 1`, so a future "temporary" hack-in cannot silently reintroduce
+the regression.
+
 ## Superseded ADRs
 
 - **ADR-002 (offset pagination)** — superseded. There are no paginated


### PR DESCRIPTION
## Summary
- Gates the `deploy` job on `if: vars.DEPLOY_ENABLED == 'true'` so the workflow shows "skipped" (neutral) instead of "failed" (red) until the registry-push rollout from #121 is wired up. Operators flip the repo variable to `"true"` to enable; no workflow edit needed.
- Replaces the `exit 1` placeholder body in the "Push to registry" step with a descriptive `echo` that exits 0, so flipping the variable on does not immediately re-red the job before the real push commands replace it.
- Adds two hygiene assertions in `apps/backend/tests/unit/architecture/test_deploy_workflow_hygiene.py` (parses `deploy.yml`, asserts the `if:` guard is present, asserts no step in the `deploy` job carries a raw `exit 1`) plus a short ADR-015 in `docs/decisions.md` documenting the kill-switch convention.

## Test plan
- [x] Both new tests fail on `main` (verified with the unmodified workflow before the fix).
- [x] Both new tests pass after the fix.
- [x] `task check` is green end-to-end (lint, format:check, pyright, import-linter, skills:validate, unit/integration/contract suites, error-contract codegen + tests).