### PR TITLE
feat(bench): expose BENCH_WARMUP and BENCH_TIMEOUT env vars (closes #275)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -75,3 +75,8 @@ BENCH_SKILL_VERSION=1
 # Optional PID of the running service process (for NFR-008 RSS measurement);
 # leave empty or unset to skip service-side memory reporting.
 BENCH_SERVICE_PID=
+# Number of warm-up requests to discard per fixture x mode batch before
+# timing begins. 0 disables warm-up.
+BENCH_WARMUP=1
+# HTTP request timeout in seconds for each extraction call. Must be > 0.
+BENCH_TIMEOUT=300

--- a/apps/backend/app/core/benchmark_settings.py
+++ b/apps/backend/app/core/benchmark_settings.py
@@ -56,3 +56,5 @@ class BenchmarkSettings(BaseSettings):
     skill_name: str = "invoice"
     skill_version: str = "1"
     service_pid: Annotated[int | None, BeforeValidator(_empty_string_to_none)] = None
+    warmup: Annotated[int, Field(ge=0)] = 1
+    timeout: Annotated[float, Field(gt=0)] = 300.0

--- a/apps/backend/scripts/benchmark.py
+++ b/apps/backend/scripts/benchmark.py
@@ -473,8 +473,9 @@ def run_benchmark(config: BenchConfig) -> BenchResults:
 
 
 # Argparse-name -> BenchmarkSettings-field mapping for the CLI flags that are
-# backed by a ``BENCH_*`` env var. Flags not in this set (``--warmup`` /
-# ``--timeout``) are script-local and keep concrete argparse defaults.
+# backed by a ``BENCH_*`` env var. Every CLI knob the benchmark script exposes
+# flows through :class:`BenchmarkSettings` so the env-CLI parity claim in the
+# module docstring holds (issue #275).
 _BENCH_FIELD_BY_ARG: dict[str, str] = {
     "url": "url",
     "iterations": "iterations",
@@ -482,6 +483,8 @@ _BENCH_FIELD_BY_ARG: dict[str, str] = {
     "skill_name": "skill_name",
     "skill_version": "skill_version",
     "service_pid": "service_pid",
+    "warmup": "warmup",
+    "timeout": "timeout",
 }
 
 
@@ -538,6 +541,8 @@ def parse_args(argv: list[str]) -> BenchConfig:
             "  BENCH_SKILL_NAME     Override --skill-name (default: invoice)\n"
             "  BENCH_SKILL_VERSION  Override --skill-version (default: 1)\n"
             "  BENCH_SERVICE_PID    Override --service-pid (default: none)\n"
+            "  BENCH_WARMUP         Override --warmup (default: 1)\n"
+            "  BENCH_TIMEOUT        Override --timeout (default: 300)\n"
         ),
     )
     # BenchmarkSettings-backed flags: SUPPRESS so only explicit CLI flags populate
@@ -575,17 +580,16 @@ def parse_args(argv: list[str]) -> BenchConfig:
         default=argparse.SUPPRESS,
         help="PID of the running service process for RSS measurement (NFR-008)",
     )
-    # Script-local flags: not env-backed, keep concrete argparse defaults.
     parser.add_argument(
         "--warmup",
         type=int,
-        default=1,
+        default=argparse.SUPPRESS,
         help="Number of warm-up requests to discard per batch (default: 1)",
     )
     parser.add_argument(
         "--timeout",
         type=float,
-        default=300.0,
+        default=argparse.SUPPRESS,
         help="HTTP request timeout in seconds (default: 300)",
     )
 
@@ -610,12 +614,6 @@ def parse_args(argv: list[str]) -> BenchConfig:
             sys.stderr.write(f"Error: {source}: {error['msg']}\n")
         raise SystemExit(2) from None  # operator-facing message, not a domain error
 
-    if args.warmup < 0:
-        parser.error("--warmup must be a non-negative integer")
-
-    if args.timeout <= 0:
-        parser.error("--timeout must be a positive number")
-
     # Normalize service_pid=0 -> None. PID 0 is never a valid target process
     # (POSIX reserves it for the current process group in signal semantics),
     # and ``ps -p 0`` produces no output. Matches the pre-refactor
@@ -628,8 +626,8 @@ def parse_args(argv: list[str]) -> BenchConfig:
         fixtures_dir=settings.fixtures_dir,
         skill_name=settings.skill_name,
         skill_version=settings.skill_version,
-        warmup=args.warmup,
-        timeout=args.timeout,
+        warmup=settings.warmup,
+        timeout=settings.timeout,
         service_pid=service_pid,
     )
 

--- a/apps/backend/tests/unit/core/test_benchmark_settings.py
+++ b/apps/backend/tests/unit/core/test_benchmark_settings.py
@@ -33,6 +33,8 @@ def test_benchmark_settings_defaults() -> None:
     assert s.skill_name == "invoice"
     assert s.skill_version == "1"
     assert s.service_pid is None
+    assert s.warmup == 1
+    assert s.timeout == 300.0
 
 
 def test_benchmark_settings_reads_env_prefix(
@@ -47,6 +49,8 @@ def test_benchmark_settings_reads_env_prefix(
     monkeypatch.setenv("BENCH_SKILL_NAME", "receipt")
     monkeypatch.setenv("BENCH_SKILL_VERSION", "2")
     monkeypatch.setenv("BENCH_SERVICE_PID", "4242")
+    monkeypatch.setenv("BENCH_WARMUP", "5")
+    monkeypatch.setenv("BENCH_TIMEOUT", "60.5")
 
     s = BenchmarkSettings(_env_file=None)  # type: ignore[call-arg]
 
@@ -56,6 +60,8 @@ def test_benchmark_settings_reads_env_prefix(
     assert s.skill_name == "receipt"
     assert s.skill_version == "2"
     assert s.service_pid == 4242
+    assert s.warmup == 5
+    assert s.timeout == 60.5
 
 
 def test_benchmark_settings_empty_service_pid_is_none(
@@ -83,5 +89,40 @@ def test_benchmark_settings_rejects_invalid_service_pid(
 ) -> None:
     """A non-integer BENCH_SERVICE_PID value raises ValidationError."""
     monkeypatch.setenv("BENCH_SERVICE_PID", "not-an-int")
+    with pytest.raises(ValidationError):
+        BenchmarkSettings(_env_file=None)  # type: ignore[call-arg]
+
+
+def test_benchmark_settings_rejects_negative_warmup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A negative BENCH_WARMUP value raises ValidationError (Field(ge=0))."""
+    monkeypatch.setenv("BENCH_WARMUP", "-1")
+    with pytest.raises(ValidationError):
+        BenchmarkSettings(_env_file=None)  # type: ignore[call-arg]
+
+
+def test_benchmark_settings_accepts_zero_warmup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warmup=0 is valid (no warm-up iterations); guards Field(ge=0), not gt=0."""
+    monkeypatch.setenv("BENCH_WARMUP", "0")
+    assert BenchmarkSettings(_env_file=None).warmup == 0  # type: ignore[call-arg]
+
+
+def test_benchmark_settings_rejects_zero_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero BENCH_TIMEOUT value raises ValidationError (Field(gt=0))."""
+    monkeypatch.setenv("BENCH_TIMEOUT", "0")
+    with pytest.raises(ValidationError):
+        BenchmarkSettings(_env_file=None)  # type: ignore[call-arg]
+
+
+def test_benchmark_settings_rejects_negative_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A negative BENCH_TIMEOUT value raises ValidationError (Field(gt=0))."""
+    monkeypatch.setenv("BENCH_TIMEOUT", "-1.0")
     with pytest.raises(ValidationError):
         BenchmarkSettings(_env_file=None)  # type: ignore[call-arg]

--- a/apps/backend/tests/unit/scripts/test_benchmark.py
+++ b/apps/backend/tests/unit/scripts/test_benchmark.py
@@ -262,6 +262,8 @@ def test_parse_args_reads_bench_env_vars_via_pydantic_settings(
     ``os.environ.get`` (CLAUDE.md-forbidden). After the refactor they flow
     through :class:`app.core.benchmark_settings.BenchmarkSettings`, so this
     test pins the wiring by exercising every BENCH_* variable at once.
+
+    Extended for issue #275 to also cover ``BENCH_WARMUP`` / ``BENCH_TIMEOUT``.
     """
     fixtures_dir = tmp_path / "bench-pdfs"
     monkeypatch.setenv("BENCH_URL", "http://example:9090")
@@ -270,6 +272,8 @@ def test_parse_args_reads_bench_env_vars_via_pydantic_settings(
     monkeypatch.setenv("BENCH_SKILL_NAME", "receipt")
     monkeypatch.setenv("BENCH_SKILL_VERSION", "2")
     monkeypatch.setenv("BENCH_SERVICE_PID", "1234")
+    monkeypatch.setenv("BENCH_WARMUP", "3")
+    monkeypatch.setenv("BENCH_TIMEOUT", "75.5")
 
     config = parse_args([])
 
@@ -279,6 +283,41 @@ def test_parse_args_reads_bench_env_vars_via_pydantic_settings(
     assert config.skill_name == "receipt"
     assert config.skill_version == "2"
     assert config.service_pid == 1234
+    assert config.warmup == 3
+    assert config.timeout == 75.5
+
+
+def test_parse_args_cli_warmup_and_timeout_override_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--warmup`` / ``--timeout`` on the CLI win over ``BENCH_*`` env values.
+
+    Regression guard for issue #275: after env-parity was restored for these
+    two knobs, the CLI must still take precedence over env — matching
+    pydantic-settings' documented init-kwargs > env source priority and the
+    behaviour of the other BENCH_*-backed flags.
+    """
+    monkeypatch.setenv("BENCH_WARMUP", "2")
+    monkeypatch.setenv("BENCH_TIMEOUT", "30.0")
+
+    config = parse_args(["--warmup", "7", "--timeout", "45"])
+
+    assert config.warmup == 7
+    assert config.timeout == 45.0
+
+
+def test_parse_args_negative_warmup_exits_nonzero() -> None:
+    """``--warmup -1`` exits non-zero via pydantic Field(ge=0)."""
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--warmup", "-1"])
+    assert exc_info.value.code != 0
+
+
+def test_parse_args_zero_timeout_exits_nonzero() -> None:
+    """``--timeout 0`` exits non-zero via pydantic Field(gt=0)."""
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--timeout", "0"])
+    assert exc_info.value.code != 0
 
 
 def test_parse_args_empty_bench_service_pid_is_none(


### PR DESCRIPTION
## Summary

- Adds `warmup` (`Field(ge=0)`) and `timeout` (`Field(gt=0)`) fields to `BenchmarkSettings`, completing env-CLI parity for the benchmark CLI (the module docstring already claimed this parity).
- Moves `--warmup` / `--timeout` argparse flags into `_BENCH_FIELD_BY_ARG` and switches their defaults to `argparse.SUPPRESS`, so they flow through `BenchmarkSettings(**cli_overrides)` like every other `BENCH_*`-backed flag. Hand-rolled `parser.error(...)` edges collapse into pydantic's Field constraints as the single source of truth.
- Adds `BENCH_WARMUP=1` and `BENCH_TIMEOUT=300` to `apps/backend/.env.example` (the parity test at `tests/unit/core/test_env_example_parity.py` now passes with the new fields present).

## Test plan

- [x] New unit tests in `tests/unit/core/test_benchmark_settings.py` cover defaults, env override, and `ValidationError` on `BENCH_WARMUP=-1` / `BENCH_TIMEOUT=0` / `BENCH_TIMEOUT=-1.0`.
- [x] New unit tests in `tests/unit/scripts/test_benchmark.py` pin `--warmup 7 --timeout 45` winning over `BENCH_*` env and the non-zero exit on invalid CLI values.
- [x] Existing `test_env_example_covers_every_settings_field` parity test passes with the new fields present in `.env.example`.
- [x] `task check` green locally (lint, pyright strict, import-linter, skills validate, unit + integration + contract tests, error-contracts).

## Notes

- Potential parallel conflict: issue #272 may relocate `BenchmarkSettings` to `apps/backend/scripts/_benchmark_settings.py`. At push time `main` had not yet moved the file, so no rebase was needed here. If #272 lands first, the semantic fields added by this PR will need to migrate with the class — the two PRs' field-level changes are orthogonal.