### PR TITLE
ci(docker): build backend Dockerfile on every PR (closes #417)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,29 @@ jobs:
       - name: Contract tests
         run: uv run pytest tests/contract/ -v
 
+  dockerfile-build:
+    # Issue #417: `deploy.yml`'s job-level `if: vars.DEPLOY_ENABLED ==
+    # 'true'` guard (#300) skips the Build step on every merge, so the
+    # Dockerfile is not exercised in CI by default. Static checks in
+    # `test_dockerfile_hygiene.py` only parse the Dockerfile — they
+    # cannot catch wrong COPY paths, disappearing apt packages, or any
+    # runtime-of-build failure. This job closes that gap by running
+    # `docker build` on every PR without pushing to any registry.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # No downstream step pushes or calls an authenticated GH API.
+          persist-credentials: false
+
+      - name: Build backend Docker image
+        # No `--push`, no registry credentials, no DEPLOY_ENABLED
+        # coupling. Pure build verification. The image is named for
+        # local use on the runner only; it is discarded when the runner
+        # tears down.
+        run: docker build -f infra/docker/backend.Dockerfile -t pdfx-backend:ci-${{ github.sha }} .
+
   error-contracts:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
@@ -55,3 +55,41 @@ def test_ci_checkout_steps_disable_credential_persistence() -> None:
         "ci.yml checkout step(s) leave the GITHUB_TOKEN in git config:\n"
         + "\n".join(f"  - {o}" for o in offenders)
     )
+
+
+_BACKEND_DOCKERFILE_RELATIVE = "infra/docker/backend.Dockerfile"
+
+
+def test_ci_builds_dockerfile_on_every_pr() -> None:
+    """`ci.yml` must build ``infra/docker/backend.Dockerfile`` on every PR.
+
+    Issue #417: the deploy workflow's job-level ``if: vars.DEPLOY_ENABLED
+    == 'true'`` gate (landed via #300) causes the whole ``deploy`` job —
+    including the Build step — to be skipped on every merge to ``main``.
+    ``ci.yml`` does not build the Dockerfile either. The static Dockerfile
+    hygiene checks cannot catch runtime-of-build failures (wrong COPY
+    paths, apt package disappeared, etc.), so a broken Dockerfile can
+    sit on ``main`` until someone flips ``DEPLOY_ENABLED=true``.
+
+    This test pins the gate: some job in ``ci.yml`` must invoke
+    ``docker build`` against the repo-root backend Dockerfile. The job
+    name is not constrained (implementers can pick what fits the layout)
+    so the test doesn't lock in an unnecessary naming invariant.
+    """
+    workflow: dict[str, Any] = yaml.safe_load(_CI_WORKFLOW.read_text())
+
+    matching_steps: list[tuple[str, str]] = []
+    for job_name, step in _iter_steps(workflow):
+        run_body = step.get("run")
+        if not isinstance(run_body, str):
+            continue
+        if "docker build" in run_body and _BACKEND_DOCKERFILE_RELATIVE in run_body:
+            matching_steps.append((job_name, step.get("name", "")))
+
+    assert matching_steps, (
+        f"ci.yml has no step that runs `docker build` against "
+        f"`{_BACKEND_DOCKERFILE_RELATIVE}`. Without this gate a broken "
+        f"Dockerfile can ship to main undetected because the deploy "
+        f"workflow's job-level DEPLOY_ENABLED gate skips the Build step "
+        f"(issue #417)."
+    )

--- a/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
+++ b/apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py
@@ -71,25 +71,91 @@ def test_ci_builds_dockerfile_on_every_pr() -> None:
     paths, apt package disappeared, etc.), so a broken Dockerfile can
     sit on ``main`` until someone flips ``DEPLOY_ENABLED=true``.
 
-    This test pins the gate: some job in ``ci.yml`` must invoke
-    ``docker build`` against the repo-root backend Dockerfile. The job
-    name is not constrained (implementers can pick what fits the layout)
-    so the test doesn't lock in an unnecessary naming invariant.
+    The assertion enforces THREE things that together guarantee "every PR
+    builds the Dockerfile" (PR #418 review):
+
+    1. The workflow fires on the ``pull_request`` event with no ``paths:``
+       filter that could silently skip PRs touching files outside a
+       narrow subset.
+    2. At least one step in some job invokes ``docker build`` against
+       the repo-root backend Dockerfile.
+    3. Neither that step nor its containing job carries an ``if:`` guard
+       that could skip the build for some subset of PRs (e.g. a future
+       ``if: vars.DOCKER_BUILD_ENABLED == 'true'`` would make the gate
+       toggleable, which is the exact failure mode this test guards
+       against).
+
+    Job and step names are intentionally not constrained so the test
+    doesn't lock in naming invariants.
     """
     workflow: dict[str, Any] = yaml.safe_load(_CI_WORKFLOW.read_text())
 
-    matching_steps: list[tuple[str, str]] = []
-    for job_name, step in _iter_steps(workflow):
-        run_body = step.get("run")
-        if not isinstance(run_body, str):
-            continue
-        if "docker build" in run_body and _BACKEND_DOCKERFILE_RELATIVE in run_body:
-            matching_steps.append((job_name, step.get("name", "")))
+    # (1) pull_request trigger with no paths-filter gating.
+    # PyYAML parses YAML's bare ``on:`` key as the Python literal ``True``
+    # because ``on`` is a YAML 1.1 boolean. The workflow still fires
+    # correctly on GitHub (it interprets the string ``on:``), but our
+    # walker has to look under both keys. The ``# type: ignore`` is
+    # load-bearing: ``dict.get`` is typed as ``(str) -> V``, and we're
+    # intentionally probing a bool key that arises from YAML 1.1
+    # parsing of the literal ``on`` token.
+    triggers: dict[str, Any] = (
+        workflow.get("on") or workflow.get(True)  # type: ignore[arg-type]  # YAML 1.1 parses `on:` as bool True
+    ) or {}
+    pull_request_config = triggers.get("pull_request")
+    assert pull_request_config is not None, (
+        "ci.yml does not declare a `pull_request` trigger; the "
+        "dockerfile-build gate cannot fire on every PR."
+    )
+    if isinstance(pull_request_config, dict):
+        paths_filter = pull_request_config.get("paths")
+        paths_ignore_filter = pull_request_config.get("paths-ignore")
+        assert paths_filter is None, (
+            "ci.yml `pull_request` trigger declares a `paths:` filter "
+            f"({paths_filter!r}); PRs outside that filter would skip the "
+            "dockerfile-build gate. Remove the filter or switch to a "
+            "non-gating always-on trigger."
+        )
+        assert paths_ignore_filter is None, (
+            "ci.yml `pull_request` trigger declares a `paths-ignore:` "
+            f"filter ({paths_ignore_filter!r}); PRs matching those paths "
+            "would skip the dockerfile-build gate."
+        )
 
-    assert matching_steps, (
+    # (2) Locate the matching step AND its job body (for the if:
+    # assertion below).
+    jobs: dict[str, Any] = workflow.get("jobs") or {}
+    matching: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    for job_name, job_body in jobs.items():
+        for step in job_body.get("steps") or []:
+            run_body = step.get("run")
+            if not isinstance(run_body, str):
+                continue
+            if "docker build" in run_body and _BACKEND_DOCKERFILE_RELATIVE in run_body:
+                matching.append((job_name, job_body, step))
+
+    assert matching, (
         f"ci.yml has no step that runs `docker build` against "
         f"`{_BACKEND_DOCKERFILE_RELATIVE}`. Without this gate a broken "
         f"Dockerfile can ship to main undetected because the deploy "
         f"workflow's job-level DEPLOY_ENABLED gate skips the Build step "
         f"(issue #417)."
+    )
+
+    # (3) Neither the matching step nor its job carries an `if:` guard.
+    # At least one matching (job, step) pair must be unconditional; we
+    # don't require ALL matches to be unconditional in case the file
+    # legitimately has other gated docker-build steps later (e.g. a
+    # slow/opt-in variant).
+    unconditional = [
+        (job_name, step)
+        for job_name, job_body, step in matching
+        if "if" not in job_body and "if" not in step
+    ]
+    assert unconditional, (
+        "Every matching `docker build` step in ci.yml is gated with an "
+        "`if:` clause at either the job or step level. A conditional "
+        "dockerfile-build gate defeats the whole point of #417 — if the "
+        "gate is toggleable, a broken Dockerfile can still slip through "
+        "whenever the toggle is off. Keep at least one unconditional "
+        "docker-build step that runs on every PR."
     )


### PR DESCRIPTION
## Summary

- Add a new `dockerfile-build` job to `.github/workflows/ci.yml` that runs `docker build -f infra/docker/backend.Dockerfile .` on every PR. No `--push`, no registry credentials, no `DEPLOY_ENABLED` coupling — pure build verification.
- Pin the invariant with a new assertion in `apps/backend/tests/unit/architecture/test_ci_workflow_hygiene.py`: some step in `ci.yml` must invoke `docker build` against the repo-root backend Dockerfile. Job-name-agnostic so it doesn't lock in an implementation detail.
- `deploy.yml` is unchanged; the job-level `DEPLOY_ENABLED` gate stays as the deploy-path kill switch. This PR only closes the build-path validation gap.

## Why

PR #300 (closing #270) moved the `DEPLOY_ENABLED` guard to the job level of `deploy.yml`, which means the whole `deploy` job — including the `Build backend Docker image` step — is skipped on every push to `main` while `DEPLOY_ENABLED != 'true'` (the default, and the state expected until #121 lands). `ci.yml` does not build the Dockerfile either — it only runs ruff/pyright/pytest/import-linter. `test_dockerfile_hygiene.py` does static parsing only and cannot catch wrong `COPY` paths, disappearing apt packages, or any runtime-of-build failure.

The result is that a broken Dockerfile can sit on `main` undetected until someone flips `DEPLOY_ENABLED=true` — which per #121 is the exact moment we need the build path to be known-good. This PR closes that gap.

Closes #417.

## Test plan

- [x] \`task check\` green locally (including the new hygiene assertion)
- [x] Test fails on \`main\` without the new CI job (verified)
- [x] Test passes with the new job in place
- [ ] CI green (including the new \`dockerfile-build\` job itself building the backend image)