### PR TITLE
chore(governance): add CODEOWNERS (closes #411)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS for pdf-data-extraction
+#
+# GitHub matches the LAST matching pattern in this file per changed path, so
+# more specific patterns MUST sit below the global default. See
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Enforcement note: the `main-protection` ruleset currently has
+# `require_code_owner_review: false`, so this file is advisory today — it
+# populates the "Reviewers" panel on PRs but does not block merges on its
+# own. Flipping the rule to `true` is a deliberate, separate decision that
+# should be made explicitly in the ruleset, not as a side effect of this PR.
+
+# Default: everything in this repo is owned by cosmin.
+* @cosminneamtiu02
+
+# CI workflows — explicit for safety, since a broken workflow can
+# silently disable required status checks across every downstream PR.
+/.github/workflows/ @cosminneamtiu02
+
+# Error-contract source of truth — every Python/TS/JSON artifact under
+# packages/error-contracts/_generated/ is derived from this YAML, so
+# review ownership follows the source rather than the generated tree.
+/packages/error-contracts/errors.yaml @cosminneamtiu02
+
+# Discipline contract for AI-assisted development on this repo.
+/CLAUDE.md @cosminneamtiu02

--- a/apps/backend/tests/unit/meta/test_codeowners_exists.py
+++ b/apps/backend/tests/unit/meta/test_codeowners_exists.py
@@ -28,29 +28,52 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
 _CODEOWNERS_PATH = _REPO_ROOT / ".github" / "CODEOWNERS"
+_MISSING_FILE_MESSAGE = (
+    f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "
+    f"file so PRs mechanically surface the right reviewer in GitHub's "
+    f"Reviewers panel."
+)
 
 
 def _non_comment_lines(text: str) -> list[str]:
+    """Return stripped lines that are not full-line comments.
+
+    GitHub's CODEOWNERS syntax follows gitignore-style comment handling: a
+    line is a comment only when its first non-whitespace character is ``#``,
+    and a literal leading ``#`` can be escaped as ``\\#``. An inline ``#``
+    partway through a pattern or owner token is NOT a comment delimiter, so
+    we must not truncate at the first ``#`` on the line.
+    """
     lines: list[str] = []
     for raw in text.splitlines():
-        # Strip trailing comments and surrounding whitespace. CODEOWNERS
-        # comments are ``#`` to end-of-line; quoting is not supported, so a
-        # naive split is safe.
-        without_comment = raw.split("#", 1)[0].strip()
-        if without_comment:
-            lines.append(without_comment)
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        # Respect the ``\#`` escape by unescaping a single leading backslash
+        # so downstream token-parsing sees the literal ``#`` that the author
+        # intended as pattern content.
+        if stripped.startswith("\\#"):
+            stripped = stripped[1:]
+        lines.append(stripped)
     return lines
 
 
 def _is_global_cosmin_default(line: str) -> bool:
-    """True iff ``line`` is a CODEOWNERS ``*`` pattern whose first owner token
-    starts with ``@cosmin`` (case-insensitive).
+    """True iff ``line`` is a CODEOWNERS ``*`` pattern that assigns at least
+    one ``@cosmin…`` owner token (case-insensitive).
 
     CODEOWNERS lines are whitespace-separated: the first token is the file
     pattern, and the remaining tokens are owner handles. Parsing into tokens
     (rather than regex-matching a substring) rejects adversarial cases like
     ``* foo@cosmin.com`` where an email-shaped token would satisfy a naive
     substring match without being a real ``@cosmin…`` owner handle.
+
+    Matching against any owner token (not just the first one) is intentional:
+    CODEOWNERS permits multiple owners per line (``* @cosmin @teammate``), and
+    a ``@cosmin…`` handle in any owner position still satisfies the "cosmin
+    is the default reviewer" guardrail this file enforces.
     """
     tokens = line.split()
     if len(tokens) < 2:
@@ -65,25 +88,16 @@ def _require_codeowners_file() -> Path:
 
     Each read-based test calls this first so that a missing file surfaces the
     actionable assertion message from this helper rather than a bare
-    ``FileNotFoundError`` from ``read_text()``. The dedicated
-    ``test_codeowners_file_exists`` test still exists as the canonical
-    single-purpose assertion; this helper keeps the other tests robust if
-    they are run in isolation or reordered.
+    ``FileNotFoundError`` from ``read_text()``. ``test_codeowners_file_exists``
+    also delegates to this helper so the "file missing" message lives in
+    exactly one place and cannot drift.
     """
-    assert _CODEOWNERS_PATH.is_file(), (
-        f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "
-        f"file so PRs mechanically surface the right reviewer in GitHub's "
-        f"Reviewers panel."
-    )
+    assert _CODEOWNERS_PATH.is_file(), _MISSING_FILE_MESSAGE
     return _CODEOWNERS_PATH
 
 
 def test_codeowners_file_exists() -> None:
-    assert _CODEOWNERS_PATH.is_file(), (
-        f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "
-        f"file so PRs mechanically surface the right reviewer in GitHub's "
-        f"Reviewers panel."
-    )
+    _require_codeowners_file()
 
 
 def test_codeowners_has_non_comment_content() -> None:
@@ -105,6 +119,6 @@ def test_codeowners_has_cosmin_global_default() -> None:
     assert matches, (
         f"{_CODEOWNERS_PATH} is missing a ``* @cosmin…`` global default "
         f"line. CLAUDE.md pins cosminneamtiu02 as the PR author for this "
-        f"repo (2026-04-20 switch), so the default code owner must match. "
+        f"repo, so the default code owner must match. "
         f"Got non-comment lines: {meaningful!r}"
     )

--- a/apps/backend/tests/unit/meta/test_codeowners_exists.py
+++ b/apps/backend/tests/unit/meta/test_codeowners_exists.py
@@ -1,0 +1,79 @@
+"""Guardrail that .github/CODEOWNERS exists and declares a global default owner.
+
+CODEOWNERS is the mechanical routing signal GitHub uses to populate the
+"Reviewers" panel on PRs and — once `require_code_owner_review` is flipped on
+the `main-protection` ruleset — to block merges until a code owner has
+approved. Issue #411 tracks the absence of this file; this meta-test pins it
+so a future refactor cannot silently delete it.
+
+The assertions are intentionally narrow:
+
+- file exists at .github/CODEOWNERS (the only location GitHub reads that is
+  not the repo root or docs/; on this repo the .github/ form is canonical
+  because it co-locates with dependabot.yml and the workflows directory),
+- file is non-empty after stripping comments and whitespace,
+- at least one line is a global pattern ``* @<owner>`` that assigns a
+  ``@cosmin…``-style owner, matching the PR-authoring rule in CLAUDE.md
+  ("all human-authored pull requests on this repo are opened by
+  `cosminneamtiu02`").
+
+The global-pattern check deliberately accepts any ``@cosmin…`` prefix so that
+renaming the account (unlikely, but cheap to tolerate) does not require
+editing this test — only the CODEOWNERS file itself.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_CODEOWNERS_PATH = _REPO_ROOT / ".github" / "CODEOWNERS"
+
+# Matches a CODEOWNERS global-default line: the literal pattern ``*`` followed
+# by at least one owner handle starting with ``@cosmin``. Extra owners on the
+# same line (``* @cosmin @other``) are tolerated; comments after ``#`` are
+# stripped before matching.
+_GLOBAL_COSMIN_OWNER_RE = re.compile(r"^\*\s+.*@cosmin\S*", re.IGNORECASE)
+
+
+def _non_comment_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw in text.splitlines():
+        # Strip trailing comments and surrounding whitespace. CODEOWNERS
+        # comments are ``#`` to end-of-line; quoting is not supported, so a
+        # naive split is safe.
+        without_comment = raw.split("#", 1)[0].strip()
+        if without_comment:
+            lines.append(without_comment)
+    return lines
+
+
+def test_codeowners_file_exists() -> None:
+    assert _CODEOWNERS_PATH.is_file(), (
+        f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "
+        f"file so PRs mechanically surface the right reviewer in GitHub's "
+        f"Reviewers panel."
+    )
+
+
+def test_codeowners_has_non_comment_content() -> None:
+    text = _CODEOWNERS_PATH.read_text(encoding="utf-8")
+    meaningful = _non_comment_lines(text)
+    assert meaningful, (
+        f"{_CODEOWNERS_PATH} contains only comments/whitespace. A CODEOWNERS "
+        f"file with no pattern lines is a no-op and will not populate PR "
+        f"reviewers; add at least a ``* @<owner>`` global default."
+    )
+
+
+def test_codeowners_has_cosmin_global_default() -> None:
+    text = _CODEOWNERS_PATH.read_text(encoding="utf-8")
+    meaningful = _non_comment_lines(text)
+    matches = [line for line in meaningful if _GLOBAL_COSMIN_OWNER_RE.match(line)]
+    assert matches, (
+        f"{_CODEOWNERS_PATH} is missing a ``* @cosmin…`` global default "
+        f"line. CLAUDE.md pins cosminneamtiu02 as the PR author for this "
+        f"repo (2026-04-20 switch), so the default code owner must match. "
+        f"Got non-comment lines: {meaningful!r}"
+    )

--- a/apps/backend/tests/unit/meta/test_codeowners_exists.py
+++ b/apps/backend/tests/unit/meta/test_codeowners_exists.py
@@ -24,17 +24,10 @@ editing this test — only the CODEOWNERS file itself.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
 _CODEOWNERS_PATH = _REPO_ROOT / ".github" / "CODEOWNERS"
-
-# Matches a CODEOWNERS global-default line: the literal pattern ``*`` followed
-# by at least one owner handle starting with ``@cosmin``. Extra owners on the
-# same line (``* @cosmin @other``) are tolerated; comments after ``#`` are
-# stripped before matching.
-_GLOBAL_COSMIN_OWNER_RE = re.compile(r"^\*\s+.*@cosmin\S*", re.IGNORECASE)
 
 
 def _non_comment_lines(text: str) -> list[str]:
@@ -49,6 +42,42 @@ def _non_comment_lines(text: str) -> list[str]:
     return lines
 
 
+def _is_global_cosmin_default(line: str) -> bool:
+    """True iff ``line`` is a CODEOWNERS ``*`` pattern whose first owner token
+    starts with ``@cosmin`` (case-insensitive).
+
+    CODEOWNERS lines are whitespace-separated: the first token is the file
+    pattern, and the remaining tokens are owner handles. Parsing into tokens
+    (rather than regex-matching a substring) rejects adversarial cases like
+    ``* foo@cosmin.com`` where an email-shaped token would satisfy a naive
+    substring match without being a real ``@cosmin…`` owner handle.
+    """
+    tokens = line.split()
+    if len(tokens) < 2:
+        return False
+    if tokens[0] != "*":
+        return False
+    return any(token.lower().startswith("@cosmin") for token in tokens[1:])
+
+
+def _require_codeowners_file() -> Path:
+    """Assert the CODEOWNERS file exists, returning its path.
+
+    Each read-based test calls this first so that a missing file surfaces the
+    actionable assertion message from this helper rather than a bare
+    ``FileNotFoundError`` from ``read_text()``. The dedicated
+    ``test_codeowners_file_exists`` test still exists as the canonical
+    single-purpose assertion; this helper keeps the other tests robust if
+    they are run in isolation or reordered.
+    """
+    assert _CODEOWNERS_PATH.is_file(), (
+        f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "
+        f"file so PRs mechanically surface the right reviewer in GitHub's "
+        f"Reviewers panel."
+    )
+    return _CODEOWNERS_PATH
+
+
 def test_codeowners_file_exists() -> None:
     assert _CODEOWNERS_PATH.is_file(), (
         f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "
@@ -58,7 +87,8 @@ def test_codeowners_file_exists() -> None:
 
 
 def test_codeowners_has_non_comment_content() -> None:
-    text = _CODEOWNERS_PATH.read_text(encoding="utf-8")
+    path = _require_codeowners_file()
+    text = path.read_text(encoding="utf-8")
     meaningful = _non_comment_lines(text)
     assert meaningful, (
         f"{_CODEOWNERS_PATH} contains only comments/whitespace. A CODEOWNERS "
@@ -68,9 +98,10 @@ def test_codeowners_has_non_comment_content() -> None:
 
 
 def test_codeowners_has_cosmin_global_default() -> None:
-    text = _CODEOWNERS_PATH.read_text(encoding="utf-8")
+    path = _require_codeowners_file()
+    text = path.read_text(encoding="utf-8")
     meaningful = _non_comment_lines(text)
-    matches = [line for line in meaningful if _GLOBAL_COSMIN_OWNER_RE.match(line)]
+    matches = [line for line in meaningful if _is_global_cosmin_default(line)]
     assert matches, (
         f"{_CODEOWNERS_PATH} is missing a ``* @cosmin…`` global default "
         f"line. CLAUDE.md pins cosminneamtiu02 as the PR author for this "


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `* @cosminneamtiu02` as the global default plus explicit ownership on:
  - `/.github/workflows/` (CI safety)
  - `/packages/error-contracts/errors.yaml` (source of truth for generated error contracts)
  - `/CLAUDE.md` (discipline contract)
- Adds a meta-test at `apps/backend/tests/unit/meta/test_codeowners_exists.py` pinning: file exists, non-empty content, declares a `* @cosmin…` global default.
- **Does not** flip `require_code_owner_review` on the `main-protection` ruleset — still `false` today. That's a deliberate, separate decision.

## Test plan
- [x] `task check` passes end-to-end in the worktree.
- [x] Meta-test `test_codeowners_exists.py` → 3 passed.

Closes #411