### PR TITLE
fix(bench): route main() output through injected streams to drop process-global swap (closes #326)

### DIFF
--- a/apps/backend/scripts/benchmark.py
+++ b/apps/backend/scripts/benchmark.py
@@ -25,7 +25,10 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from typing import TextIO
 
 try:
     import resource  # Unix only
@@ -632,8 +635,22 @@ def parse_args(argv: list[str]) -> BenchConfig:
     )
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point.  Returns a process exit code."""
+def main(
+    argv: list[str] | None = None,
+    *,
+    out: TextIO | None = None,
+    err: TextIO | None = None,
+) -> int:
+    """CLI entry point.  Returns a process exit code.
+
+    ``out`` and ``err`` default to ``sys.stdout`` / ``sys.stderr`` when ``None``.
+    Integration tests inject ``io.StringIO`` instances so they can capture the
+    report and error messages without mutating the process-global streams
+    (issue #326).
+    """
+    out_stream = sys.stdout if out is None else out
+    err_stream = sys.stderr if err is None else err
+
     try:
         config = parse_args(sys.argv[1:] if argv is None else argv)
     except SystemExit as exc:
@@ -643,16 +660,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         results = run_benchmark(config)
     except FileNotFoundError as exc:
-        sys.stderr.write(f"Error: {exc}\n")
+        err_stream.write(f"Error: {exc}\n")
         return 1
     except (ConnectionError, httpx.ConnectError, httpx.TimeoutException) as exc:
-        sys.stderr.write(f"Error: {exc}\n")
+        err_stream.write(f"Error: {exc}\n")
         return 1
     except RuntimeError as exc:
-        sys.stderr.write(f"Error: {exc}\n")
+        err_stream.write(f"Error: {exc}\n")
         return 1
 
-    sys.stdout.write(format_report(results))
+    out_stream.write(format_report(results))
     return 0
 
 

--- a/apps/backend/tests/integration/scripts/test_benchmark.py
+++ b/apps/backend/tests/integration/scripts/test_benchmark.py
@@ -209,30 +209,26 @@ def test_benchmark_completes_against_stubbed_service(tmp_path: Path) -> None:
 
     try:
         import io
-        import sys
 
         captured_out = io.StringIO()
         captured_err = io.StringIO()
-        old_stdout, old_stderr = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = captured_out, captured_err
 
-        try:
-            code = bench_main(
-                [
-                    "--url",
-                    f"http://127.0.0.1:{port}",
-                    "--iterations",
-                    "1",
-                    "--warmup",
-                    "0",
-                    "--fixtures-dir",
-                    str(fixtures_dir),
-                    "--timeout",
-                    "30",
-                ]
-            )
-        finally:
-            sys.stdout, sys.stderr = old_stdout, old_stderr
+        code = bench_main(
+            [
+                "--url",
+                f"http://127.0.0.1:{port}",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+                "--fixtures-dir",
+                str(fixtures_dir),
+                "--timeout",
+                "30",
+            ],
+            out=captured_out,
+            err=captured_err,
+        )
 
         out = captured_out.getvalue()
         err = captured_err.getvalue()
@@ -255,31 +251,26 @@ def test_benchmark_unreachable_service_exits_nonzero(tmp_path: Path) -> None:
     _write_fixture_pdfs(fixtures_dir)
 
     import io
-    import sys
     import time
 
     captured_err = io.StringIO()
-    old_stderr = sys.stderr
-    sys.stderr = captured_err
 
     start = time.monotonic()
-    try:
-        code = bench_main(
-            [
-                "--url",
-                "http://127.0.0.1:1",
-                "--iterations",
-                "1",
-                "--warmup",
-                "0",
-                "--fixtures-dir",
-                str(fixtures_dir),
-                "--timeout",
-                "5",
-            ]
-        )
-    finally:
-        sys.stderr = old_stderr
+    code = bench_main(
+        [
+            "--url",
+            "http://127.0.0.1:1",
+            "--iterations",
+            "1",
+            "--warmup",
+            "0",
+            "--fixtures-dir",
+            str(fixtures_dir),
+            "--timeout",
+            "5",
+        ],
+        err=captured_err,
+    )
 
     elapsed = time.monotonic() - start
     err = captured_err.getvalue()
@@ -297,25 +288,20 @@ def test_benchmark_missing_fixtures_exits_nonzero(tmp_path: Path) -> None:
     (fixtures_dir / "native_invoice_10p.pdf").write_bytes(b"%PDF-1.4 stub")
 
     import io
-    import sys
 
     captured_err = io.StringIO()
-    old_stderr = sys.stderr
-    sys.stderr = captured_err
 
-    try:
-        code = bench_main(
-            [
-                "--url",
-                "http://127.0.0.1:1",
-                "--iterations",
-                "1",
-                "--fixtures-dir",
-                str(fixtures_dir),
-            ]
-        )
-    finally:
-        sys.stderr = old_stderr
+    code = bench_main(
+        [
+            "--url",
+            "http://127.0.0.1:1",
+            "--iterations",
+            "1",
+            "--fixtures-dir",
+            str(fixtures_dir),
+        ],
+        err=captured_err,
+    )
 
     err = captured_err.getvalue()
 
@@ -338,29 +324,24 @@ def test_benchmark_extraction_errors_exit_nonzero(tmp_path: Path) -> None:
 
     try:
         import io
-        import sys
 
         captured_err = io.StringIO()
-        old_stderr = sys.stderr
-        sys.stderr = captured_err
 
-        try:
-            code = bench_main(
-                [
-                    "--url",
-                    f"http://127.0.0.1:{port}",
-                    "--iterations",
-                    "1",
-                    "--warmup",
-                    "0",
-                    "--fixtures-dir",
-                    str(fixtures_dir),
-                    "--timeout",
-                    "30",
-                ]
-            )
-        finally:
-            sys.stderr = old_stderr
+        code = bench_main(
+            [
+                "--url",
+                f"http://127.0.0.1:{port}",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+                "--fixtures-dir",
+                str(fixtures_dir),
+                "--timeout",
+                "30",
+            ],
+            err=captured_err,
+        )
 
         err = captured_err.getvalue()
         assert code != 0, f"Expected non-zero exit, got 0. stderr: {err}"


### PR DESCRIPTION
## Summary
- Extend `scripts.benchmark.main` to `main(argv, *, out: TextIO | None = None, err: TextIO | None = None)`, defaulting to `sys.stdout` / `sys.stderr` when unset.
- Route the four `sys.stdout.write` / `sys.stderr.write` calls inside `main()` through the injected streams.
- Rewrite the four integration tests in `tests/integration/scripts/test_benchmark.py` to pass `out=` / `err=` kwargs instead of mutating `sys.stdout` / `sys.stderr` inside a try/finally. Under `asyncio_default_fixture_loop_scope = "session"` the global swap raced with pytest's capture fixtures and teardown; injected streams are scoped to the call.
- No production behaviour change when the caller does not pass kwargs — the CLI entry point (`__main__`) still writes through the process-global streams.

## Test plan
- [x] `task check` green locally (lint, types, arch, skills, tests, error contracts).
- [ ] CI green on PR.

Closes #326.