### PR TITLE
chore(gitignore): add build/, dist/, .cache/ (closes #409)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ htmlcov/
 .mypy_cache/
 .hypothesis/
 .import_linter_cache/
+.cache/
+build/
+dist/
 
 # IDE
 .vscode/*


### PR DESCRIPTION
## Summary
- Adds `.cache/`, `build/`, `dist/` to the Python block of `.gitignore` alphabetically.
- The `.claude/worktrees/` entry that #409 also mentions is already present (line 41), so no change there.
- Does **not** add a blanket `.claude/` ignore: the repo tracks `.claude/skills/langextract-skill-author/SKILL.md` and an inline comment (lines 33–38, referencing #267) explains why only the `worktrees/` subtree is excluded. A blanket rule would leave tracked files "tracked but ignored."

## Test plan
- [x] `task check` passes in the worktree (lint, types, arch, skills, tests, error contracts).
- [x] Pre-commit hooks green on commit and push.

Closes #409