### PR TITLE
refactor(errors): extract errors:generate into a script (closes #365)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,15 +121,10 @@ jobs:
         run: uv run --with pytest --with pyyaml pytest tests/ -v
 
       - name: Regenerate error contracts
-        run: |
-          uv run --with pyyaml python -c "
-          from pathlib import Path
-          from scripts.generate import generate_python, generate_typescript, generate_required_keys
-          p = Path('errors.yaml')
-          generate_python(p, Path('../../apps/backend/app/exceptions/_generated'))
-          generate_typescript(p, Path('src/generated.ts'))
-          generate_required_keys(p, Path('src/required-keys.json'))
-          "
+        # Shared entry point with `task errors:generate` (Taskfile.yml).
+        # Both callers invoke the same script so local and CI generation
+        # cannot drift. See issue #365.
+        run: uv run --with pyyaml python -m scripts.generate_all
 
       - name: Verify generated files are up to date
         working-directory: .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -163,7 +163,7 @@ tasks:
       - uv run --with pyyaml python -m scripts.check
 
   errors:generate:
-    desc: Generate error classes from errors.yaml
+    desc: Regenerate Python exception classes, TypeScript types, and required-keys.json from errors.yaml
     dir: packages/error-contracts
     cmds:
       # Single shared entry point; .github/workflows/ci.yml calls the same

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -166,8 +166,10 @@ tasks:
     desc: Generate error classes from errors.yaml
     dir: packages/error-contracts
     cmds:
-      - |
-        uv run --with pyyaml python -c "from pathlib import Path; from scripts.generate import generate_python, generate_typescript, generate_required_keys; p = Path('errors.yaml'); generate_python(p, Path('../../apps/backend/app/exceptions/_generated')); generate_typescript(p, Path('src/generated.ts')); generate_required_keys(p, Path('src/required-keys.json')); print('Generated all error contract files')"
+      # Single shared entry point; .github/workflows/ci.yml calls the same
+      # `python -m scripts.generate_all` so local and CI generation can never
+      # drift. See issue #365 for the deduplication context.
+      - uv run --with pyyaml python -m scripts.generate_all
 
   errors:test:
     desc: Run error-contracts package tests (codegen + validator); CI parity with .github/workflows/ci.yml error-contracts job

--- a/packages/error-contracts/scripts/generate_all.py
+++ b/packages/error-contracts/scripts/generate_all.py
@@ -1,0 +1,135 @@
+"""Single entry point for regenerating every error-contracts artifact.
+
+Extracted from the inlined ``python -c '...'`` blocks that previously
+lived in ``Taskfile.yml`` (the ``errors:generate`` task) and in
+``.github/workflows/ci.yml`` (the "Regenerate error contracts" step).
+Those two copies were near-identical but drifted independently; see
+issue #365 for the duplication diagnosis.
+
+Both callers now invoke::
+
+    uv run --with pyyaml python -m scripts.generate_all
+
+which walks ``errors.yaml`` once and materialises all three output
+families (Python exception classes, TypeScript types, JSON translation
+required-keys). Paths default to the monorepo layout relative to this
+script's location, so the command works with no arguments as long as
+it runs from ``packages/error-contracts/`` (the Taskfile + CI working
+directory). ``--errors-yaml`` and the three output-path flags exist for
+tests that need to point at fixtures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.generate import (
+    generate_python,
+    generate_required_keys,
+    generate_typescript,
+)
+
+# Default paths resolved against the error-contracts package root so the
+# command "just works" when invoked from packages/error-contracts/, which
+# is the working directory both the Taskfile (`dir: packages/error-contracts`)
+# and the CI workflow (`working-directory: packages/error-contracts`) use.
+_ERROR_CONTRACTS_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _ERROR_CONTRACTS_DIR.parents[1]
+_DEFAULT_ERRORS_YAML = _ERROR_CONTRACTS_DIR / "errors.yaml"
+_DEFAULT_PYTHON_DIR = (
+    _REPO_ROOT / "apps" / "backend" / "app" / "exceptions" / "_generated"
+)
+_DEFAULT_TS_PATH = _ERROR_CONTRACTS_DIR / "src" / "generated.ts"
+_DEFAULT_REQUIRED_KEYS_PATH = _ERROR_CONTRACTS_DIR / "src" / "required-keys.json"
+
+
+def main(
+    errors_yaml: Path | None = None,
+    python_dir: Path | None = None,
+    typescript_path: Path | None = None,
+    required_keys_path: Path | None = None,
+) -> int:
+    """Regenerate Python + TypeScript + required-keys.json artifacts.
+
+    All four parameters default to the production monorepo layout. Tests
+    pass explicit ``tmp_path`` fixtures; the Taskfile and CI call with
+    no arguments so defaults drive the real file locations.
+
+    Returns 0 on success. Raises ``ValueError`` (from ``load_and_validate``)
+    on malformed ``errors.yaml``; the caller's shell propagates the
+    non-zero exit. We deliberately do not catch and convert to a return
+    code — a malformed ``errors.yaml`` is a developer-facing bug and the
+    raw traceback is the most useful signal.
+    """
+    errors_path = errors_yaml if errors_yaml is not None else _DEFAULT_ERRORS_YAML
+    py_dir = python_dir if python_dir is not None else _DEFAULT_PYTHON_DIR
+    ts_path = typescript_path if typescript_path is not None else _DEFAULT_TS_PATH
+    keys_path = (
+        required_keys_path
+        if required_keys_path is not None
+        else _DEFAULT_REQUIRED_KEYS_PATH
+    )
+
+    generate_python(errors_path, py_dir)
+    generate_typescript(errors_path, ts_path)
+    generate_required_keys(errors_path, keys_path)
+
+    sys.stdout.write("Generated all error contract files\n")
+    return 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate Python exception classes, TypeScript types, and "
+            "required-keys.json from errors.yaml."
+        ),
+    )
+    parser.add_argument(
+        "--errors-yaml",
+        type=Path,
+        default=None,
+        help="Path to errors.yaml (defaults to packages/error-contracts/errors.yaml).",
+    )
+    parser.add_argument(
+        "--python-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory to write generated Python exception modules "
+            "(defaults to apps/backend/app/exceptions/_generated)."
+        ),
+    )
+    parser.add_argument(
+        "--typescript-path",
+        type=Path,
+        default=None,
+        help=(
+            "Path to write the generated TypeScript module "
+            "(defaults to packages/error-contracts/src/generated.ts)."
+        ),
+    )
+    parser.add_argument(
+        "--required-keys-path",
+        type=Path,
+        default=None,
+        help=(
+            "Path to write required-keys.json "
+            "(defaults to packages/error-contracts/src/required-keys.json)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = _parse_args(sys.argv[1:])
+    sys.exit(
+        main(
+            errors_yaml=args.errors_yaml,
+            python_dir=args.python_dir,
+            typescript_path=args.typescript_path,
+            required_keys_path=args.required_keys_path,
+        )
+    )

--- a/packages/error-contracts/scripts/generate_all.py
+++ b/packages/error-contracts/scripts/generate_all.py
@@ -16,11 +16,15 @@ required-keys). Each generator independently re-reads and re-validates
 ``errors.yaml``; the wrapper does not share the parsed result across
 calls. That redundancy is cheap at the current size of ``errors.yaml``
 and keeps each generator usable standalone from ``generate.py``. Paths
-default to the monorepo layout relative to this script's location, so
-the command works with no arguments as long as it runs from
-``packages/error-contracts/`` (the Taskfile + CI working directory).
-``--errors-yaml`` and the three output-path flags exist for tests that
-need to point at fixtures.
+default to the monorepo layout derived from this script's absolute
+``__file__`` location, so the no-argument form resolves correct output
+locations regardless of the caller's working directory. The one
+practical constraint on ``python -m scripts.generate_all`` is module
+resolution — ``scripts/`` must be on ``sys.path``, which Python gets
+for free when the command runs from ``packages/error-contracts/`` (the
+Taskfile + CI working directory) or when ``PYTHONPATH`` includes that
+directory. ``--errors-yaml`` and the three output-path flags exist for
+tests that need to point at fixtures.
 """
 
 from __future__ import annotations

--- a/packages/error-contracts/scripts/generate_all.py
+++ b/packages/error-contracts/scripts/generate_all.py
@@ -10,13 +10,17 @@ Both callers now invoke::
 
     uv run --with pyyaml python -m scripts.generate_all
 
-which walks ``errors.yaml`` once and materialises all three output
-families (Python exception classes, TypeScript types, JSON translation
-required-keys). Paths default to the monorepo layout relative to this
-script's location, so the command works with no arguments as long as
-it runs from ``packages/error-contracts/`` (the Taskfile + CI working
-directory). ``--errors-yaml`` and the three output-path flags exist for
-tests that need to point at fixtures.
+which regenerates all three output families from ``errors.yaml``
+(Python exception classes, TypeScript types, JSON translation
+required-keys). Each generator independently re-reads and re-validates
+``errors.yaml``; the wrapper does not share the parsed result across
+calls. That redundancy is cheap at the current size of ``errors.yaml``
+and keeps each generator usable standalone from ``generate.py``. Paths
+default to the monorepo layout relative to this script's location, so
+the command works with no arguments as long as it runs from
+``packages/error-contracts/`` (the Taskfile + CI working directory).
+``--errors-yaml`` and the three output-path flags exist for tests that
+need to point at fixtures.
 """
 
 from __future__ import annotations
@@ -99,7 +103,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=None,
         help=(
             "Directory to write generated Python exception modules "
-            "(defaults to apps/backend/app/exceptions/_generated)."
+            "(defaults to apps/backend/app/exceptions/_generated). "
+            "Override is intended for tests writing to tmp_path: the "
+            "generated __init__.py and _registry.py emit hard-coded "
+            "`app.exceptions._generated.*` import paths, so artifacts "
+            "written elsewhere won't be importable without renaming."
         ),
     )
     parser.add_argument(

--- a/packages/error-contracts/tests/test_generate_all_script.py
+++ b/packages/error-contracts/tests/test_generate_all_script.py
@@ -14,12 +14,15 @@ already have their own coverage in ``test_generate.py``. We check:
 1. Invoking ``main()`` with explicit paths produces Python + TS + JSON
    artifacts identical to calling the three generators directly (i.e.
    the wrapper does not reorder arguments or drop calls).
-2. ``main()`` defaults its paths from the project layout when called
-   with no arguments, so the module-as-script invocation used by the
-   Taskfile / CI works without environment setup.
-3. Running the script as a module via ``python -m scripts.generate_all``
+2. Running the script as a module via ``python -m scripts.generate_all``
    exits zero and writes all three artifact families — the end-to-end
    path the Taskfile and CI workflow actually execute.
+
+The zero-argument / default-path branch of ``main()`` is exercised
+transitively whenever ``task errors:check`` regenerates artifacts
+against the real ``errors.yaml`` and byte-compares them; duplicating
+that in this file would require spinning up a temp repo layout and
+adds no signal over what the drift check already provides.
 """
 
 from __future__ import annotations

--- a/packages/error-contracts/tests/test_generate_all_script.py
+++ b/packages/error-contracts/tests/test_generate_all_script.py
@@ -1,0 +1,202 @@
+"""Tests for the `scripts.generate_all` entry-point wrapper.
+
+Issue #365: the previous `task errors:generate` Taskfile step and the
+`.github/workflows/ci.yml` "Regenerate error contracts" step both inlined
+the same 8-statement `python -c` block. Drift between the two copies
+would silently skew local vs. CI behaviour. The fix extracts a shared
+``main()`` into ``scripts/generate_all.py``; both callers now invoke
+``python -m scripts.generate_all``.
+
+These tests cover the wrapper specifically — the individual generators
+(``generate_python``, ``generate_typescript``, ``generate_required_keys``)
+already have their own coverage in ``test_generate.py``. We check:
+
+1. Invoking ``main()`` with explicit paths produces Python + TS + JSON
+   artifacts identical to calling the three generators directly (i.e.
+   the wrapper does not reorder arguments or drop calls).
+2. ``main()`` defaults its paths from the project layout when called
+   with no arguments, so the module-as-script invocation used by the
+   Taskfile / CI works without environment setup.
+3. Running the script as a module via ``python -m scripts.generate_all``
+   exits zero and writes all three artifact families — the end-to-end
+   path the Taskfile and CI workflow actually execute.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.generate import (
+    generate_python,
+    generate_required_keys,
+    generate_typescript,
+)
+from scripts.generate_all import main as generate_all_main
+
+SAMPLE_YAML = """
+version: 1
+errors:
+  NOT_FOUND:
+    http_status: 404
+    description: Resource not found
+    params: {}
+  WIDGET_NOT_FOUND:
+    http_status: 404
+    description: Widget not found
+    params:
+      widget_id: string
+"""
+
+
+def _read_dir(path: Path) -> dict[str, str]:
+    """Return {relative_name: text} for every file under path (non-recursive suffices)."""
+    return {p.name: p.read_text() for p in sorted(path.iterdir()) if p.is_file()}
+
+
+def test_main_with_explicit_paths_matches_direct_generator_calls(
+    tmp_path: Path,
+) -> None:
+    """``main()`` invoking the three generators yields the same bytes as calling them directly.
+
+    This pins the wrapper's behaviour: it must not reorder arguments, drop
+    any of the three outputs, or transform paths. A regression here is
+    exactly the duplication hazard issue #365 was filed to eliminate —
+    the previous inlined `python -c` block and the new wrapper must be
+    observationally indistinguishable.
+    """
+    errors_yaml = tmp_path / "errors.yaml"
+    errors_yaml.write_text(SAMPLE_YAML)
+
+    # Direct-generator baseline.
+    baseline_python_dir = tmp_path / "baseline_python"
+    baseline_ts = tmp_path / "baseline.ts"
+    baseline_keys = tmp_path / "baseline-keys.json"
+    generate_python(errors_yaml, baseline_python_dir)
+    generate_typescript(errors_yaml, baseline_ts)
+    generate_required_keys(errors_yaml, baseline_keys)
+
+    # Wrapper output.
+    wrapper_python_dir = tmp_path / "wrapper_python"
+    wrapper_ts = tmp_path / "wrapper.ts"
+    wrapper_keys = tmp_path / "wrapper-keys.json"
+    exit_code = generate_all_main(
+        errors_yaml=errors_yaml,
+        python_dir=wrapper_python_dir,
+        typescript_path=wrapper_ts,
+        required_keys_path=wrapper_keys,
+    )
+    assert exit_code == 0
+
+    assert _read_dir(baseline_python_dir) == _read_dir(wrapper_python_dir)
+    assert baseline_ts.read_text() == wrapper_ts.read_text()
+    assert baseline_keys.read_text() == wrapper_keys.read_text()
+
+
+def test_main_produces_valid_json_for_required_keys(tmp_path: Path) -> None:
+    """The JSON artifact the wrapper writes is loadable and has the expected shape."""
+    errors_yaml = tmp_path / "errors.yaml"
+    errors_yaml.write_text(SAMPLE_YAML)
+
+    python_dir = tmp_path / "python"
+    ts_path = tmp_path / "generated.ts"
+    keys_path = tmp_path / "required-keys.json"
+    generate_all_main(
+        errors_yaml=errors_yaml,
+        python_dir=python_dir,
+        typescript_path=ts_path,
+        required_keys_path=keys_path,
+    )
+
+    payload = json.loads(keys_path.read_text())
+    assert payload["namespace"] == "errors"
+    assert set(payload["keys"]) == {"NOT_FOUND", "WIDGET_NOT_FOUND"}
+    assert payload["params_by_key"]["WIDGET_NOT_FOUND"] == ["widget_id"]
+    assert payload["params_by_key"]["NOT_FOUND"] == []
+
+
+def test_main_writes_all_three_artifact_families(tmp_path: Path) -> None:
+    """Pins that the wrapper produces Python files, a TS file, and a JSON file."""
+    errors_yaml = tmp_path / "errors.yaml"
+    errors_yaml.write_text(SAMPLE_YAML)
+
+    python_dir = tmp_path / "python"
+    ts_path = tmp_path / "generated.ts"
+    keys_path = tmp_path / "required-keys.json"
+    generate_all_main(
+        errors_yaml=errors_yaml,
+        python_dir=python_dir,
+        typescript_path=ts_path,
+        required_keys_path=keys_path,
+    )
+
+    # Python artifacts: at minimum __init__.py + _registry.py + one file per class.
+    python_files = {p.name for p in python_dir.iterdir() if p.is_file()}
+    assert "__init__.py" in python_files
+    assert "_registry.py" in python_files
+    assert "not_found_error.py" in python_files
+    assert "widget_not_found_error.py" in python_files
+
+    assert ts_path.exists()
+    assert "export type ErrorCode" in ts_path.read_text()
+
+    assert keys_path.exists()
+    assert json.loads(keys_path.read_text())["version"] == 1
+
+
+def test_main_module_invocation_exits_zero_and_writes_live_artifacts(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: `python -m scripts.generate_all` on the real errors.yaml.
+
+    Exercises the exact command the Taskfile and CI workflow run. The test
+    copies the package layout (scripts/ + errors.yaml) into `tmp_path` so
+    we don't mutate the live `apps/backend/app/exceptions/_generated`
+    tree — that's `task errors:generate`'s job on demand, not a side
+    effect of `task check`.
+    """
+    package_root = Path(__file__).resolve().parents[1]
+    scripts_src = package_root / "scripts"
+
+    work = tmp_path / "work"
+    work.mkdir()
+    errors_yaml = work / "errors.yaml"
+    errors_yaml.write_text(SAMPLE_YAML)
+
+    # Lay scripts/ alongside errors.yaml so `python -m scripts.generate_all`
+    # resolves identically to how it does from packages/error-contracts/.
+    scripts_dst = work / "scripts"
+    scripts_dst.mkdir()
+    for src in scripts_src.iterdir():
+        if src.is_file() and src.suffix == ".py":
+            (scripts_dst / src.name).write_text(src.read_text())
+
+    python_dir = work / "python_out"
+    ts_path = work / "generated.ts"
+    keys_path = work / "required-keys.json"
+
+    proc = subprocess.run(  # noqa: S603 — sys.executable is trusted
+        [
+            sys.executable,
+            "-m",
+            "scripts.generate_all",
+            "--errors-yaml",
+            str(errors_yaml),
+            "--python-dir",
+            str(python_dir),
+            "--typescript-path",
+            str(ts_path),
+            "--required-keys-path",
+            str(keys_path),
+        ],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"stderr: {proc.stderr}\nstdout: {proc.stdout}"
+    assert python_dir.exists()
+    assert ts_path.exists()
+    assert keys_path.exists()

--- a/packages/error-contracts/tests/test_generate_all_script.py
+++ b/packages/error-contracts/tests/test_generate_all_script.py
@@ -106,12 +106,13 @@ def test_main_produces_valid_json_for_required_keys(tmp_path: Path) -> None:
     python_dir = tmp_path / "python"
     ts_path = tmp_path / "generated.ts"
     keys_path = tmp_path / "required-keys.json"
-    generate_all_main(
+    exit_code = generate_all_main(
         errors_yaml=errors_yaml,
         python_dir=python_dir,
         typescript_path=ts_path,
         required_keys_path=keys_path,
     )
+    assert exit_code == 0
 
     payload = json.loads(keys_path.read_text())
     assert payload["namespace"] == "errors"
@@ -128,12 +129,13 @@ def test_main_writes_all_three_artifact_families(tmp_path: Path) -> None:
     python_dir = tmp_path / "python"
     ts_path = tmp_path / "generated.ts"
     keys_path = tmp_path / "required-keys.json"
-    generate_all_main(
+    exit_code = generate_all_main(
         errors_yaml=errors_yaml,
         python_dir=python_dir,
         typescript_path=ts_path,
         required_keys_path=keys_path,
     )
+    assert exit_code == 0
 
     # Python artifacts: at minimum __init__.py + _registry.py + one file per class.
     python_files = {p.name for p in python_dir.iterdir() if p.is_file()}
@@ -152,11 +154,12 @@ def test_main_writes_all_three_artifact_families(tmp_path: Path) -> None:
 def test_main_module_invocation_exits_zero_and_writes_live_artifacts(
     tmp_path: Path,
 ) -> None:
-    """End-to-end: `python -m scripts.generate_all` on the real errors.yaml.
+    """End-to-end: `python -m scripts.generate_all` with an isolated errors.yaml.
 
-    Exercises the exact command the Taskfile and CI workflow run. The test
-    copies the package layout (scripts/ + errors.yaml) into `tmp_path` so
-    we don't mutate the live `apps/backend/app/exceptions/_generated`
+    Exercises the exact command shape the Taskfile and CI workflow run.
+    The test stages `scripts/` in `tmp_path` and writes a temporary
+    `errors.yaml` from ``SAMPLE_YAML``, so we verify module invocation
+    without mutating the live `apps/backend/app/exceptions/_generated`
     tree — that's `task errors:generate`'s job on demand, not a side
     effect of `task check`.
     """


### PR DESCRIPTION
closes #365

## Summary

- Extracted the inlined 8-statement `python -c` from `Taskfile.yml` (errors:generate) and `.github/workflows/ci.yml` (Regenerate error contracts step) into a single shared entry point at `packages/error-contracts/scripts/generate_all.py`.
- Both callers now run `uv run --with pyyaml python -m scripts.generate_all` — local and CI generation can no longer drift.
- New script is argparse-driven: zero-arg invocation uses production defaults; tests pass `--errors-yaml / --python-dir / --typescript-path / --required-keys-path` pointing at `tmp_path` fixtures.
- Added `packages/error-contracts/tests/test_generate_all_script.py` covering byte-equality vs direct generator calls, JSON shape, artifact presence, and an end-to-end subprocess invocation.

## Test plan

- [x] `task check` passes locally (all 11 gates green)
- [x] `task errors:generate` emits byte-identical `_generated/` output (confirmed via `task errors:check`)
- [ ] CI green on PR