### PR TITLE
docs(ai-guide): refresh to reflect implemented extraction feature (closes #367)

### DIFF
--- a/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
+++ b/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
@@ -58,7 +58,7 @@ def test_ai_guide_mentions_every_existing_extraction_subpackage() -> None:
     subpackages = sorted(
         entry.name
         for entry in _EXTRACTION_FEATURE_DIR.iterdir()
-        if entry.is_dir() and not entry.name.startswith("_")
+        if entry.is_dir() and not entry.name.startswith("_") and (entry / "__init__.py").is_file()
     )
     assert subpackages, (
         f"No subpackages found under {_EXTRACTION_FEATURE_DIR}; the "

--- a/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
+++ b/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
@@ -1,0 +1,72 @@
+"""Guard rail preventing docs/ai-guide.md from drifting back into staleness.
+
+Issue #367 observed that `docs/ai-guide.md` still described the repo as a
+"post-bootstrap shell" with no extraction feature, even though
+`apps/backend/app/features/extraction/` and its subpackages have been
+implemented. A new AI agent reading the guide at session start would be
+actively misled.
+
+This test is the mechanical guard that keeps the guide honest. It asserts:
+
+1. None of the known stale claims (phrasings taken verbatim from the
+   pre-#367 version) reappear in the guide.
+2. Every subpackage that actually exists under
+   `apps/backend/app/features/extraction/` is mentioned by name in the
+   guide, so adding a new subpackage without updating the guide will fail
+   this test.
+
+When this test fails, update `docs/ai-guide.md` to reflect current reality
+instead of silencing the test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_AI_GUIDE_PATH = _REPO_ROOT / "docs" / "ai-guide.md"
+_EXTRACTION_FEATURE_DIR = _REPO_ROOT / "apps" / "backend" / "app" / "features" / "extraction"
+
+# Phrases copied verbatim from the stale ai-guide.md at commit-of-issue-#367.
+# Each entry is a lowercased substring; matching is case-insensitive.
+_STALE_PHRASES: tuple[str, ...] = (
+    "features/extraction/ subpackage does not exist",
+    "no extraction feature (yet)",
+    "the `apps/backend/skills/` data directory does not exist",
+    "no skill yamls",
+)
+
+
+def _ai_guide_text_lower() -> str:
+    return _AI_GUIDE_PATH.read_text(encoding="utf-8").lower()
+
+
+def test_ai_guide_does_not_contain_stale_phrases() -> None:
+    """No known stale phrasing from pre-#367 may re-appear in the guide."""
+    text_lower = _ai_guide_text_lower()
+    offending = [phrase for phrase in _STALE_PHRASES if phrase.lower() in text_lower]
+    assert not offending, (
+        "docs/ai-guide.md contains stale phrasing: "
+        f"{offending!r}. Update the guide to describe what exists today "
+        "rather than reintroducing pre-#367 claims."
+    )
+
+
+def test_ai_guide_mentions_every_existing_extraction_subpackage() -> None:
+    """Every implemented extraction subpackage must be named in the guide."""
+    text_lower = _ai_guide_text_lower()
+    subpackages = sorted(
+        entry.name
+        for entry in _EXTRACTION_FEATURE_DIR.iterdir()
+        if entry.is_dir() and not entry.name.startswith("_")
+    )
+    assert subpackages, (
+        f"No subpackages found under {_EXTRACTION_FEATURE_DIR}; the "
+        "extraction feature layout has changed and this test must be updated."
+    )
+    missing = [name for name in subpackages if name.lower() not in text_lower]
+    assert not missing, (
+        f"docs/ai-guide.md does not mention these implemented extraction "
+        f"subpackages: {missing!r}. Add them to the guide so readers learn "
+        "what exists."
+    )

--- a/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
+++ b/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
@@ -38,6 +38,11 @@ _STALE_PHRASES: tuple[str, ...] = (
 
 
 def _ai_guide_text_lower() -> str:
+    assert _AI_GUIDE_PATH.is_file(), (
+        f"Expected AI guide at {_AI_GUIDE_PATH}, but it does not exist. "
+        "If docs/ai-guide.md was moved or renamed, update this test to point "
+        "to the new location."
+    )
     return _AI_GUIDE_PATH.read_text(encoding="utf-8").lower()
 
 
@@ -55,6 +60,11 @@ def test_ai_guide_does_not_contain_stale_phrases() -> None:
 def test_ai_guide_mentions_every_existing_extraction_subpackage() -> None:
     """Every implemented extraction subpackage must be named in the guide."""
     text_lower = _ai_guide_text_lower()
+    assert _EXTRACTION_FEATURE_DIR.is_dir(), (
+        f"Expected extraction feature directory at {_EXTRACTION_FEATURE_DIR}, "
+        "but it does not exist. If the extraction feature was relocated or "
+        "renamed, update this test to point to the new location."
+    )
     subpackages = sorted(
         entry.name
         for entry in _EXTRACTION_FEATURE_DIR.iterdir()

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -124,9 +124,17 @@ is constructed once at startup in `app/main.py`, drives middleware
 configuration (CORS origins, upload byte cap), and is available to any
 downstream handler via `Depends(get_settings)`.
 
-**Extraction request lifecycle.** `router.extract` enforces the byte-size
-guard while streaming the upload, then calls `ExtractionService.extract(...)`.
-`ExtractionService` runs the pipeline under a single `asyncio.timeout` budget
+**Extraction request lifecycle.** Byte-size enforcement on `POST /api/v1/extract`
+is a defense-in-depth pair, not a single gate. `UploadSizeLimitMiddleware` is
+the true streaming-time guard: it runs at the ASGI layer before route dispatch,
+inspects `Content-Length`, and rejects oversized (or chunked-without-length)
+requests before Starlette's multipart parser spools any bytes. By the time
+`router.extract` receives a FastAPI `UploadFile`, Starlette has already
+parsed and spooled the multipart upload, so the route-level
+`read_with_byte_limit` check is a backstop in case a proxy stripped
+`Content-Length` — it is not the mechanism that prevents multipart spooling.
+`router.extract` then calls `ExtractionService.extract(...)`, which runs the
+pipeline under a single `asyncio.timeout` budget
 (`Settings.extraction_timeout_seconds`) and a per-service semaphore cap
 (`Settings.max_concurrent_extractions`) so over-cap callers fail fast with
 `ExtractionOverloadedError` (503) instead of queueing. Timed-out background

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -41,12 +41,15 @@ Python exception class per error code in `app/exceptions/_generated/`. A single
 exception handler in `app/api/errors.py` maps all `DomainError` subclasses to a
 consistent JSON response shape: `{error: {code, params, details, request_id}}`.
 Alongside the three generic codes (`NOT_FOUND`, `VALIDATION_FAILED`,
-`INTERNAL_ERROR`), the extraction pipeline's codes are in place:
-`SKILL_NOT_FOUND`, `SKILL_VALIDATION_FAILED`, `PDF_INVALID`,
-`PDF_PASSWORD_PROTECTED`, `PDF_TOO_LARGE`, `PDF_TOO_MANY_PAGES`,
-`PDF_NO_TEXT_EXTRACTABLE`, `PDF_PARSER_UNAVAILABLE`, `INTELLIGENCE_UNAVAILABLE`,
-`INTELLIGENCE_TIMEOUT`, `STRUCTURED_OUTPUT_FAILED`,
-`EXTRACTION_BUDGET_EXCEEDED`, `EXTRACTION_OVERLOADED`.
+`INTERNAL_ERROR`), the HTTP-returned extraction/runtime codes are:
+`SKILL_NOT_FOUND`, `PDF_INVALID`, `PDF_PASSWORD_PROTECTED`, `PDF_TOO_LARGE`,
+`PDF_TOO_MANY_PAGES`, `PDF_NO_TEXT_EXTRACTABLE`, `PDF_PARSER_UNAVAILABLE`,
+`INTELLIGENCE_UNAVAILABLE`, `INTELLIGENCE_TIMEOUT`,
+`STRUCTURED_OUTPUT_FAILED`, `EXTRACTION_BUDGET_EXCEEDED`,
+`EXTRACTION_OVERLOADED`. The contract also defines `SKILL_VALIDATION_FAILED`,
+but that is a startup/operator failure raised during `create_app()` when a
+skill YAML fails to validate; clients should not expect it as an HTTP API
+response.
 
 **Health endpoints.** `/health` is a pure liveness probe returning
 `{"status":"ok"}`. `/ready` is gated on a TTL-cached Ollama probe
@@ -127,12 +130,14 @@ downstream handler via `Depends(get_settings)`.
 **Extraction request lifecycle.** Byte-size enforcement on `POST /api/v1/extract`
 is a defense-in-depth pair, not a single gate. `UploadSizeLimitMiddleware` is
 the true streaming-time guard: it runs at the ASGI layer before route dispatch,
-inspects `Content-Length`, and rejects oversized (or chunked-without-length)
-requests before Starlette's multipart parser spools any bytes. By the time
-`router.extract` receives a FastAPI `UploadFile`, Starlette has already
-parsed and spooled the multipart upload, so the route-level
-`read_with_byte_limit` check is a backstop in case a proxy stripped
-`Content-Length` — it is not the mechanism that prevents multipart spooling.
+inspects `Content-Length`, and rejects oversized or missing/ambiguous-length
+requests (fail-closed) before Starlette's multipart parser spools any bytes.
+By the time `router.extract` receives a FastAPI `UploadFile`, Starlette has
+already parsed and spooled the multipart upload, so the route-level
+`read_with_byte_limit` check is a secondary safeguard if the ASGI guard is
+bypassed, misconfigured, or not applied to a given upload route (for example,
+a newly added upload endpoint not covered by the guarded paths). It is not the
+mechanism that prevents multipart spooling on a correctly guarded route.
 `router.extract` then calls `ExtractionService.extract(...)`, which runs the
 pipeline under a single `asyncio.timeout` budget
 (`Settings.extraction_timeout_seconds`) and a per-service semaphore cap
@@ -142,9 +147,14 @@ work (Docling / Ollama) is allowed to finish but its result is discarded.
 
 **Error handling.** Any layer that raises a `DomainError` subclass gets
 serialized via the registered exception handler into a consistent response
-envelope. The error code is machine-readable and stable. The extraction
-pipeline's layers do NOT raise generic `ValueError` / `RuntimeError`; they
-raise a generated `DomainError` subclass from `errors.yaml`.
+envelope. The error code is machine-readable and stable. Expected,
+user-facing failures inside the extraction pipeline do NOT surface as bare
+`ValueError` / `RuntimeError`; they raise a generated `DomainError` subclass
+from `errors.yaml`. Value-object constructors (e.g. `CharRange`,
+`BoundingBox`, `DoclingConfig`) still raise `ValueError` from their
+`__post_init__` / `__init__` invariant checks because those guard against
+programmer errors — wrong arguments at call-site — not runtime pipeline
+failures; see `CLAUDE.md` for the carve-out.
 
 **Request correlation.** `RequestIdMiddleware` generates a UUID per request
 and binds it to `structlog.contextvars` so every log line inside the request

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -1,8 +1,8 @@
-# AI Guide — Post-Bootstrap Shell Overview
+# AI Guide — Implemented Service Overview
 
-What is already implemented in the post-bootstrap shell, what is not, and how
-the pieces connect. Read [`CLAUDE.md`](../CLAUDE.md) for the rules and forbidden
-patterns.
+What is already implemented, how the pieces fit together, and what is
+deliberately out of scope. Read [`CLAUDE.md`](../CLAUDE.md) for the rules and
+forbidden patterns.
 
 ## What the Project Is
 
@@ -17,9 +17,12 @@ Full context lives in:
 
 - [`docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-design.md`](superpowers/specs/2026-04-13-pdf-extraction-microservice-design.md)
 - [`docs/superpowers/specs/2026-04-13-pdf-extraction-microservice-requirements.md`](superpowers/specs/2026-04-13-pdf-extraction-microservice-requirements.md)
-- [`docs/graphs/PDFX/`](graphs/PDFX/) — 1 project + 7 epics + 29 features (see each file's frontmatter for current `status`)
+- [`docs/graphs/PDFX/`](graphs/PDFX/) — 1 project + 7 epics + 29 features. Each
+  feature file's frontmatter carries its current `status`; consult the graph
+  tree for the authoritative per-feature state rather than assuming any
+  particular feature here is built or unbuilt.
 
-## Backend — What's Built (post-bootstrap shell)
+## Backend — What's Built
 
 **Core infrastructure.** App factory (`app/main.py`), configuration via
 pydantic-settings (`app/core/config.py`), structured logging via structlog
@@ -28,19 +31,22 @@ pydantic-settings (`app/core/config.py`), structured logging via structlog
 
 **Middleware stack.** Request-ID generation and validation (UUID-only, prevents
 log injection), access logging with method/path/status/duration, CORS with
-configurable origins. Security headers middleware was removed during the
-bootstrap run since the service runs on a trusted network only. All wired in
-`app/api/middleware.py`.
+configurable origins, upload-size limit middleware. Security headers
+middleware was removed during the bootstrap run since the service runs on a
+trusted network only. All wired in `app/api/middleware.py`.
 
 **Error handling.** Fully implemented via a code-generated system. Error codes
 live in `packages/error-contracts/errors.yaml`; a codegen script produces one
 Python exception class per error code in `app/exceptions/_generated/`. A single
 exception handler in `app/api/errors.py` maps all `DomainError` subclasses to a
 consistent JSON response shape: `{error: {code, params, details, request_id}}`.
-The post-bootstrap shell ships three generic error codes (`NOT_FOUND`,
-`VALIDATION_FAILED`, `INTERNAL_ERROR`). Extraction-specific codes
-(skill lookup, PDF parsing, intelligence layer, API layer) are added as
-feature-dev lands the corresponding features.
+Alongside the three generic codes (`NOT_FOUND`, `VALIDATION_FAILED`,
+`INTERNAL_ERROR`), the extraction pipeline's codes are in place:
+`SKILL_NOT_FOUND`, `SKILL_VALIDATION_FAILED`, `PDF_INVALID`,
+`PDF_PASSWORD_PROTECTED`, `PDF_TOO_LARGE`, `PDF_TOO_MANY_PAGES`,
+`PDF_NO_TEXT_EXTRACTABLE`, `PDF_PARSER_UNAVAILABLE`, `INTELLIGENCE_UNAVAILABLE`,
+`INTELLIGENCE_TIMEOUT`, `STRUCTURED_OUTPUT_FAILED`,
+`EXTRACTION_BUDGET_EXCEEDED`, `EXTRACTION_OVERLOADED`.
 
 **Health endpoints.** `/health` is a pure liveness probe returning
 `{"status":"ok"}`. `/ready` is gated on a TTL-cached Ollama probe
@@ -51,36 +57,51 @@ otherwise.
 **Architecture enforcement.** `import-linter` is wired as `task check:arch`, a
 direct dependency of `task check` (issue #215; `task lint` is ruff-only). The
 bootstrap shell originally shipped with one contract — `shared/` and `core/`
-cannot import from `features/`. Feature-dev's PDFX-E007-F004 milestone
-subsequently wired the full extraction-feature layer DAG and third-party
-containment contracts; the contract set (C1–C6) now lives in
-[`apps/backend/architecture/import-linter-contracts.ini`](../apps/backend/architecture/import-linter-contracts.ini).
+cannot import from `features/`. PDFX-E007-F004 layered in the full
+extraction-feature layer DAG and third-party containment contracts; the
+contract set (C1–C6) now lives in
+[`apps/backend/architecture/import-linter-contracts.ini`](../apps/backend/architecture/import-linter-contracts.ini),
+and a companion AST-scan unit test (`test_dynamic_import_containment.py`)
+catches dynamic / cross-feature imports that import-linter's static graph
+cannot see.
 
-## What Is NOT Built — To Be Added by feature-dev
-
-### No extraction feature (yet)
-
-The `features/extraction/` subpackage does not exist in the post-bootstrap
-shell. Feature-dev builds it out according to the 29 features in
-[`docs/graphs/PDFX/`](graphs/PDFX/). The expected shape after feature-dev:
+**Extraction vertical slice.** The `features/extraction/` subpackage exists and
+is populated. The `POST /api/v1/extract` route is wired. The service composes
+the full pipeline: skill lookup -> PDF parsing (Docling) -> text concatenation
+-> LLM-driven extraction (LangExtract + Ollama-Gemma provider with
+structured-output validation) -> coordinate resolution -> optional PyMuPDF
+annotation. Current layout under `apps/backend/app/features/extraction/`:
 
 ```
-apps/backend/app/features/extraction/
-├── router.py
-├── service.py
-├── schemas/
-├── parsing/
-├── intelligence/
-├── extraction/
-├── skills/
-├── coordinates/
-└── annotation/
+router.py                       # POST /api/v1/extract
+service.py                      # ExtractionService pipeline orchestrator
+deps.py                         # per-component DI factories for test overrides
+extraction_result.py            # pipeline-result value object
+schemas/                        # request/response Pydantic models, OutputMode,
+                                # ExtractedField, ExtractionMetadata, etc.
+parsing/                        # DoclingDocumentParser, DoclingConfig,
+                                # BoundingBox, ParsedDocument, PDF preflight
+intelligence/                   # IntelligenceProvider Protocol,
+                                # OllamaGemmaProvider, OllamaHealthProbe,
+                                # StructuredOutputValidator,
+                                # CorrectionPromptBuilder,
+                                # LangExtract wrapper schema
+extraction/                     # ExtractionEngine (LangExtract orchestration)
+                                # and validating LangExtract adapter
+skills/                         # Skill domain object, SkillManifest,
+                                # SkillLoader (YAML -> Skill),
+                                # duplicate-key-safe YAML loader
+coordinates/                    # SpanResolver, SubBlockMatcher,
+                                # TextConcatenator, OffsetIndex, CharRange
+annotation/                     # PdfAnnotator (PyMuPDF highlights)
 ```
 
-### No skill YAMLs
+Skill YAMLs live under `apps/backend/skills/` (the canonical data directory
+resolved by `Settings.skills_dir`). The directory is checked into the repo as
+an empty location (`.gitkeep`); it is populated per deployment with the skill
+files the service should advertise.
 
-The `apps/backend/skills/` data directory does not exist. Feature-dev creates
-it during PDFX-E002 and skill authors populate it.
+## What Is Deliberately Out of Scope
 
 ### No authentication or authorization
 
@@ -96,31 +117,46 @@ request is self-contained and produces zero disk writes outside logging.
 
 The service is API-only. Its consumer is code, not a browser.
 
-## How Things Bind Together (current shell)
+## How Things Bind Together
 
-**Config → Middleware → Router.** `Settings` (from env via pydantic-settings) is
-constructed once at startup in `app/main.py`, drives middleware configuration
-(CORS origins), and is available to any downstream handler via
-`Depends(get_settings)`.
+**Config -> Middleware -> Router.** `Settings` (from env via pydantic-settings)
+is constructed once at startup in `app/main.py`, drives middleware
+configuration (CORS origins, upload byte cap), and is available to any
+downstream handler via `Depends(get_settings)`.
+
+**Extraction request lifecycle.** `router.extract` enforces the byte-size
+guard while streaming the upload, then calls `ExtractionService.extract(...)`.
+`ExtractionService` runs the pipeline under a single `asyncio.timeout` budget
+(`Settings.extraction_timeout_seconds`) and a per-service semaphore cap
+(`Settings.max_concurrent_extractions`) so over-cap callers fail fast with
+`ExtractionOverloadedError` (503) instead of queueing. Timed-out background
+work (Docling / Ollama) is allowed to finish but its result is discarded.
 
 **Error handling.** Any layer that raises a `DomainError` subclass gets
 serialized via the registered exception handler into a consistent response
-envelope. The error code is machine-readable and stable.
+envelope. The error code is machine-readable and stable. The extraction
+pipeline's layers do NOT raise generic `ValueError` / `RuntimeError`; they
+raise a generated `DomainError` subclass from `errors.yaml`.
 
-**Request correlation.** `RequestIdMiddleware` generates a UUID per request and
-binds it to `structlog.contextvars` so every log line inside the request scope
-carries a `request_id` field. The ID is also set on the response header
+**Request correlation.** `RequestIdMiddleware` generates a UUID per request
+and binds it to `structlog.contextvars` so every log line inside the request
+scope carries a `request_id` field. The ID is also set on the response header
 `X-Request-ID`.
 
 **Error contracts.** `errors.yaml` is the source of truth. `task errors:generate`
-produces Python classes (plus TypeScript and JSON outputs with no current
-consumer). Adding a new error is one YAML edit plus `task errors:generate`.
+produces Python classes (plus TypeScript and JSON outputs). Adding a new error
+is one YAML edit plus `task errors:generate`.
 
-## Next Steps (feature-dev)
+## Guidance for New AI Agents
 
-The graph tree in [`docs/graphs/PDFX/`](graphs/PDFX/) lists 29 thickened
-features in topological priority order (10 through 290). Each feature file
-contains Problem, Scope, Out of scope, Acceptance criteria, Dependencies,
-Technical constraints, and Open questions. Start at priority 60 (PDFX-E002-F001
-is the first feature after template cleanup is already applied by this
-bootstrap run) and walk the tree in priority order.
+- Treat `docs/graphs/PDFX/` as the authoritative per-feature status; do NOT
+  rely on prose in this guide to determine whether a specific feature is
+  implemented. A feature file's frontmatter `status` field is load-bearing.
+- Before editing code that touches a third-party library (Docling, LangExtract,
+  PyMuPDF, Ollama HTTP client), use Context7 to fetch current docs. Training
+  data may lag.
+- Every new extraction path must raise a `DomainError` subclass from
+  `errors.yaml`, never a bare `ValueError` / `RuntimeError` / `HTTPException`.
+- Third-party imports are containment-locked to specific files (see
+  `CLAUDE.md` and `import-linter-contracts.ini`); add new Docling / PyMuPDF /
+  LangExtract / Ollama-HTTP imports only in the designated containment files.


### PR DESCRIPTION
closes #367

## Summary
- Drop the "What Is NOT Built" section's false claims (no extraction feature, no skills data dir, no skill YAMLs) that contradicted the live state of `apps/backend/app/features/extraction/`.
- Rewrite the guide to describe what exists today: the POST /api/v1/extract route, the ExtractionService pipeline, every populated subpackage (parsing, intelligence, extraction, skills, coordinates, annotation), and the extraction-specific error codes generated from errors.yaml.
- Point readers at `docs/graphs/PDFX/` frontmatter as the authoritative per-feature status source, so the guide stops trying to answer a question that already has a better answer elsewhere.
- Add a meta-test (`apps/backend/tests/unit/meta/test_ai_guide_not_stale.py`) that greps the guide for the specific stale phrasings observed in the issue and also asserts every subpackage under `apps/backend/app/features/extraction/` is mentioned by name, so future drift fails CI rather than silently misleading AI agents.

## Test plan
- [x] \`task check\` passes locally
- [x] Meta test fails on the pre-#367 version and passes on the refreshed version (verified via red-then-green)