### PR TITLE
fix(errors): emit structured log for DomainError responses (closes #323)

### DIFF
--- a/apps/backend/app/api/errors.py
+++ b/apps/backend/app/api/errors.py
@@ -32,6 +32,29 @@ def register_exception_handlers(app: FastAPI) -> None:
         exc: DomainError,
     ) -> JSONResponse:
         request_id = _get_request_id(request)
+        # Observability contract (issue #323): 5xx DomainError subclasses —
+        # ``StructuredOutputFailedError``, ``IntelligenceUnavailableError``,
+        # ``IntelligenceTimeoutError``, ``PdfParserUnavailableError``,
+        # ``ExtractionOverloadedError`` — are on-call-actionable, so emit at
+        # warning with ``exc_info=True`` so tracebacks reach the aggregator.
+        # 4xx is user-caused and high-volume; info-level keeps it visible
+        # without paging and omits the traceback.
+        http_5xx_floor = 500
+        if exc.http_status >= http_5xx_floor:
+            logger.warning(
+                "domain_error",
+                code=exc.code,
+                http_status=exc.http_status,
+                request_id=request_id,
+                exc_info=True,  # noqa: LOG014 — this function IS a FastAPI exception handler
+            )
+        else:
+            logger.info(
+                "domain_error",
+                code=exc.code,
+                http_status=exc.http_status,
+                request_id=request_id,
+            )
         return JSONResponse(
             status_code=exc.http_status,
             headers={"X-Request-Id": request_id},

--- a/apps/backend/tests/unit/exceptions/test_error_handler.py
+++ b/apps/backend/tests/unit/exceptions/test_error_handler.py
@@ -2,6 +2,7 @@
 
 import ast
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -21,6 +22,10 @@ def _create_test_app_with_handler() -> FastAPI:
     @test_app.get("/trigger-domain-error")
     async def trigger_domain_error() -> None:
         raise NotFoundError
+
+    @test_app.get("/trigger-5xx-domain-error")
+    async def trigger_5xx_domain_error() -> None:
+        raise InternalError
 
     @test_app.get("/trigger-validation-error")
     async def trigger_validation_error() -> None:
@@ -186,3 +191,58 @@ def test_error_handler_source_has_no_hardcoded_error_codes() -> None:
         f"generated class attributes (e.g. ValidationFailedError.code) "
         f"instead. Offenders: {offenders}"
     )
+
+
+def test_handle_domain_error_emits_warning_with_exc_info_for_5xx(
+    test_client: TestClient,
+) -> None:
+    """A 5xx DomainError subclass must emit a structured 'domain_error' warning log.
+
+    Issue #323 guard: before this fix the handler was silent, so
+    ``InternalError`` / ``IntelligenceUnavailableError`` / ``TimeoutError``
+    / etc. produced only an access-log 5xx line with no code, no params,
+    no traceback. Observers had to correlate the request_id against the
+    exception's origin by hand.
+
+    Spies directly on ``errors_module.logger`` because
+    ``structlog.testing.capture_logs`` depends on structlog's own processor
+    chain and is bypassed when earlier tests in the suite reroute structlog
+    through stdlib logging.
+    """
+    with patch.object(errors_module, "logger") as mock_logger:
+        response = test_client.get("/trigger-5xx-domain-error")
+
+    assert response.status_code == InternalError.http_status
+
+    mock_logger.warning.assert_called_once()
+    args, kwargs = mock_logger.warning.call_args
+    assert args == ("domain_error",)
+    assert kwargs["code"] == InternalError.code
+    assert kwargs["http_status"] == InternalError.http_status
+    assert kwargs["exc_info"] is True
+    assert "request_id" in kwargs
+
+    mock_logger.info.assert_not_called()
+
+
+def test_handle_domain_error_emits_info_for_4xx(test_client: TestClient) -> None:
+    """A 4xx DomainError subclass emits an info-level 'domain_error' event without traceback.
+
+    4xx errors are user-caused (bad input, missing resource) and are
+    high-volume by design. Info level keeps them visible in aggregation
+    without paging, and ``exc_info`` is omitted to avoid noise in logs.
+    """
+    with patch.object(errors_module, "logger") as mock_logger:
+        response = test_client.get("/trigger-domain-error")
+
+    assert response.status_code == 404  # NotFoundError
+
+    mock_logger.info.assert_called_once()
+    args, kwargs = mock_logger.info.call_args
+    assert args == ("domain_error",)
+    assert kwargs["code"] == NotFoundError.code
+    assert kwargs["http_status"] == NotFoundError.http_status
+    assert "request_id" in kwargs
+    assert "exc_info" not in kwargs
+
+    mock_logger.warning.assert_not_called()

--- a/apps/backend/tests/unit/exceptions/test_error_handler.py
+++ b/apps/backend/tests/unit/exceptions/test_error_handler.py
@@ -199,10 +199,10 @@ def test_handle_domain_error_emits_warning_with_exc_info_for_5xx(
     """A 5xx DomainError subclass must emit a structured 'domain_error' warning log.
 
     Issue #323 guard: before this fix the handler was silent, so
-    ``InternalError`` / ``IntelligenceUnavailableError`` / ``TimeoutError``
-    / etc. produced only an access-log 5xx line with no code, no params,
-    no traceback. Observers had to correlate the request_id against the
-    exception's origin by hand.
+    ``InternalError`` / ``IntelligenceUnavailableError`` /
+    ``IntelligenceTimeoutError`` / etc. produced only an access-log 5xx
+    line with no code, no params, no traceback. Observers had to
+    correlate the request_id against the exception's origin by hand.
 
     Spies directly on ``errors_module.logger`` because
     ``structlog.testing.capture_logs`` depends on structlog's own processor


### PR DESCRIPTION
## Summary
- `handle_domain_error` now emits a structured `domain_error` log event for every `DomainError` subclass raised.
- `http_status >= 500` (`StructuredOutputFailedError`, `IntelligenceUnavailableError`, `IntelligenceTimeoutError`, `PdfParserUnavailableError`, `ExtractionOverloadedError`) → `logger.warning(..., exc_info=True)` so tracebacks reach the log aggregator alongside the code/http_status/request_id fields.
- `http_status < 500` (4xx user errors) → `logger.info(...)` without `exc_info` (keeps 4xx visible for aggregation without paging or log-volume blow-up).
- `ruff LOG014` is suppressed on the 5xx branch with an inline reason — the function is a FastAPI exception handler registered via `@app.exception_handler(DomainError)`, which ruff's static check cannot detect.
- Two TDD unit tests (`test_handle_domain_error_emits_warning_with_exc_info_for_5xx`, `test_handle_domain_error_emits_info_for_4xx`) pin the new contract using `unittest.mock.patch.object(errors_module, "logger")` rather than `structlog.testing.capture_logs()` — the capture helper is bypassed when earlier tests in the suite reroute structlog through stdlib logging, so spying directly on the logger reference is the only reliable path.

## Test plan
- [x] `task check` green locally.
- [x] `pytest tests/unit/ -q` green locally (842 pass).
- [ ] CI green on PR.

Closes #323.