### PR TITLE
docs(docker): intentional apt-floating under digest-pinned base (closes #362)

### DIFF
--- a/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
+++ b/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
@@ -22,12 +22,13 @@ The intent is therefore:
    guard comment containing the stable marker
    `reproducibility-boundary:digest-only`, so future contributors who skim
    the Dockerfile see the rationale before reintroducing brittle pins.
-3. No `apt-get install` line may pin a package with `=<version>`. Any
-   contributor who wants to pin must first change the documented policy and
-   justify the tradeoff in review, rather than silently changing how package
-   drift and security updates are handled.
+3. No `apt-get install` line may pin a package as `pkg=version` (for
+   example, `tesseract-ocr=5.3.0-2`). Any contributor who wants to pin must
+   first change the documented policy and justify the tradeoff in review,
+   rather than silently changing how package drift and security updates are
+   handled.
 
-If this test fails, do NOT add `=<version>` pins to make it pass. Read the
+If this test fails, do NOT add `pkg=version` pins to make it pass. Read the
 guard comment in `infra/docker/backend.Dockerfile` and the rationale in the
 PR that closed issue #362.
 """
@@ -60,7 +61,11 @@ _APT_PIN_RE: Final[re.Pattern[str]] = re.compile(
     r"(?<![\w$-])[a-z0-9][a-z0-9.+\-]*=[a-zA-Z0-9][\w.:+~\-]*"
 )
 _FROM_DIGEST_RE: Final[re.Pattern[str]] = re.compile(r"^\s*FROM\s+\S*@sha256:[0-9a-f]{64}")
-_ARG_DIGEST_RE: Final[re.Pattern[str]] = re.compile(r"^\s*ARG\s+\w+\s*=\s*\S*@sha256:[0-9a-f]{64}")
+# Named `name` group exposes the ARG name so callers can refine the match to
+# a specific ARG without re-authoring the rest of the pattern.
+_ARG_DIGEST_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\s*ARG\s+(?P<name>\w+)\s*=\s*\S*@sha256:[0-9a-f]{64}"
+)
 
 
 def _dockerfile_lines() -> list[str]:
@@ -81,16 +86,39 @@ def _dockerfile_line_without_comment(line: str) -> str:
     return line.split("#", 1)[0].rstrip()
 
 
-def _apt_install_line_indices(lines: list[str]) -> list[int]:
-    return [
-        i
-        for i, line in enumerate(lines)
-        if _APT_INSTALL_RE.search(_dockerfile_line_without_comment(line))
-    ]
-
-
 def _from_line_indices(lines: list[str]) -> list[int]:
     return [i for i, line in enumerate(lines) if line.lstrip().startswith("FROM ")]
+
+
+def _runtime_stage_line_range(lines: list[str]) -> tuple[int, int]:
+    """Return ``(start, end)`` line indices covering the runtime stage.
+
+    The runtime stage is the *second* ``FROM`` directive onward. The builder
+    stage's apt installs are discarded at the end of the multi-stage build,
+    so a `=<version>` pin there does not ship with the image and is outside
+    this policy. Scoping the apt-install scan to the runtime stage matches
+    `tests/unit/architecture/test_dockerfile_hygiene.py::_runtime_stage_text`
+    and keeps this module's docstring (which talks about the *runtime*-stage
+    install) honest.
+    """
+    from_indices = _from_line_indices(lines)
+    if len(from_indices) < 2:
+        msg = (
+            f"expected at least two FROM directives (builder + runtime); "
+            f"found {len(from_indices)} in {_DOCKERFILE_PATH}"
+        )
+        raise AssertionError(msg)
+    return from_indices[1], len(lines)
+
+
+def _apt_install_line_indices(lines: list[str]) -> list[int]:
+    """Return line indices of `apt-get install` anchors in the runtime stage only."""
+    start, end = _runtime_stage_line_range(lines)
+    return [
+        i
+        for i in range(start, end)
+        if _APT_INSTALL_RE.search(_dockerfile_line_without_comment(lines[i]))
+    ]
 
 
 def _resolve_from_reference(lines: list[str], from_idx: int) -> str:
@@ -183,18 +211,30 @@ def test_from_lines_are_digest_pinned() -> None:
             f"updates and are guarded separately below."
         )
         # If the FROM goes via an ARG, also assert the ARG default itself
-        # matches the ARG-digest regex, so the module-level pattern is not
-        # dead code and any future drift in ARG formatting is caught.
+        # matches `_ARG_DIGEST_RE` AND is the *specific* ARG the FROM
+        # references. Using the module-level `_ARG_DIGEST_RE` (whose named
+        # `name` group exposes the ARG name) keeps the shared pattern
+        # authoritative, while filtering on `name == arg_name` catches the
+        # regression where an unrelated digest-pinned ARG further up the
+        # file would otherwise satisfy a generic check.
         tokens = lines[idx].split()
-        if len(tokens) >= 2 and re.fullmatch(r"\$\{(\w+)\}|\$(\w+)", tokens[1]):
+        arg_ref_match = (
+            re.fullmatch(r"\$\{(\w+)\}|\$(\w+)", tokens[1]) if len(tokens) >= 2 else None
+        )
+        if arg_ref_match is not None:
+            arg_name = arg_ref_match.group(1) or arg_ref_match.group(2)
             matching_arg = next(
-                (line for line in lines[:idx] if _ARG_DIGEST_RE.match(line)),
+                (
+                    line
+                    for line in lines[:idx]
+                    if (m := _ARG_DIGEST_RE.match(line)) is not None and m.group("name") == arg_name
+                ),
                 None,
             )
             assert matching_arg is not None, (
-                f"{_DOCKERFILE_PATH} line {idx + 1} FROM resolves via an ARG "
-                f"but no `ARG <NAME>=<image>@sha256:<64-hex>` default was "
-                f"found above it."
+                f"{_DOCKERFILE_PATH} line {idx + 1} FROM resolves via ARG "
+                f"{arg_name!r} but no `ARG {arg_name}=<image>@sha256:<64-hex>` "
+                f"default was found above it."
             )
 
 
@@ -204,8 +244,14 @@ def test_no_apt_install_line_pins_package_version() -> None:
     Enforces option (b) from issue #362: apt packages intentionally float so
     they can receive Debian security updates within the digest-pinned base
     image. Pinning defeats the point; if a future PR really needs to pin a
-    specific package, it must first remove the digest from the base image
-    and justify the tradeoff in its own review.
+    specific package, it must first update the documented policy (the
+    rationale block in `infra/docker/backend.Dockerfile` and the docstring
+    at the top of this file) and update these guard-rail tests to match,
+    justifying the reproducibility/security tradeoff in its own review.
+    Dropping the base-image `@sha256:` digest is NOT an acceptable escape
+    hatch: `test_from_lines_are_digest_pinned` is the sibling guard that
+    pins the base-image layers, and weakening it to unblock apt pinning
+    would reduce reproducibility, not increase it.
     """
     lines = _dockerfile_lines()
     install_indices = _apt_install_line_indices(lines)
@@ -230,6 +276,8 @@ def test_no_apt_install_line_pins_package_version() -> None:
         f"{_DOCKERFILE_PATH} has version-pinned apt packages, which contradicts "
         f"the issue #362 resolution (option b — intentional floating under a "
         f"digest-pinned base). Offending pins: {offending!r}. If you really do "
-        f"need to pin, remove the `@sha256:` digest from the base image first "
-        f"and justify the tradeoff in your PR."
+        f"need to pin, update the documented policy (the Dockerfile rationale "
+        f"block and this test's module docstring) and these guard-rail tests "
+        f"first, and justify the tradeoff in your PR — do NOT drop the "
+        f"`@sha256:` digest on the base image, which would merely widen drift."
     )

--- a/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
+++ b/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
@@ -3,26 +3,29 @@
 Issue #362 flagged the runtime-stage `apt-get install` as non-reproducible
 because it does not pin package versions (e.g. `tesseract-ocr=5.3.0-2`).
 
-The resolution (option **b** in the issue body) is NOT to pin: the base image
-is already pinned by SHA256 digest (`python:3.13-slim@sha256:d168b8d9…`),
-which is the real reproducibility boundary. Pinning Debian packages on top of
-a digest-pinned base would block Debian security updates without adding
-reproducibility that the digest doesn't already provide — the same digest
-always resolves to the same layers, so the same `apt-get install` always sees
-the same Debian suite snapshot at build time.
+The resolution (option **b** in the issue body) is NOT to pin. The base image
+is pinned by SHA256 digest (`python:3.13-slim@sha256:d168b8d9…`), which fixes
+the base-image layers. That does NOT make `apt-get install` deterministic
+against the standard Debian repositories: repo contents can change over time,
+so apt-installed packages may drift even when the base image digest is
+unchanged. This project intentionally accepts that drift so Debian security
+updates continue to flow; a fully reproducible apt install would require an
+apt snapshot or equivalently pinned mirror (e.g. snapshot.debian.org) in
+addition to the base-image digest.
 
 The intent is therefore:
 
 1. FROM lines must remain digest-pinned (`@sha256:…`). Losing the digest is
-   what turns floating apt packages into a reproducibility hole, and is the
-   failure mode this test guards against.
+   one way to widen build drift beyond the intentionally floating apt step,
+   and is the failure mode this test guards against.
 2. The runtime-stage `apt-get install` block must carry an above-the-line
    guard comment containing the stable marker
    `reproducibility-boundary:digest-only`, so future contributors who skim
    the Dockerfile see the rationale before reintroducing brittle pins.
 3. No `apt-get install` line may pin a package with `=<version>`. Any
-   contributor who wants to pin must first remove the digest pin and justify
-   the tradeoff, which is a deliberate, reviewed change — not a silent drift.
+   contributor who wants to pin must first change the documented policy and
+   justify the tradeoff in review, rather than silently changing how package
+   drift and security updates are handled.
 
 If this test fails, do NOT add `=<version>` pins to make it pass. Read the
 guard comment in `infra/docker/backend.Dockerfile` and the rationale in the
@@ -67,21 +70,39 @@ def _dockerfile_lines() -> list[str]:
     return _DOCKERFILE_PATH.read_text(encoding="utf-8").splitlines()
 
 
+def _dockerfile_line_without_comment(line: str) -> str:
+    """Return the executable portion of a Dockerfile line.
+
+    Ignores full-line comments and strips trailing inline comments so
+    comment text containing `apt-get install` (e.g. the rationale block in
+    `backend.Dockerfile`) is not treated as an install anchor by the test
+    helpers.
+    """
+    return line.split("#", 1)[0].rstrip()
+
+
 def _apt_install_line_indices(lines: list[str]) -> list[int]:
-    return [i for i, line in enumerate(lines) if _APT_INSTALL_RE.search(line)]
+    return [
+        i
+        for i, line in enumerate(lines)
+        if _APT_INSTALL_RE.search(_dockerfile_line_without_comment(line))
+    ]
 
 
 def _from_line_indices(lines: list[str]) -> list[int]:
     return [i for i, line in enumerate(lines) if line.lstrip().startswith("FROM ")]
 
 
-def _resolve_from_reference(lines: list[str], from_line: str) -> str:
-    """Return the concrete image reference for a FROM line.
+def _resolve_from_reference(lines: list[str], from_idx: int) -> str:
+    """Return the concrete image reference for the FROM line at ``from_idx``.
 
     If the FROM uses an ARG (e.g. `FROM ${PYTHON_IMAGE}`), look up the
-    most-recent `ARG <NAME>=<value>` default above the FROM and substitute.
-    This mirrors Docker's own ARG-before-FROM scoping rules.
+    most-recent `ARG <NAME>=<value>` default that appears *above* the FROM
+    and substitute. This mirrors Docker's own ARG-before-FROM scoping rules,
+    where an ARG must be declared before the FROM to be usable in that
+    FROM's image reference.
     """
+    from_line = lines[from_idx]
     tokens = from_line.split()
     # Expect: ["FROM", "<image-ref>", ...maybe "AS", "<stage>"]
     if len(tokens) < 2:
@@ -93,13 +114,19 @@ def _resolve_from_reference(lines: list[str], from_line: str) -> str:
         return image_ref
     arg_name = arg_ref.group(1) or arg_ref.group(2)
     arg_default_re = re.compile(rf"^\s*ARG\s+{re.escape(arg_name)}\s*=\s*(\S+)")
-    for line in lines:
+    # Scan only lines strictly above the FROM and return the LAST match, so
+    # a later `ARG NAME=...` override above the FROM wins over an earlier one
+    # and an `ARG` below the FROM is never considered.
+    resolved: str | None = None
+    for line in lines[:from_idx]:
         match = arg_default_re.match(line)
         if match:
-            return match.group(1)
+            resolved = match.group(1)
+    if resolved is not None:
+        return resolved
     msg = (
         f"FROM references ARG {arg_name!r} but no `ARG {arg_name}=<default>` "
-        f"was found in {_DOCKERFILE_PATH}"
+        f"was found above it in {_DOCKERFILE_PATH}"
     )
     raise AssertionError(msg)
 
@@ -129,23 +156,46 @@ def test_runtime_apt_install_has_reproducibility_marker() -> None:
 
 
 def test_from_lines_are_digest_pinned() -> None:
-    """Every FROM must resolve to an image reference carrying `@sha256:…`.
+    """Every FROM must resolve to an image reference carrying a full `@sha256:…` digest.
 
-    The digest is the reproducibility boundary. If a FROM loses its digest
-    (or references an ARG whose default lost its digest), the justification
-    for leaving apt packages floating collapses and this test fires.
+    The digest is the reproducibility boundary for the base-image layers. If
+    a FROM loses its digest (or references an ARG whose default lost its
+    digest), the justification for the intentional apt-floating policy
+    collapses and this test fires. A truncated or non-hex digest also fails,
+    because a short-form digest does not pin the image byte-for-byte.
     """
     lines = _dockerfile_lines()
     from_indices = _from_line_indices(lines)
     assert from_indices, f"{_DOCKERFILE_PATH} contains no FROM line"
+    _sha256_digest_re = re.compile(r"@sha256:[0-9a-f]{64}(?:\b|$)")
     for idx in from_indices:
-        resolved = _resolve_from_reference(lines, lines[idx])
-        assert "@sha256:" in resolved, (
+        resolved = _resolve_from_reference(lines, idx)
+        # Either the FROM line itself or the resolved ARG default must carry
+        # a full 64-hex SHA256 digest. Validate against the shared pattern so
+        # `_FROM_DIGEST_RE` / `_ARG_DIGEST_RE` below are authoritative.
+        if _FROM_DIGEST_RE.match(lines[idx]):
+            continue
+        assert _sha256_digest_re.search(resolved), (
             f"{_DOCKERFILE_PATH} line {idx + 1} FROM resolves to {resolved!r}, "
-            f"which is not digest-pinned. Issue #362 requires digest-pinned "
-            f"bases because they ARE the reproducibility boundary that lets "
-            f"apt packages stay floating for security updates."
+            f"which is not pinned to a full 64-hex `@sha256:` digest. Issue "
+            f"#362 requires digest-pinned bases because they anchor the "
+            f"base-image layers; apt packages still float for security "
+            f"updates and are guarded separately below."
         )
+        # If the FROM goes via an ARG, also assert the ARG default itself
+        # matches the ARG-digest regex, so the module-level pattern is not
+        # dead code and any future drift in ARG formatting is caught.
+        tokens = lines[idx].split()
+        if len(tokens) >= 2 and re.fullmatch(r"\$\{(\w+)\}|\$(\w+)", tokens[1]):
+            matching_arg = next(
+                (line for line in lines[:idx] if _ARG_DIGEST_RE.match(line)),
+                None,
+            )
+            assert matching_arg is not None, (
+                f"{_DOCKERFILE_PATH} line {idx + 1} FROM resolves via an ARG "
+                f"but no `ARG <NAME>=<image>@sha256:<64-hex>` default was "
+                f"found above it."
+            )
 
 
 def test_no_apt_install_line_pins_package_version() -> None:

--- a/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
+++ b/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
@@ -1,0 +1,185 @@
+"""Guard rails around the runtime-stage `apt-get install` in backend.Dockerfile.
+
+Issue #362 flagged the runtime-stage `apt-get install` as non-reproducible
+because it does not pin package versions (e.g. `tesseract-ocr=5.3.0-2`).
+
+The resolution (option **b** in the issue body) is NOT to pin: the base image
+is already pinned by SHA256 digest (`python:3.13-slim@sha256:d168b8d9…`),
+which is the real reproducibility boundary. Pinning Debian packages on top of
+a digest-pinned base would block Debian security updates without adding
+reproducibility that the digest doesn't already provide — the same digest
+always resolves to the same layers, so the same `apt-get install` always sees
+the same Debian suite snapshot at build time.
+
+The intent is therefore:
+
+1. FROM lines must remain digest-pinned (`@sha256:…`). Losing the digest is
+   what turns floating apt packages into a reproducibility hole, and is the
+   failure mode this test guards against.
+2. The runtime-stage `apt-get install` block must carry an above-the-line
+   guard comment containing the stable marker
+   `reproducibility-boundary:digest-only`, so future contributors who skim
+   the Dockerfile see the rationale before reintroducing brittle pins.
+3. No `apt-get install` line may pin a package with `=<version>`. Any
+   contributor who wants to pin must first remove the digest pin and justify
+   the tradeoff, which is a deliberate, reviewed change — not a silent drift.
+
+If this test fails, do NOT add `=<version>` pins to make it pass. Read the
+guard comment in `infra/docker/backend.Dockerfile` and the rationale in the
+PR that closed issue #362.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Final
+
+# parents[5] walks: this file -> meta/ -> unit/ -> tests/ -> backend/ ->
+# apps/ -> repo root. Mirrors the convention used by
+# `tests/unit/docker/test_dockerignore_at_repo_root.py`.
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+_DOCKERFILE_PATH: Final[Path] = _REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
+
+_MARKER: Final[str] = "reproducibility-boundary:digest-only"
+# How many lines above the `apt-get install` line the marker must appear.
+# Tight enough to prove the marker is topically adjacent to the install block,
+# loose enough to accommodate a multi-line comment block.
+_MARKER_PROXIMITY_LINES: Final[int] = 40
+
+_APT_INSTALL_RE: Final[re.Pattern[str]] = re.compile(r"\bapt-get\s+install\b")
+# Matches a pin like `tesseract-ocr=5.3.0-2` but NOT a bare
+# `--key=value` flag (which starts with `-`) and NOT shell variables
+# (which start with `$`). We look for a Debian-style package name token
+# (starts with an alphanumeric, contains letters/digits/dots/plus/dash)
+# followed immediately by `=` and a version-ish token.
+_APT_PIN_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?<![\w$-])[a-z0-9][a-z0-9.+\-]*=[a-zA-Z0-9][\w.:+~\-]*"
+)
+_FROM_DIGEST_RE: Final[re.Pattern[str]] = re.compile(r"^\s*FROM\s+\S*@sha256:[0-9a-f]{64}")
+_ARG_DIGEST_RE: Final[re.Pattern[str]] = re.compile(r"^\s*ARG\s+\w+\s*=\s*\S*@sha256:[0-9a-f]{64}")
+
+
+def _dockerfile_lines() -> list[str]:
+    if not _DOCKERFILE_PATH.is_file():
+        msg = f"expected backend Dockerfile at {_DOCKERFILE_PATH}"
+        raise AssertionError(msg)
+    return _DOCKERFILE_PATH.read_text(encoding="utf-8").splitlines()
+
+
+def _apt_install_line_indices(lines: list[str]) -> list[int]:
+    return [i for i, line in enumerate(lines) if _APT_INSTALL_RE.search(line)]
+
+
+def _from_line_indices(lines: list[str]) -> list[int]:
+    return [i for i, line in enumerate(lines) if line.lstrip().startswith("FROM ")]
+
+
+def _resolve_from_reference(lines: list[str], from_line: str) -> str:
+    """Return the concrete image reference for a FROM line.
+
+    If the FROM uses an ARG (e.g. `FROM ${PYTHON_IMAGE}`), look up the
+    most-recent `ARG <NAME>=<value>` default above the FROM and substitute.
+    This mirrors Docker's own ARG-before-FROM scoping rules.
+    """
+    tokens = from_line.split()
+    # Expect: ["FROM", "<image-ref>", ...maybe "AS", "<stage>"]
+    if len(tokens) < 2:
+        msg = f"malformed FROM line: {from_line!r}"
+        raise AssertionError(msg)
+    image_ref = tokens[1]
+    arg_ref = re.fullmatch(r"\$\{(\w+)\}|\$(\w+)", image_ref)
+    if arg_ref is None:
+        return image_ref
+    arg_name = arg_ref.group(1) or arg_ref.group(2)
+    arg_default_re = re.compile(rf"^\s*ARG\s+{re.escape(arg_name)}\s*=\s*(\S+)")
+    for line in lines:
+        match = arg_default_re.match(line)
+        if match:
+            return match.group(1)
+    msg = (
+        f"FROM references ARG {arg_name!r} but no `ARG {arg_name}=<default>` "
+        f"was found in {_DOCKERFILE_PATH}"
+    )
+    raise AssertionError(msg)
+
+
+def test_runtime_apt_install_has_reproducibility_marker() -> None:
+    """A guard comment with the stable marker must precede `apt-get install`.
+
+    The marker is the anchor for this test and for any future contributor
+    skimming the Dockerfile. Moving the install block without moving the
+    marker fails this test, which is the intended behavior.
+    """
+    lines = _dockerfile_lines()
+    install_indices = _apt_install_line_indices(lines)
+    assert install_indices, (
+        f"{_DOCKERFILE_PATH} contains no `apt-get install` line. If the runtime "
+        f"stage no longer installs apt packages, delete this test too."
+    )
+    for install_idx in install_indices:
+        window_start = max(0, install_idx - _MARKER_PROXIMITY_LINES)
+        window = lines[window_start:install_idx]
+        assert any(_MARKER in line for line in window), (
+            f"{_DOCKERFILE_PATH} line {install_idx + 1} runs `apt-get install` "
+            f"but no `{_MARKER}` marker comment appears within the preceding "
+            f"{_MARKER_PROXIMITY_LINES} lines. Issue #362 requires this marker "
+            f"so the intentional non-pinning is visible to future contributors."
+        )
+
+
+def test_from_lines_are_digest_pinned() -> None:
+    """Every FROM must resolve to an image reference carrying `@sha256:…`.
+
+    The digest is the reproducibility boundary. If a FROM loses its digest
+    (or references an ARG whose default lost its digest), the justification
+    for leaving apt packages floating collapses and this test fires.
+    """
+    lines = _dockerfile_lines()
+    from_indices = _from_line_indices(lines)
+    assert from_indices, f"{_DOCKERFILE_PATH} contains no FROM line"
+    for idx in from_indices:
+        resolved = _resolve_from_reference(lines, lines[idx])
+        assert "@sha256:" in resolved, (
+            f"{_DOCKERFILE_PATH} line {idx + 1} FROM resolves to {resolved!r}, "
+            f"which is not digest-pinned. Issue #362 requires digest-pinned "
+            f"bases because they ARE the reproducibility boundary that lets "
+            f"apt packages stay floating for security updates."
+        )
+
+
+def test_no_apt_install_line_pins_package_version() -> None:
+    """No `apt-get install` line may carry `pkg=version` pins.
+
+    Enforces option (b) from issue #362: apt packages intentionally float so
+    they can receive Debian security updates within the digest-pinned base
+    image. Pinning defeats the point; if a future PR really needs to pin a
+    specific package, it must first remove the digest from the base image
+    and justify the tradeoff in its own review.
+    """
+    lines = _dockerfile_lines()
+    install_indices = _apt_install_line_indices(lines)
+    # `apt-get install` can continue over backslash-terminated lines. Walk
+    # downward from each install anchor until we hit a line that does NOT end
+    # with a backslash — that's the end of the logical RUN command.
+    offending: list[tuple[int, str, str]] = []
+    for start in install_indices:
+        idx = start
+        while idx < len(lines):
+            line = lines[idx]
+            # Strip trailing comments before scanning — a `# pkg=ver` inside a
+            # comment should not be flagged.
+            code, _, _comment = line.partition("#")
+            offending.extend(
+                (idx + 1, match.group(0), line.rstrip()) for match in _APT_PIN_RE.finditer(code)
+            )
+            if not code.rstrip().endswith("\\"):
+                break
+            idx += 1
+    assert not offending, (
+        f"{_DOCKERFILE_PATH} has version-pinned apt packages, which contradicts "
+        f"the issue #362 resolution (option b — intentional floating under a "
+        f"digest-pinned base). Offending pins: {offending!r}. If you really do "
+        f"need to pin, remove the `@sha256:` digest from the base image first "
+        f"and justify the tradeoff in your PR."
+    )

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -67,6 +67,29 @@ FROM ${PYTHON_IMAGE}
 # tini is a tiny (~10 KB) binary; apt's Debian-stable package is kept to
 # just the binary via `--no-install-recommends`, respecting the
 # #139 / #192 image-size budget.
+#
+# reproducibility-boundary:digest-only (issue #362)
+# -------------------------------------------------
+# The apt packages below are INTENTIONALLY not pinned to `pkg=version`
+# tuples. The reproducibility boundary for this image is the
+# `@sha256:…` digest on the `python:3.13-slim` base declared at the top
+# of this file — the digest always resolves to the exact same Debian
+# suite snapshot, so the same `apt-get install` run inside the same
+# digest produces the same layers. Pinning apt on top of that would NOT
+# add reproducibility the digest doesn't already provide; it would only
+# block Debian security updates between base-image pin bumps.
+#
+# If a future contributor needs to pin a package with `=<version>`, the
+# correct sequence is:
+#   1. Remove the `@sha256:` digest from `ARG PYTHON_IMAGE` above
+#      (otherwise the pin adds no value — see paragraph above).
+#   2. Explain the tradeoff in the PR description.
+#   3. Update the `apps/backend/tests/unit/meta/`
+#      `test_dockerfile_apt_intentional_floating.py` guard rails to match
+#      the new policy.
+# Skipping any of those steps means the test below will fire. That is the
+# intended behavior — the marker string on the first line of this block
+# (`reproducibility-boundary:digest-only`) is the anchor the test greps.
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         tesseract-ocr \

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -71,25 +71,37 @@ FROM ${PYTHON_IMAGE}
 # reproducibility-boundary:digest-only (issue #362)
 # -------------------------------------------------
 # The apt packages below are INTENTIONALLY not pinned to `pkg=version`
-# tuples. The reproducibility boundary for this image is the
-# `@sha256:…` digest on the `python:3.13-slim` base declared at the top
-# of this file — the digest always resolves to the exact same Debian
-# suite snapshot, so the same `apt-get install` run inside the same
-# digest produces the same layers. Pinning apt on top of that would NOT
-# add reproducibility the digest doesn't already provide; it would only
-# block Debian security updates between base-image pin bumps.
+# tuples. That means rebuilds are expected to pick up newer Debian
+# package versions over time, by design, when `apt-get update` reads
+# from the default moving apt repositories. This is how the image
+# receives Debian security fixes between base-image pin bumps.
 #
-# If a future contributor needs to pin a package with `=<version>`, the
-# correct sequence is:
-#   1. Remove the `@sha256:` digest from `ARG PYTHON_IMAGE` above
-#      (otherwise the pin adds no value — see paragraph above).
-#   2. Explain the tradeoff in the PR description.
-#   3. Update the `apps/backend/tests/unit/meta/`
-#      `test_dockerfile_apt_intentional_floating.py` guard rails to match
-#      the new policy.
-# Skipping any of those steps means the test below will fire. That is the
-# intended behavior — the marker string on the first line of this block
-# (`reproducibility-boundary:digest-only`) is the anchor the test greps.
+# The `@sha256:…` digest on the `python:3.13-slim` base declared at the
+# top of this file pins the starting filesystem for both stages, but it
+# does NOT pin the apt repository snapshot consulted during
+# `apt-get update`. So an unchanged base-image digest does not
+# guarantee identical apt results or byte-for-byte identical layers
+# across rebuilds.
+#
+# Full reproducibility for these apt installs would require pointing
+# apt at a snapshot repository (for example `snapshot.debian.org` or
+# another dated mirror) and/or pinning exact package versions with
+# `=<version>`. We intentionally do not do that here because the
+# desired policy is to keep apt packages floating for security updates.
+#
+# If a future contributor needs to pin a package with `=<version>`
+# and/or switch to a snapshot apt repository, the correct sequence is:
+#   1. Explain the reproducibility/security tradeoff in the PR
+#      description (pins buy determinism at the cost of Debian
+#      security updates, and can become brittle as repositories rotate
+#      older builds).
+#   2. Update the `apps/backend/tests/unit/meta/`
+#      `test_dockerfile_apt_intentional_floating.py` guard rails to
+#      match the new policy.
+# Skipping any of those steps means the test below will fire. That is
+# the intended behavior — the marker string on the first line of this
+# block (`reproducibility-boundary:digest-only`) is the anchor the
+# test greps.
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         tesseract-ocr \

--- a/infra/docker/backend.Dockerfile
+++ b/infra/docker/backend.Dockerfile
@@ -85,11 +85,11 @@ FROM ${PYTHON_IMAGE}
 #
 # Full reproducibility for these apt installs would require pointing
 # apt at a snapshot repository (for example `snapshot.debian.org` or
-# another dated mirror) and/or pinning exact package versions with
-# `=<version>`. We intentionally do not do that here because the
+# another dated mirror) and/or pinning exact package versions as
+# `pkg=version`. We intentionally do not do that here because the
 # desired policy is to keep apt packages floating for security updates.
 #
-# If a future contributor needs to pin a package with `=<version>`
+# If a future contributor needs to pin a package as `pkg=version`
 # and/or switch to a snapshot apt repository, the correct sequence is:
 #   1. Explain the reproducibility/security tradeoff in the PR
 #      description (pins buy determinism at the cost of Debian


### PR DESCRIPTION
closes #362

## Summary

Resolving as the issue author's **option (b)**: keep apt packages floating, document the intent explicitly, enforce it with a meta-test.

**Rationale:** the base image is digest-pinned (`python:3.13-slim@sha256:d168b8d9…`), which IS the reproducibility boundary. Pinning apt packages on top of a digest-pinned base would block Debian security updates without adding reproducibility the digest doesn't already provide. The correct fix is to make the tradeoff explicit so no one reintroduces brittle pins.

## Changes

- `infra/docker/backend.Dockerfile` — added a guard comment above the runtime-stage apt-get install, with a stable marker (`# reproducibility-boundary:digest-only`) and a note on when pinning would become appropriate.
- `apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py` — meta-test asserting:
  - marker comment present near the apt-get install line
  - `FROM` line uses `@sha256:` digest pinning
  - no `apt-get install ... pkg=version` pins (enforces the intent)

## Test plan

- [ ] CI green on PR