### PR TITLE
fix(license): set copyright to Cosmin Neamtiu, update year to 2026 (closes #331)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Project Template
+Copyright (c) 2026 Cosmin Neamtiu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Replace the placeholder `Copyright (c) 2025 Project Template` in `LICENSE` with `Copyright (c) 2026 Cosmin Neamtiu`.
- Fixes the year drift (commits are 2026-04-\*) and names an identifiable copyright holder so downstream redistribution has a clear attribution.

## Test plan
- [x] `task check` green locally.
- [ ] CI green on PR.

Closes #331.