### PR TITLE
fix(contributing): drop Node/pnpm/Biome from stale stack (closes #330)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,18 @@
 ## Getting Started
 
 1. Clone the repository
-2. Install prerequisites: Python 3.13, Node 22, pnpm 10, Docker
-3. Run `task dev` to start the full stack
+2. Install prerequisites: Python 3.13, [uv](https://docs.astral.sh/uv/), Docker
+3. Run `task dev` to start the backend stack
 
 ## Development Setup
 
-See [docs/architecture.md](docs/architecture.md) for the system architecture
-and [docs/conventions.md](docs/conventions.md) for coding conventions.
+See [docs/architecture.md](docs/architecture.md) for the system architecture,
+[docs/conventions.md](docs/conventions.md) for coding conventions, and
+[docs/runbook.md](docs/runbook.md) for day-to-day operations.
 
 ## Code Style
 
 - **Python**: Ruff (ALL rules), Pyright strict
-- **TypeScript**: Biome, tsc strict
 - **Commits**: [Conventional Commits](https://www.conventionalcommits.org/)
 
 ## Pull Request Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Getting Started
 
 1. Clone the repository
-2. Install prerequisites: Python 3.13, [uv](https://docs.astral.sh/uv/), Docker
+2. Install prerequisites: Python 3.13, [uv](https://docs.astral.sh/uv/), Docker, [task](https://taskfile.dev/installation/) (go-task)
 3. Run `task dev` to start the backend stack
 
 ## Development Setup


### PR DESCRIPTION
## Summary
- Remove the obsolete `Node 22, pnpm 10` prerequisites and the `TypeScript: Biome, tsc strict` code-style bullet from `CONTRIBUTING.md`. The frontend stack was deleted months ago (ADR-011, PDFX-E001-F003 status=done) — no `apps/frontend/`, `packages/api-client/`, or root `package.json` remains.
- Add `uv` to the prerequisites (the actual Python package manager in use).
- Cross-link `docs/runbook.md` for day-to-day operations alongside `architecture.md` and `conventions.md`.

## Test plan
- [x] `task check` green locally.
- [ ] CI green on PR.

Closes #330.