### PR TITLE
fix(intelligence): make _raw_generate client argument required (closes #277)

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -365,12 +365,17 @@ class OllamaGemmaProvider(BaseLanguageModel):
         self,
         prompt: str,
         *,
-        client: httpx.AsyncClient | None = None,
+        client: httpx.AsyncClient,
     ) -> str:
-        http = client or self.http_client
+        # ``client`` is required (not defaulted to ``self.http_client``) so any
+        # caller is forced to go through ``_get_http_client()`` for loop-bound
+        # rebinding. Falling back to ``self.http_client`` bypassed the
+        # rebuild-on-loop-switch logic and was a foot-gun for any new caller
+        # that forgot to call ``_get_http_client()`` first — Pyright strict
+        # now surfaces the mistake at author time (issue #277).
         payload = _build_payload(self._model, prompt)
         try:
-            response = await http.post(self._generate_url, json=payload)
+            response = await client.post(self._generate_url, json=payload)
             response.raise_for_status()
         except httpx.ConnectError as exc:
             _logger.warning("intelligence_unavailable", cause="connect_error", error=str(exc))


### PR DESCRIPTION
## Summary

- \`OllamaGemmaProvider._raw_generate\` had \`client: httpx.AsyncClient | None = None\` and fell back to \`self.http_client\` on the \`None\` branch. That bypassed \`_get_http_client()\`'s loop-bound rebuild — the guard that #234 / #132 added to stop \"Event loop is closed\" races when the same provider instance is used across \`asyncio.run\` scopes.
- Today's only caller (\`_validated_generate\`) passes \`client\` correctly, but the default was a foot-gun for any future caller. Removing it forces callers through \`_get_http_client()\`, and pyright strict now flags any omission at author time.

## Test plan

- [x] \`task check\` passes (lint, types strict, arch 11/0, unit+integration+contract, error-contracts)
- [x] Single caller (\`_validated_generate\` on line 352) already passes an explicit \`client\` arg — no call-site change required