### PR TITLE
refactor(bench): move BenchmarkSettings out of app.core into scripts (closes #272)

### DIFF
--- a/apps/backend/scripts/__init__.py
+++ b/apps/backend/scripts/__init__.py
@@ -4,4 +4,15 @@ Modules here are standalone entry points invoked via `uv run python -m
 scripts.<name>` or wired through Taskfile targets. They must not import
 `app.main`, FastAPI, Docling, LangExtract, PyMuPDF, or the Ollama HTTP
 client — they exist specifically to bypass the full service boot.
+
+``BenchmarkSettings`` is re-exported here so cross-package consumers (e.g.
+the ``.env.example`` parity test in ``tests/unit/core/``) can import it as
+``from scripts import BenchmarkSettings`` without reaching into the
+underscore-private ``scripts._benchmark_settings`` module. The underscore
+path remains the implementation location; the re-export is the public
+boundary for the one legitimate outside reader.
 """
+
+from scripts._benchmark_settings import BenchmarkSettings
+
+__all__ = ["BenchmarkSettings"]

--- a/apps/backend/scripts/_benchmark_settings.py
+++ b/apps/backend/scripts/_benchmark_settings.py
@@ -1,4 +1,4 @@
-"""BenchmarkSettings — pydantic-settings model for ``scripts/benchmark`` (issue #237).
+"""BenchmarkSettings — pydantic-settings model for ``scripts/benchmark`` (issues #237, #272).
 
 The benchmark script is a CLI operator tool that reads its own ``BENCH_*``
 environment variables. CLAUDE.md forbids ``os.environ`` / ``os.getenv``
@@ -7,6 +7,12 @@ categorically, so those env vars flow through a dedicated
 the benchmark knobs off the main :class:`app.core.config.Settings`
 preserves the "application config vs operator-script config" separation
 while still satisfying the pydantic-settings-everywhere invariant.
+
+This module lives next to its sole consumer (``scripts/benchmark.py``)
+rather than under ``app/core/`` because ``app/core/`` is scoped to
+runtime service config and logging (CLAUDE.md). The leading underscore
+marks it as module-private to the ``scripts`` package — no code outside
+``scripts/`` should import it (issue #272).
 
 CLI flags on the script still win over env vars — ``parse_args`` uses
 the ``BenchmarkSettings`` defaults as the argparse ``default=`` values.

--- a/apps/backend/scripts/benchmark.py
+++ b/apps/backend/scripts/benchmark.py
@@ -36,7 +36,7 @@ import httpx
 import structlog
 from pydantic import ValidationError
 
-from app.core.benchmark_settings import BenchmarkSettings
+from scripts._benchmark_settings import BenchmarkSettings
 
 _logger = structlog.get_logger(__name__)
 
@@ -504,7 +504,7 @@ def _format_bench_error_source(loc: str, cli_overrides: dict[str, Any]) -> str:
 def parse_args(argv: list[str]) -> BenchConfig:
     """Parse CLI arguments and return a ``BenchConfig``.
 
-    Defaults come from :class:`app.core.benchmark_settings.BenchmarkSettings`,
+    Defaults come from :class:`scripts._benchmark_settings.BenchmarkSettings`,
     so ``BENCH_*`` environment variables flow through pydantic-settings
     rather than ``os.environ`` (CLAUDE.md forbidden pattern; issue #237).
     Explicit CLI flags still win over env vars.

--- a/apps/backend/tests/unit/core/test_env_example_parity.py
+++ b/apps/backend/tests/unit/core/test_env_example_parity.py
@@ -19,8 +19,8 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings
 
-from app.core.benchmark_settings import BenchmarkSettings
 from app.core.config import Settings
+from scripts._benchmark_settings import BenchmarkSettings
 
 # Fields that intentionally do NOT appear in ``.env.example``. Empty today;
 # add entries with an inline comment explaining the waiver if the need ever

--- a/apps/backend/tests/unit/core/test_env_example_parity.py
+++ b/apps/backend/tests/unit/core/test_env_example_parity.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from pydantic_settings import BaseSettings
 
 from app.core.config import Settings
-from scripts._benchmark_settings import BenchmarkSettings
+from scripts import BenchmarkSettings
 
 # Fields that intentionally do NOT appear in ``.env.example``. Empty today;
 # add entries with an inline comment explaining the waiver if the need ever

--- a/apps/backend/tests/unit/scripts/test_benchmark.py
+++ b/apps/backend/tests/unit/scripts/test_benchmark.py
@@ -260,7 +260,7 @@ def test_parse_args_reads_bench_env_vars_via_pydantic_settings(
 
     Regression guard for issue #237: the script previously read env vars via
     ``os.environ.get`` (CLAUDE.md-forbidden). After the refactor they flow
-    through :class:`app.core.benchmark_settings.BenchmarkSettings`, so this
+    through :class:`scripts._benchmark_settings.BenchmarkSettings`, so this
     test pins the wiring by exercising every BENCH_* variable at once.
 
     Extended for issue #275 to also cover ``BENCH_WARMUP`` / ``BENCH_TIMEOUT``.

--- a/apps/backend/tests/unit/scripts/test_benchmark_settings.py
+++ b/apps/backend/tests/unit/scripts/test_benchmark_settings.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from app.core.benchmark_settings import BenchmarkSettings
+from scripts._benchmark_settings import BenchmarkSettings
 
 
 def test_benchmark_settings_defaults() -> None:


### PR DESCRIPTION
## Summary

- Surgical move: `apps/backend/app/core/benchmark_settings.py` → `apps/backend/scripts/_benchmark_settings.py` (leading underscore = module-private to the `scripts` package).
- `BenchmarkSettings` is operator-script config consumed only by `scripts/benchmark.py`; CLAUDE.md scopes `app/core/` to runtime service config and logging, so the file now lives next to its sole consumer.
- Test file moved alongside (`tests/unit/core/test_benchmark_settings.py` → `tests/unit/scripts/test_benchmark_settings.py`) to keep the test-dir-shape-mirrors-source rule.
- Updated the four import sites: `scripts/benchmark.py`, the moved test, `tests/unit/scripts/test_benchmark.py` (docstring class-path), and `tests/unit/core/test_env_example_parity.py` (the env-parity check still owns BenchmarkSettings + Settings).

## Why no contract / arch-test changes were needed

- The C2-C6 import-linter contracts use `source_modules = app` and forbid third-party packages by name; `app.core.benchmark_settings` was never on any allow-list or ignore-list.
- The AST-scan tests in `test_dynamic_import_containment.py` walk `app/` recursively, so removing the file from `app/core/` is a no-op for them.
- The behavior of `BenchmarkSettings` is unchanged — only the file location and import path moved.

## Coordination with #275

Issue #275 proposes adding `warmup` / `timeout` fields to `BenchmarkSettings`. No PR for #275 was open at the time this branch was opened, so no rebase was required. If #275 lands first, this branch will need a trivial rebase that re-applies the move on top of the new fields. Reviewers: please coordinate merge order with the #275 author.

## Test plan

- [x] `task check` green (lint, format, pyright strict, import-linter 11/11 contracts kept, all unit + integration + contract tests, error-codegen drift check)
- [x] `uv run python -m scripts.benchmark --help` prints the help text without crashing
- [x] Moved `test_benchmark_settings.py` runs in its new location with only the import line changed
- [x] `git mv` preserves rename history (verified via `git status`)