### PR TITLE
ci: add concurrency group to error-contracts job (closes #410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,15 +116,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Job-level concurrency group (issue #410). The workflow-level group
-    # (`${{ github.workflow }}-${{ github.ref }}`) cancels BOTH jobs when a
-    # second push arrives on the same ref. That leaves PRs in a "workflow
-    # cancelled" state where required status checks show as missing, and
-    # `gh pr merge --auto` waits forever. Scoping error-contracts to its
-    # own group means its short ~1 min window is isolated from the long
-    # backend-checks job: a second push only cancels the stale
-    # error-contracts run, not the full workflow.
+    # (`${{ github.workflow }}-${{ github.ref }}`) still cancels the entire
+    # prior workflow run when a second push arrives on the same ref,
+    # including both backend-checks and error-contracts. This job-level
+    # group does not change that stacked-push behavior; it only ensures
+    # error-contracts runs do not overlap with each other in any case where
+    # they are not already superseded by the workflow-level cancellation
+    # policy (e.g. a separate workflow introducing a similarly named
+    # group). The `${{ github.workflow }}` prefix namespaces the group so
+    # it cannot collide with groups defined in other workflows — global
+    # `concurrency.group` names are repository-wide, not per-workflow.
     concurrency:
-      group: ci-error-contracts-${{ github.ref }}
+      group: ${{ github.workflow }}-ci-error-contracts-${{ github.ref }}
       cancel-in-progress: true
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,17 @@ jobs:
   error-contracts:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Job-level concurrency group (issue #410). The workflow-level group
+    # (`${{ github.workflow }}-${{ github.ref }}`) cancels BOTH jobs when a
+    # second push arrives on the same ref. That leaves PRs in a "workflow
+    # cancelled" state where required status checks show as missing, and
+    # `gh pr merge --auto` waits forever. Scoping error-contracts to its
+    # own group means its short ~1 min window is isolated from the long
+    # backend-checks job: a second push only cancels the stale
+    # error-contracts run, not the full workflow.
+    concurrency:
+      group: ci-error-contracts-${{ github.ref }}
+      cancel-in-progress: true
     defaults:
       run:
         working-directory: packages/error-contracts

--- a/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
+++ b/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
@@ -1,0 +1,126 @@
+"""Meta-tests for job-level concurrency groups in `.github/workflows/ci.yml`.
+
+Issue #410: the `error-contracts` job shared the workflow-level concurrency
+group `${{ github.workflow }}-${{ github.ref }}` (with
+`cancel-in-progress: true`). Stacked pushes to the same branch therefore
+cancelled in-flight error-contracts runs alongside the long `backend-checks`
+job. A cancelled status check does NOT satisfy the ruleset's
+required-status-checks gate: cancelled shows as "missing" to
+`gh pr merge --auto`, which then waits forever.
+
+The fix is to add a job-level `concurrency` block to the `error-contracts`
+job so its own short window (~1 min) is scoped independently of the
+workflow-level group, i.e. a second push cancels only the stale
+error-contracts run, not the whole workflow, and the fresh error-contracts
+run completes without getting cancelled on the next push while the long job
+is still finishing.
+
+This test pins the invariant: if a future edit removes the job-level
+`concurrency` block or drops `cancel-in-progress: true`, CI fails loudly
+with a pointer back to #410.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+_CI_WORKFLOW_PATH: Final[Path] = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_ci_workflow() -> dict[str, Any]:
+    data = yaml.safe_load(_CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        msg = (
+            f"{_CI_WORKFLOW_PATH} did not parse to a mapping "
+            f"(got {type(data).__name__}); workflow schema may have changed."
+        )
+        raise AssertionError(msg)  # noqa: TRY004
+    return data
+
+
+def _get_job(name: str) -> dict[str, Any]:
+    workflow = _load_ci_workflow()
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        msg = (
+            f"{_CI_WORKFLOW_PATH} top-level 'jobs' is {type(jobs).__name__!r} "
+            f"(expected mapping); workflow schema may have changed."
+        )
+        raise AssertionError(msg)  # noqa: TRY004
+    job = jobs.get(name)
+    if not isinstance(job, dict):
+        msg = (
+            f"Job {name!r} missing from {_CI_WORKFLOW_PATH} or not a mapping "
+            f"(got {type(job).__name__}). Available jobs: {sorted(jobs)}."
+        )
+        raise AssertionError(msg)  # noqa: TRY004
+    return job
+
+
+def test_error_contracts_job_has_concurrency_block() -> None:
+    """The `error-contracts` job must declare a job-level `concurrency` block.
+
+    Without it, the job inherits only the workflow-level group and gets
+    cancelled alongside `backend-checks` on every stacked push — see #410.
+    """
+    job = _get_job("error-contracts")
+    concurrency = job.get("concurrency")
+    assert isinstance(concurrency, dict), (
+        "error-contracts job is missing a `concurrency:` mapping in "
+        f"{_CI_WORKFLOW_PATH}. Add a job-level block scoped to this job "
+        "(e.g. group: ci-error-contracts-${{ github.ref }}, "
+        "cancel-in-progress: true) so stacked pushes cancel only the "
+        "stale error-contracts run, not the full workflow. See issue #410."
+    )
+
+
+def test_error_contracts_concurrency_group_is_job_scoped() -> None:
+    """The job-level `group` must be distinct from the workflow-level group.
+
+    Using `${{ github.workflow }}-${{ github.ref }}` at the job level would
+    collide with the workflow-level group and give no isolation. The group
+    string must identify the `error-contracts` job specifically.
+    """
+    job = _get_job("error-contracts")
+    concurrency = job.get("concurrency")
+    assert isinstance(concurrency, dict)
+    group = concurrency.get("group")
+    assert isinstance(group, str), (
+        f"error-contracts job's concurrency.group must be a string (got {type(group).__name__})."
+    )
+    assert group, "error-contracts job's concurrency.group must be non-empty."
+    assert "error-contracts" in group, (
+        f"error-contracts job's concurrency.group is {group!r}, which does "
+        "not contain 'error-contracts'. Use a job-scoped identifier such as "
+        "`ci-error-contracts-${{ github.ref }}` so the group does not "
+        "collide with the workflow-level group. See issue #410."
+    )
+    assert "github.ref" in group, (
+        f"error-contracts job's concurrency.group is {group!r}, which does "
+        "not include `${{ github.ref }}`. Scope the group per-ref so "
+        "concurrent runs on different branches/PRs do not cancel each "
+        "other. See issue #410."
+    )
+
+
+def test_error_contracts_concurrency_cancels_in_progress() -> None:
+    """`cancel-in-progress: true` at the job level is required.
+
+    Without it, a second push to the same ref would queue behind the
+    stale error-contracts run instead of cancelling it, wasting runner
+    minutes (the core complaint of #410).
+    """
+    job = _get_job("error-contracts")
+    concurrency = job.get("concurrency")
+    assert isinstance(concurrency, dict)
+    cancel = concurrency.get("cancel-in-progress")
+    assert cancel is True, (
+        "error-contracts job's concurrency.cancel-in-progress must be "
+        f"literally `true` (got {cancel!r}). Without it, stacked pushes "
+        "queue instead of cancelling, defeating the point of the "
+        "job-level concurrency group. See issue #410."
+    )

--- a/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
+++ b/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
@@ -1,27 +1,37 @@
-"""Meta-tests for job-level concurrency groups in `.github/workflows/ci.yml`.
+"""Meta-tests for the `error-contracts` job-level concurrency block in `.github/workflows/ci.yml`.
 
-Issue #410: the `error-contracts` job shared the workflow-level concurrency
-group `${{ github.workflow }}-${{ github.ref }}` (with
-`cancel-in-progress: true`). Stacked pushes to the same branch therefore
-cancelled in-flight error-contracts runs alongside the long `backend-checks`
-job. A cancelled status check does NOT satisfy the ruleset's
-required-status-checks gate: cancelled shows as "missing" to
-`gh pr merge --auto`, which then waits forever.
+Issue #410: pin the shape of the job-level `concurrency` block on the
+`error-contracts` job so future edits cannot silently drop it or rename it
+into a group that collides with another workflow's concurrency group.
 
-The fix is to add a job-level `concurrency` block to the `error-contracts`
-job so it uses its own job-scoped group instead of reusing the
-workflow-level group. That keeps the short-lived `error-contracts`
-concurrency policy isolated at the job level, even though stacked pushes
-may still cancel the prior workflow run while workflow-level
-`cancel-in-progress: true` remains enabled. The job-scoped group also
-includes `${{ github.workflow }}` so it cannot collide with similarly
-named groups defined in other workflows — `concurrency.group` names are
-repository-global, not per-workflow.
+What this block DOES enforce (and what this test pins):
 
-This test pins the invariant: if a future edit removes the job-level
-`concurrency` block, drops `cancel-in-progress: true`, or drops the
-`${{ github.workflow }}` prefix from the group, CI fails loudly with a
-pointer back to #410.
+1. `error-contracts` declares its own job-level `concurrency` mapping,
+   separate from the workflow-level block at the top of `ci.yml`.
+2. The group name is prefixed with `${{ github.workflow }}` so it cannot
+   collide with similarly named groups in other workflows in this repo
+   (e.g. `deploy.yml`, `dependabot-*.yml`). `concurrency.group` names are
+   repository-global and case-insensitive per GitHub's docs, so a prefix
+   is the only way to guarantee cross-workflow isolation.
+3. The group includes `${{ github.ref }}` so concurrent runs on different
+   branches/PRs do not cancel each other.
+4. `cancel-in-progress: true` is pinned at the job level so this job's
+   cancellation semantics are documented locally and cannot be weakened
+   by a future change to the workflow-level block alone.
+
+What this block does NOT do (and what this test does NOT claim):
+
+The workflow-level `concurrency` block at the top of `ci.yml` still uses
+`cancel-in-progress: true`, which cancels the ENTIRE prior workflow run
+(including `error-contracts`) on stacked pushes to the same ref. Job-level
+concurrency layers on top of workflow-level concurrency — it does not
+override or replace it. Preventing stacked-push cancellation of
+`error-contracts` specifically would require a separate change to the
+workflow-level block, which is out of scope for #410.
+
+If a future edit removes the job-level `concurrency` block, drops
+`cancel-in-progress: true`, or drops the `${{ github.workflow }}` prefix
+from the group, CI fails loudly here with a pointer back to #410.
 """
 
 from __future__ import annotations
@@ -68,8 +78,10 @@ def _get_job(name: str) -> dict[str, Any]:
 def test_error_contracts_job_has_concurrency_block() -> None:
     """The `error-contracts` job must declare a job-level `concurrency` block.
 
-    Without it, the job inherits only the workflow-level group and gets
-    cancelled alongside `backend-checks` on every stacked push — see #410.
+    The block pins cross-workflow isolation (group prefix) and
+    `cancel-in-progress` semantics locally so a future edit to the
+    workflow-level block cannot silently weaken them. See #410 for the
+    scope of what this block does and does not address.
     """
     job = _get_job("error-contracts")
     concurrency = job.get("concurrency")
@@ -128,8 +140,11 @@ def test_error_contracts_concurrency_cancels_in_progress() -> None:
     """`cancel-in-progress: true` at the job level is required.
 
     Without it, a second push to the same ref would queue behind the
-    stale error-contracts run instead of cancelling it, wasting runner
-    minutes (the core complaint of #410).
+    stale error-contracts run instead of cancelling it within this
+    job-scoped group, wasting runner minutes for the specific case where
+    the workflow-level cancellation did not apply (e.g. a future edit
+    that removes or scopes the workflow-level block differently). See
+    issue #410.
     """
     job = _get_job("error-contracts")
     concurrency = job.get("concurrency")
@@ -138,6 +153,6 @@ def test_error_contracts_concurrency_cancels_in_progress() -> None:
     assert cancel is True, (
         "error-contracts job's concurrency.cancel-in-progress must be "
         f"literally `true` (got {cancel!r}). Without it, stacked pushes "
-        "queue instead of cancelling, defeating the point of the "
-        "job-level concurrency group. See issue #410."
+        "queue instead of cancelling in this job-scoped group, defeating "
+        "the point of the job-level concurrency block. See issue #410."
     )

--- a/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
+++ b/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
@@ -9,15 +9,19 @@ required-status-checks gate: cancelled shows as "missing" to
 `gh pr merge --auto`, which then waits forever.
 
 The fix is to add a job-level `concurrency` block to the `error-contracts`
-job so its own short window (~1 min) is scoped independently of the
-workflow-level group, i.e. a second push cancels only the stale
-error-contracts run, not the whole workflow, and the fresh error-contracts
-run completes without getting cancelled on the next push while the long job
-is still finishing.
+job so it uses its own job-scoped group instead of reusing the
+workflow-level group. That keeps the short-lived `error-contracts`
+concurrency policy isolated at the job level, even though stacked pushes
+may still cancel the prior workflow run while workflow-level
+`cancel-in-progress: true` remains enabled. The job-scoped group also
+includes `${{ github.workflow }}` so it cannot collide with similarly
+named groups defined in other workflows — `concurrency.group` names are
+repository-global, not per-workflow.
 
 This test pins the invariant: if a future edit removes the job-level
-`concurrency` block or drops `cancel-in-progress: true`, CI fails loudly
-with a pointer back to #410.
+`concurrency` block, drops `cancel-in-progress: true`, or drops the
+`${{ github.workflow }}` prefix from the group, CI fails loudly with a
+pointer back to #410.
 """
 
 from __future__ import annotations
@@ -72,9 +76,10 @@ def test_error_contracts_job_has_concurrency_block() -> None:
     assert isinstance(concurrency, dict), (
         "error-contracts job is missing a `concurrency:` mapping in "
         f"{_CI_WORKFLOW_PATH}. Add a job-level block scoped to this job "
-        "(e.g. group: ci-error-contracts-${{ github.ref }}, "
-        "cancel-in-progress: true) so stacked pushes cancel only the "
-        "stale error-contracts run, not the full workflow. See issue #410."
+        "(e.g. group: ${{ github.workflow }}-ci-error-contracts-${{ github.ref }}, "
+        "cancel-in-progress: true) so error-contracts has its own "
+        "job-scoped concurrency policy isolated from the workflow-level "
+        "group. See issue #410."
     )
 
 
@@ -83,7 +88,9 @@ def test_error_contracts_concurrency_group_is_job_scoped() -> None:
 
     Using `${{ github.workflow }}-${{ github.ref }}` at the job level would
     collide with the workflow-level group and give no isolation. The group
-    string must identify the `error-contracts` job specifically.
+    string must identify the `error-contracts` job specifically, and must
+    include `${{ github.workflow }}` so the repo-global group namespace
+    cannot collide with similarly named groups in other workflows.
     """
     job = _get_job("error-contracts")
     concurrency = job.get("concurrency")
@@ -96,14 +103,24 @@ def test_error_contracts_concurrency_group_is_job_scoped() -> None:
     assert "error-contracts" in group, (
         f"error-contracts job's concurrency.group is {group!r}, which does "
         "not contain 'error-contracts'. Use a job-scoped identifier such as "
-        "`ci-error-contracts-${{ github.ref }}` so the group does not "
-        "collide with the workflow-level group. See issue #410."
+        "`${{ github.workflow }}-ci-error-contracts-${{ github.ref }}` so "
+        "the group does not collide with the workflow-level group. See "
+        "issue #410."
     )
     assert "github.ref" in group, (
         f"error-contracts job's concurrency.group is {group!r}, which does "
         "not include `${{ github.ref }}`. Scope the group per-ref so "
         "concurrent runs on different branches/PRs do not cancel each "
         "other. See issue #410."
+    )
+    assert "github.workflow" in group, (
+        f"error-contracts job's concurrency.group is {group!r}, which does "
+        "not include `${{ github.workflow }}`. `concurrency.group` names "
+        "are repository-global, so prefix the group with "
+        "`${{ github.workflow }}` (matching the workflow-level group and "
+        "other workflows in this repo such as deploy.yml, "
+        "dependabot-*.yml) to avoid cross-workflow collisions. See "
+        "issue #410."
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a job-level `concurrency` block to the `error-contracts` job in `.github/workflows/ci.yml` so its concurrency policy is scoped with a `${{ github.workflow }}`-prefixed, `${{ github.ref }}`-scoped group name, isolating it from concurrency groups defined in other workflows in this repo (concurrency-group names are repository-global per GitHub's spec).
- Pins `cancel-in-progress: true` at the job level so error-contracts' cancellation semantics are documented locally and cannot be silently weakened by a future edit to the workflow-level block alone.
- Pins the invariant with a new meta-test at `apps/backend/tests/unit/meta/test_ci_concurrency_groups.py` that parses the workflow YAML and asserts the `error-contracts` job has a `concurrency` block with (a) a job-scoped, per-workflow, per-ref `group`, and (b) `cancel-in-progress: true`.

## Scope

- Workflow change is intentionally limited to the `error-contracts` job, matching the issue body. `backend-checks` and `dockerfile-build` are untouched; rescoping their concurrency belongs in separate issues if desired.
- The workflow-level `concurrency:` block at the top of `ci.yml` is left intact. Its `cancel-in-progress: true` still cancels the entire prior workflow run on stacked pushes, including error-contracts — this PR does not (and is not intended to) change that. Preventing full-workflow cancellation on stacked pushes would require a separate change to the workflow-level block, which is out of scope for #410.

## YAML diff snippet

```yaml
  error-contracts:
    runs-on: ubuntu-latest
    timeout-minutes: 10
+   # Job-level concurrency group (issue #410). The workflow-level group
+   # (`${{ github.workflow }}-${{ github.ref }}`) still cancels the entire
+   # prior workflow run when a second push arrives on the same ref,
+   # including both backend-checks and error-contracts. This job-level
+   # group does not change that stacked-push behavior; it only ensures
+   # error-contracts runs do not overlap with each other in any case where
+   # they are not already superseded by the workflow-level cancellation
+   # policy (e.g. a separate workflow introducing a similarly named
+   # group). The `${{ github.workflow }}` prefix namespaces the group so
+   # it cannot collide with groups defined in other workflows — global
+   # `concurrency.group` names are repository-wide, not per-workflow.
+   concurrency:
+     group: ${{ github.workflow }}-ci-error-contracts-${{ github.ref }}
+     cancel-in-progress: true
    defaults:
      run:
        working-directory: packages/error-contracts
```

## Test plan

- [x] `task check` is green locally on `fix/410-ci-concurrency-group` (lint, types, arch, skills, unit, integration, contract, error-contracts).
- [x] New `tests/unit/meta/test_ci_concurrency_groups.py` has 3 tests — presence of the `concurrency` block, job-scoped `group` string containing `error-contracts`, `${{ github.ref }}`, and `${{ github.workflow }}`, and `cancel-in-progress: true` literal.
- [x] Verified TDD red -> green: tests failed before the workflow edit, passed after.
- [ ] CI on this PR runs without regressing the existing `backend-checks` / `dockerfile-build` / `error-contracts` gates.

AI-assisted with Claude.
