### PR TITLE
fix(docker): move .dockerignore to repo root so build context honors it (closes #269)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,9 +9,14 @@
 # apps/backend/.dockerignore is silently ignored. See issue #269.
 #
 # Entries below follow Docker's .dockerignore syntax (gitignore-like but
-# NOT identical): `**/foo/` matches `foo/` at any depth, leading slash is
-# NOT supported for absolute paths (all patterns are relative to the
-# context root). A leading `!` re-includes an otherwise-excluded path.
+# NOT identical). All patterns are matched relative to the build-context
+# root; a leading `/` anchors the pattern to the root (it does NOT mean an
+# absolute filesystem path — Docker strips it and treats the remainder as
+# a repo-root-relative match). Without a leading slash the pattern also
+# matches against the path relative to the context root, but `**/foo/`
+# makes "at any depth" explicit. A leading `!` re-includes an otherwise-
+# excluded path. See Docker's `.dockerignore` reference:
+# https://docs.docker.com/reference/dockerfile/#dockerignore-file
 
 # ── Version control ──────────────────────────────────────────
 .git/
@@ -66,3 +71,28 @@ Thumbs.db
 .env.*
 !.env.example
 !**/.env.example
+
+# ── Non-runtime trees in the backend slice ───────────────────
+# The Dockerfile (`infra/docker/backend.Dockerfile`) only COPYs
+# `apps/backend/pyproject.toml`, `apps/backend/uv.lock`,
+# `apps/backend/app/`, and `apps/backend/skills/`. Everything else under
+# `apps/backend/` would still be uploaded to the daemon as build context
+# without these exclusions, which was the regression issue #269 set out
+# to fix. Adding each tree explicitly so a newcomer can see, at a glance,
+# what the image does NOT need.
+apps/backend/tests/
+apps/backend/architecture/
+apps/backend/fixtures/
+apps/backend/scripts/
+
+# ── CI / workflow metadata ───────────────────────────────────
+# `.github/` (Actions workflows, Dependabot config, issue templates) is
+# repo-management only and is never COPYd into the image.
+.github/
+
+# ── Non-backend monorepo packages ────────────────────────────
+# `packages/error-contracts/` is a codegen input; the generated Python
+# files live under `apps/backend/app/exceptions/_generated/` (already
+# bundled via `apps/backend/app/`), so the source package itself is not
+# needed in the runtime image.
+packages/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,40 +1,38 @@
-# Docker build context — repo root.
+# ── Repo-root .dockerignore ──────────────────────────────────
+# Docker honors ONLY the .dockerignore adjacent to the build-context root.
+# The canonical build command in this repo (`.github/workflows/deploy.yml`
+# and `task docker:build`) is:
 #
-# Both `.github/workflows/deploy.yml` and `task docker:build` use `.`
-# (repo root) as the Docker build context, so the `.dockerignore` must
-# live HERE to take effect (Docker only consults the one adjacent to
-# the context root — issue #269). The previous location at
-# `apps/backend/.dockerignore` was silently inactive: without this
-# file the daemon received the entire monorepo, including
-# `.claude/worktrees/` (tens of gigabytes of generated AI-agent
-# workspaces), every cache directory, and all test fixtures —
-# ballooning the context and invalidating the build cache on any
-# repo-wide file change.
+#     docker build -f infra/docker/backend.Dockerfile .
 #
-# The Dockerfile itself (`infra/docker/backend.Dockerfile`) COPYs only
-# `apps/backend/pyproject.toml`, `apps/backend/uv.lock`,
-# `apps/backend/app/`, and `apps/backend/skills/`. Everything else in
-# the context is wasted bytes at best and a leak surface at worst.
+# so the context is the repo root — this file. A per-slice file at
+# apps/backend/.dockerignore is silently ignored. See issue #269.
+#
+# Entries below follow Docker's .dockerignore syntax (gitignore-like but
+# NOT identical): `**/foo/` matches `foo/` at any depth, leading slash is
+# NOT supported for absolute paths (all patterns are relative to the
+# context root). A leading `!` re-includes an otherwise-excluded path.
 
-# VCS & editor metadata
+# ── Version control ──────────────────────────────────────────
 .git/
-.github/
+.gitattributes
+.gitignore
+
+# ── Agent and local-state trees ──────────────────────────────
+# .claude/ carries worktree state for parallel agents (issue #267) and
+# must never be baked into an image.
+.claude/
 .vscode/
 .idea/
-*.swp
-*.swo
 
-# Claude Code / superpowers tooling — can reach tens of gigabytes of
-# generated parallel-agent workspaces. Parallel with the `.gitignore`
-# entry discussed in issue #267 and added in PR #274.
-.claude/
-
-# Python bytecode, caches, build artifacts
+# ── Python build + cache artifacts ───────────────────────────
+# These are machine-local and poison Docker's layer cache on any change.
+# `uv sync` inside the builder stage provisions a fresh .venv from
+# pyproject.toml + uv.lock, so the host .venv must not be uploaded.
+**/.venv/
 **/__pycache__/
 **/*.py[cod]
 **/*.egg-info/
-**/*.egg
-**/.venv/
 **/.pytest_cache/
 **/.ruff_cache/
 **/.mypy_cache/
@@ -44,21 +42,27 @@
 **/coverage.xml
 **/htmlcov/
 
-# Node / tooling (error-contracts package uses these when operated on
-# in dev but never during the backend image build)
+# ── Node / frontend caches (defensive; no frontend today) ────
 **/node_modules/
 
-# OS
+# ── Docs and markdown ────────────────────────────────────────
+# Documentation is not needed at runtime. Keep the backend README in case
+# a future Dockerfile step references it (e.g. for metadata LABEL).
+docs/
+*.md
+!apps/backend/README.md
+
+# ── OS / editor noise ────────────────────────────────────────
 .DS_Store
 Thumbs.db
+*.log
+*.swp
+*~
 
-# Repo-level artefacts the backend image does NOT need. The Dockerfile
-# explicitly COPYs only `apps/backend/app/` and `apps/backend/skills/`,
-# so anything outside those paths only bloats the context.
-docs/
-packages/
-apps/backend/tests/
-apps/backend/architecture/
-apps/backend/fixtures/
-apps/backend/scripts/
-*.md
+# ── Environment files ────────────────────────────────────────
+# Only `.env.example` is tracked; the real `.env` must never leak into
+# a built image regardless of layer.
+.env
+.env.*
+!.env.example
+!**/.env.example

--- a/apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py
+++ b/apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Final
 
+import pytest
+
 # parents[5] walks: this file -> docker/ -> unit/ -> tests/ -> backend/ ->
 # apps/ -> repo root. This mirrors the convention used by
 # `tests/unit/architecture/_linter_subprocess.REPO_ROOT`.
@@ -33,6 +35,10 @@ _MISPLACED_DOCKERIGNORE: Final[Path] = _REPO_ROOT / "apps" / "backend" / ".docke
 # directories/globs whose inclusion in the build context either bloats the
 # daemon upload, poisons the build cache, or leaks local-only state into
 # the image. Each entry is expressed exactly as it must appear in the file.
+# The large non-runtime trees (`apps/backend/tests/`, `apps/backend/architecture/`,
+# `apps/backend/fixtures/`, `.github/`) are not COPYd by
+# `infra/docker/backend.Dockerfile` but would otherwise be tarballed into the
+# build context, which is the regression issue #269 set out to fix.
 _REQUIRED_EXCLUSIONS: Final[tuple[str, ...]] = (
     ".git/",
     ".claude/",
@@ -42,17 +48,53 @@ _REQUIRED_EXCLUSIONS: Final[tuple[str, ...]] = (
     "**/.ruff_cache/",
     "**/.import_linter_cache/",
     "docs/",
+    "apps/backend/tests/",
+    "apps/backend/architecture/",
+    "apps/backend/fixtures/",
+    ".github/",
 )
 
 
 def _read_root_dockerignore_lines() -> list[str]:
-    """Return the non-comment, non-blank lines of the root `.dockerignore`."""
+    """Return the non-comment, non-blank lines of the root `.dockerignore`.
+
+    Fails the calling test with a clear message if the file is missing,
+    instead of letting `read_text()` raise a bare `FileNotFoundError`. This
+    keeps the error surface consistent with `test_root_dockerignore_exists`
+    even if a future test-collection order runs the exclusion assertion
+    first, or if someone deletes `.dockerignore` while iterating.
+    """
+    if not _ROOT_DOCKERIGNORE.is_file():
+        pytest.fail(
+            f"expected repo-root .dockerignore at {_ROOT_DOCKERIGNORE} — see "
+            "`test_root_dockerignore_exists` for the root-cause diagnostic. "
+            "Issue #269."
+        )
     text = _ROOT_DOCKERIGNORE.read_text(encoding="utf-8")
     return [
         stripped
         for raw_line in text.splitlines()
         if (stripped := raw_line.strip()) and not stripped.startswith("#")
     ]
+
+
+def test_read_helper_fails_cleanly_when_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_read_root_dockerignore_lines` must raise `Failed`, not `FileNotFoundError`.
+
+    Point `_ROOT_DOCKERIGNORE` at a non-existent path under `tmp_path` and
+    assert the helper surfaces a `pytest.fail(...)` with a clear diagnostic
+    instead of propagating a raw `FileNotFoundError` from `read_text()`.
+    """
+    missing = tmp_path / ".dockerignore-does-not-exist"
+    monkeypatch.setattr(
+        "tests.unit.docker.test_dockerignore_at_repo_root._ROOT_DOCKERIGNORE",
+        missing,
+    )
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        _read_root_dockerignore_lines()
+    assert "expected repo-root .dockerignore" in str(excinfo.value)
 
 
 def test_root_dockerignore_exists() -> None:

--- a/apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py
+++ b/apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py
@@ -1,0 +1,102 @@
+"""Static assertions on the repo-root `.dockerignore` (issue #269).
+
+Docker only honors a `.dockerignore` that sits adjacent to the build-context
+root. The canonical build command for this repo — pinned in both
+`.github/workflows/deploy.yml` and `task docker:build` — is:
+
+    docker build -f infra/docker/backend.Dockerfile -t <tag> .
+
+i.e. the context root is the *repo root*, not `apps/backend/`. A
+`.dockerignore` placed at `apps/backend/.dockerignore` has zero effect on
+this build: the daemon receives the whole monorepo (`.claude/worktrees/`,
+`.venv/`, `.hypothesis/`, `.import_linter_cache/`, full git history, docs,
+every test tree) as the context tarball, slowing builds and invalidating
+the cache on unrelated file changes.
+
+This test pins the fix so a future PR cannot silently regress it by
+re-introducing the misplaced per-slice file or deleting the root one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+# parents[5] walks: this file -> docker/ -> unit/ -> tests/ -> backend/ ->
+# apps/ -> repo root. This mirrors the convention used by
+# `tests/unit/architecture/_linter_subprocess.REPO_ROOT`.
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+_ROOT_DOCKERIGNORE: Final[Path] = _REPO_ROOT / ".dockerignore"
+_MISPLACED_DOCKERIGNORE: Final[Path] = _REPO_ROOT / "apps" / "backend" / ".dockerignore"
+
+# Exclusions that MUST appear in the root .dockerignore. These are the
+# directories/globs whose inclusion in the build context either bloats the
+# daemon upload, poisons the build cache, or leaks local-only state into
+# the image. Each entry is expressed exactly as it must appear in the file.
+_REQUIRED_EXCLUSIONS: Final[tuple[str, ...]] = (
+    ".git/",
+    ".claude/",
+    "**/.venv/",
+    "**/__pycache__/",
+    "**/.pytest_cache/",
+    "**/.ruff_cache/",
+    "**/.import_linter_cache/",
+    "docs/",
+)
+
+
+def _read_root_dockerignore_lines() -> list[str]:
+    """Return the non-comment, non-blank lines of the root `.dockerignore`."""
+    text = _ROOT_DOCKERIGNORE.read_text(encoding="utf-8")
+    return [
+        stripped
+        for raw_line in text.splitlines()
+        if (stripped := raw_line.strip()) and not stripped.startswith("#")
+    ]
+
+
+def test_root_dockerignore_exists() -> None:
+    """A `.dockerignore` file must exist at the repo root.
+
+    Without it, `docker build -f infra/docker/backend.Dockerfile .` sends
+    the entire repo (including local-only caches and the `.claude/` worktree
+    tree) to the daemon as context.
+    """
+    assert _ROOT_DOCKERIGNORE.is_file(), (
+        f"expected repo-root .dockerignore at {_ROOT_DOCKERIGNORE} — Docker only "
+        "honors .dockerignore adjacent to the build context, and the build "
+        "context is `.` (repo root) per .github/workflows/deploy.yml and "
+        "`task docker:build`. See issue #269."
+    )
+
+
+def test_misplaced_dockerignore_removed() -> None:
+    """The old `apps/backend/.dockerignore` must NOT exist.
+
+    Keeping a file with that name around is a footgun: it looks effective,
+    but Docker ignores it entirely when the build context is the repo root.
+    The fix is to delete it and centralize all exclusions in the root file.
+    """
+    assert not _MISPLACED_DOCKERIGNORE.exists(), (
+        f"{_MISPLACED_DOCKERIGNORE} is misplaced — Docker ignores .dockerignore "
+        "files that are not adjacent to the build-context root. Delete it and "
+        "rely on the repo-root .dockerignore. See issue #269."
+    )
+
+
+def test_root_dockerignore_contains_critical_exclusions() -> None:
+    """The root `.dockerignore` must list every critical exclusion.
+
+    Missing any one of these would leak the corresponding tree into the
+    build context: `.git/` is the largest per-repo offender; `.claude/`
+    carries parallel-agent worktrees (issue #267); `**/.venv/` carries the
+    full Python virtualenv; cache directories (`__pycache__`, `.pytest_cache`,
+    `.ruff_cache`, `.import_linter_cache`) invalidate Docker layer cache on
+    unrelated file changes. `docs/` is not needed at runtime.
+    """
+    lines = _read_root_dockerignore_lines()
+    missing = [entry for entry in _REQUIRED_EXCLUSIONS if entry not in lines]
+    assert not missing, (
+        f"root .dockerignore at {_ROOT_DOCKERIGNORE} is missing required "
+        f"exclusions: {missing!r}. Existing entries: {lines!r}. See issue #269."
+    )


### PR DESCRIPTION
## Summary

- Issue #269: `.dockerignore` lived at `apps/backend/.dockerignore`, but the build context is the repo root (`.github/workflows/deploy.yml:29` and `task docker:build` both run `docker build -f infra/docker/backend.Dockerfile .`). Docker only honors `.dockerignore` adjacent to the context root, so the old file had zero effect and every build shipped `.claude/worktrees/`, `.venv/`, `.hypothesis/`, `.import_linter_cache/`, full git history, docs, and every test tree to the daemon.
- Created `.dockerignore` at the repo root covering version control (`.git/`), agent/local state (`.claude/`, `.vscode/`, `.idea/`), Python caches (`**/.venv/`, `**/__pycache__/`, `**/.pytest_cache/`, `**/.ruff_cache/`, `**/.import_linter_cache/`, `**/.hypothesis/`, coverage files), node caches, docs, OS/editor noise, and env files (with `!.env.example` re-include). Kept `!apps/backend/README.md` carve-out in case a future `LABEL` step references it.
- Deleted the superseded `apps/backend/.dockerignore` so the footgun of a "looks-effective but silently ignored" file cannot resurface.
- Added `apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py` (new test slice) that asserts the root file exists, the misplaced file is gone, and every critical exclusion is present. Verified RED on HEAD (`233a75f`) before the fix, GREEN after.

## Test plan

- [x] Write failing unit tests under `apps/backend/tests/unit/docker/` (3 tests, all fail on main — file not found / missing exclusions).
- [x] `uv run pytest tests/unit/docker/ -v` → 3 passed after fix.
- [x] `task check` → all gates green (lint, types, architecture, skills validation, unit + integration + contract tests, error-contract codegen parity).
- [x] Confirmed Dockerfile (`infra/docker/backend.Dockerfile`) only COPYs `apps/backend/{pyproject.toml,uv.lock,app,skills}` — none are excluded by the new `.dockerignore`.
- [x] Pre-commit hooks (trim trailing whitespace, ruff, backend unit tests) passed on commit and push.