### PR TITLE
fix(extraction): distinguish CancelledError from TimeoutError in logs (closes #416)

### DIFF
--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -273,8 +273,9 @@ class ExtractionService:
             # ``extraction_timeout`` event in the ``TimeoutError`` branch
             # below) gives operators a greppable breadcrumb to tell the
             # two apart in triage dashboards. We MUST re-raise —
-            # ``CancelledError`` is a ``BaseException`` on Python 3.8+ and
-            # swallowing it breaks cooperative task cancellation.
+            # ``CancelledError`` is a ``BaseException`` in supported
+            # runtimes, and swallowing it breaks cooperative task
+            # cancellation.
             elapsed_ms = int((time.monotonic() - t0) * 1000)
             _logger.info(
                 "extraction_cancelled",

--- a/apps/backend/app/features/extraction/service.py
+++ b/apps/backend/app/features/extraction/service.py
@@ -38,6 +38,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING
 
+import structlog
+
 from app.exceptions import (
     ExtractionBudgetExceededError,
     ExtractionOverloadedError,
@@ -62,6 +64,9 @@ if TYPE_CHECKING:
     )
     from app.features.extraction.parsing.document_parser import DocumentParser
     from app.features.extraction.skills.skill_manifest import SkillManifest
+
+
+_logger = structlog.get_logger(__name__)
 
 
 class ExtractionService:
@@ -257,6 +262,27 @@ class ExtractionService:
                     response=response,
                     annotated_pdf_bytes=annotated_pdf,
                 )
+        except asyncio.CancelledError:
+            # Issue #416: caller-driven cancellation (task cancel, client
+            # disconnect) must be distinguishable from budget expiry in
+            # structured logs. ``asyncio.timeout`` converts its own internal
+            # ``CancelledError`` to ``TimeoutError`` at the context-manager
+            # boundary when the deadline fired, so any ``CancelledError``
+            # reaching here is an outer cancellation — not a budget timeout.
+            # Logging ``extraction_cancelled`` (separate from the
+            # ``extraction_timeout`` event in the ``TimeoutError`` branch
+            # below) gives operators a greppable breadcrumb to tell the
+            # two apart in triage dashboards. We MUST re-raise —
+            # ``CancelledError`` is a ``BaseException`` on Python 3.8+ and
+            # swallowing it breaks cooperative task cancellation.
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            _logger.info(
+                "extraction_cancelled",
+                skill_name=skill_name,
+                skill_version=skill_version,
+                duration_ms=elapsed_ms,
+            )
+            raise
         except TimeoutError:
             # Only remap when *this* timeout context caused the raise.
             # Unrelated inner TimeoutErrors (e.g. a parser/annotator/library's
@@ -277,6 +303,20 @@ class ExtractionService:
             # HTTP 504) with the pipeline budget attached.
             if not budget_cm.expired():
                 raise
+            # Issue #416: emit a distinct ``extraction_timeout`` event so
+            # operators can tell a pipeline-budget timeout apart from a
+            # caller-cancellation (``extraction_cancelled`` above) in
+            # structured logs. The event carries the configured budget and
+            # elapsed duration so triage can tell at a glance how long the
+            # pipeline ran before hitting the cap.
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            _logger.info(
+                "extraction_timeout",
+                skill_name=skill_name,
+                skill_version=skill_version,
+                budget_seconds=self._timeout_seconds,
+                duration_ms=elapsed_ms,
+            )
             raise ExtractionBudgetExceededError(
                 budget_seconds=self._timeout_seconds,
             ) from None

--- a/apps/backend/tests/unit/features/extraction/test_extraction_service.py
+++ b/apps/backend/tests/unit/features/extraction/test_extraction_service.py
@@ -12,7 +12,6 @@ import time
 from typing import Any
 
 import pytest
-import structlog.testing
 
 from app.core.config import Settings
 from app.exceptions import (
@@ -23,6 +22,7 @@ from app.exceptions import (
     SkillNotFoundError,
     StructuredOutputFailedError,
 )
+from app.features.extraction import service as service_module
 from app.features.extraction.coordinates.offset_index import OffsetIndex
 from app.features.extraction.coordinates.offset_index_entry import OffsetIndexEntry
 from app.features.extraction.extraction.raw_extraction import RawExtraction
@@ -1074,6 +1074,34 @@ async def test_ollama_internal_timeout_is_not_remapped_to_extraction_budget_erro
 # ---------------------------------------------------------------------------
 
 
+class _SpyLogger:
+    """Test double for ``service_module._logger`` (Copilot-review #439).
+
+    Why we don't use ``structlog.testing.capture_logs()`` here: the service
+    module defines ``_logger = structlog.get_logger(__name__)`` at import
+    time, and our ``configure_logging()`` registers
+    ``cache_logger_on_first_use=True``. Whichever test first touches the
+    service's ``_logger`` outside a ``capture_logs()`` context can cause
+    structlog to cache a bound logger that subsequent ``capture_logs()``
+    contexts won't see — making log-assertion tests order-dependent. A
+    direct monkeypatched spy sidesteps structlog's global state entirely,
+    the same pattern used in
+    ``tests/unit/features/extraction/skills/test_skill_loader.py``.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+    def warning(self, event: str, **kwargs: object) -> None:  # pragma: no cover
+        self.events.append((event, kwargs))
+
+    def error(self, event: str, **kwargs: object) -> None:  # pragma: no cover
+        self.events.append((event, kwargs))
+
+
 class _CancellingEngine:
     """Engine that raises ``asyncio.CancelledError`` mid-extraction.
 
@@ -1093,7 +1121,9 @@ class _CancellingEngine:
         raise asyncio.CancelledError
 
 
-async def test_cancelled_error_emits_extraction_cancelled_event_and_reraises() -> None:
+async def test_cancelled_error_emits_extraction_cancelled_event_and_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Issue #416: CancelledError path logs ``extraction_cancelled`` and re-raises.
 
     The extraction service must never swallow ``asyncio.CancelledError`` —
@@ -1102,17 +1132,16 @@ async def test_cancelled_error_emits_extraction_cancelled_event_and_reraises() -
     distinct event so operators can tell a caller-cancellation breadcrumb
     apart from a pipeline-budget timeout in structured logs.
     """
+    spy = _SpyLogger()
+    monkeypatch.setattr(service_module, "_logger", spy)
     service = _build_service(engine=_CancellingEngine())
 
-    with (
-        structlog.testing.capture_logs() as captured,
-        pytest.raises(asyncio.CancelledError),
-    ):
+    with pytest.raises(asyncio.CancelledError):
         await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
 
-    cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
+    cancelled_events = [kwargs for event, kwargs in spy.events if event == "extraction_cancelled"]
     assert len(cancelled_events) == 1, (
-        f"Expected exactly one extraction_cancelled event; got {captured!r}"
+        f"Expected exactly one extraction_cancelled event; got {spy.events!r}"
     )
     # Pin the structured context fields the PR relies on for operability.
     # These keys drive on-call triage dashboards; silent renames/drops
@@ -1122,11 +1151,13 @@ async def test_cancelled_error_emits_extraction_cancelled_event_and_reraises() -
     assert cancelled_event["skill_version"] == "1"
     assert isinstance(cancelled_event["duration_ms"], int)
     # Must NOT masquerade as the timeout event.
-    timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
+    timeout_events = [kwargs for event, kwargs in spy.events if event == "extraction_timeout"]
     assert timeout_events == []
 
 
-async def test_timeout_emits_extraction_timeout_event_with_budget_seconds() -> None:
+async def test_timeout_emits_extraction_timeout_event_with_budget_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Issue #416: pipeline-budget timeout logs ``extraction_timeout`` with context.
 
     A ``extraction_timeout`` event must be emitted alongside the
@@ -1135,19 +1166,18 @@ async def test_timeout_emits_extraction_timeout_event_with_budget_seconds() -> N
     The event carries the configured budget so triage can tell at a glance
     how long the pipeline ran before hitting the cap.
     """
+    spy = _SpyLogger()
+    monkeypatch.setattr(service_module, "_logger", spy)
     engine = _FakeEngine(sleep_seconds=0.2)
     settings = _build_settings(extraction_timeout_seconds=0.05)
     service = _build_service(engine=engine, settings=settings)
 
-    with (
-        structlog.testing.capture_logs() as captured,
-        pytest.raises(ExtractionBudgetExceededError),
-    ):
+    with pytest.raises(ExtractionBudgetExceededError):
         await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
 
-    timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
+    timeout_events = [kwargs for event, kwargs in spy.events if event == "extraction_timeout"]
     assert len(timeout_events) == 1, (
-        f"Expected exactly one extraction_timeout event; got {captured!r}"
+        f"Expected exactly one extraction_timeout event; got {spy.events!r}"
     )
     # Pin the structured context fields the PR relies on for operability.
     # These keys drive on-call triage dashboards; silent renames/drops
@@ -1158,11 +1188,13 @@ async def test_timeout_emits_extraction_timeout_event_with_budget_seconds() -> N
     assert timeout_event["budget_seconds"] == 0.05
     assert isinstance(timeout_event["duration_ms"], int)
     # Must NOT masquerade as the cancellation event.
-    cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
+    cancelled_events = [kwargs for event, kwargs in spy.events if event == "extraction_cancelled"]
     assert cancelled_events == []
 
 
-async def test_inner_timeout_error_does_not_emit_extraction_timeout_event() -> None:
+async def test_inner_timeout_error_does_not_emit_extraction_timeout_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Issue #416: the ``extraction_timeout`` event fires only for budget expiry.
 
     A downstream component may raise a built-in ``TimeoutError`` for reasons
@@ -1173,13 +1205,15 @@ async def test_inner_timeout_error_does_not_emit_extraction_timeout_event() -> N
     fire either. Keeping the two concerns paired avoids a misleading
     "budget exceeded" log line when the real failing component is elsewhere.
     """
+    spy = _SpyLogger()
+    monkeypatch.setattr(service_module, "_logger", spy)
     settings = _build_settings(extraction_timeout_seconds=60.0)
     service = _build_service(parser=_InnerTimeoutParser(), settings=settings)
 
-    with structlog.testing.capture_logs() as captured, pytest.raises(TimeoutError):
+    with pytest.raises(TimeoutError):
         await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
 
-    timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
+    timeout_events = [kwargs for event, kwargs in spy.events if event == "extraction_timeout"]
     assert timeout_events == []
-    cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
+    cancelled_events = [kwargs for event, kwargs in spy.events if event == "extraction_cancelled"]
     assert cancelled_events == []

--- a/apps/backend/tests/unit/features/extraction/test_extraction_service.py
+++ b/apps/backend/tests/unit/features/extraction/test_extraction_service.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 
 import pytest
+import structlog.testing
 
 from app.core.config import Settings
 from app.exceptions import (
@@ -1055,3 +1056,116 @@ async def test_ollama_internal_timeout_is_not_remapped_to_extraction_budget_erro
     assert not isinstance(excinfo.value, ExtractionBudgetExceededError)
     assert excinfo.value.params is not None
     assert excinfo.value.params.model_dump() == {"budget_seconds": 30.0}
+
+
+# ---------------------------------------------------------------------------
+# Issue #416: cancellation vs. timeout log distinguishability.
+#
+# ``asyncio.timeout`` cancels cooperative awaits by injecting
+# ``asyncio.CancelledError`` and then converting it to ``TimeoutError`` at
+# the context-manager boundary when the deadline has expired. But if an
+# OUTER cancellation (caller cancelled the task, client disconnected) fires
+# inside the pipeline, the same ``CancelledError`` can propagate past the
+# ``except TimeoutError`` branch unlabelled — operators triaging a 5xx spike
+# have no way to tell "caller cancelled" from "we ran out of budget" from
+# the structured logs. These tests pin two distinct, greppable events:
+# ``extraction_cancelled`` for caller cancellation, ``extraction_timeout``
+# for pipeline-budget expiry.
+# ---------------------------------------------------------------------------
+
+
+class _CancellingEngine:
+    """Engine that raises ``asyncio.CancelledError`` mid-extraction.
+
+    Models the shape of a caller-driven cancellation (task cancel, client
+    disconnect) observed from inside the pipeline after the semaphore is
+    acquired but before the work completes. The service's ``CancelledError``
+    branch must fire unconditionally on this path — whether or not the
+    outer ``asyncio.timeout`` has anything to do with it.
+    """
+
+    async def extract(
+        self,
+        _text: str,
+        _skill: Any,
+        _provider: Any,
+    ) -> list[RawExtraction]:
+        raise asyncio.CancelledError
+
+
+async def test_cancelled_error_emits_extraction_cancelled_event_and_reraises() -> None:
+    """Issue #416: CancelledError path logs ``extraction_cancelled`` and re-raises.
+
+    The extraction service must never swallow ``asyncio.CancelledError`` —
+    cooperative cancellation relies on it propagating out so the caller's
+    task can terminate cleanly. The fix is observability-only: we log a
+    distinct event so operators can tell a caller-cancellation breadcrumb
+    apart from a pipeline-budget timeout in structured logs.
+    """
+    service = _build_service(engine=_CancellingEngine())
+
+    with (
+        structlog.testing.capture_logs() as captured,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
+    assert len(cancelled_events) == 1, (
+        f"Expected exactly one extraction_cancelled event; got {captured!r}"
+    )
+    # Must NOT masquerade as the timeout event.
+    timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
+    assert timeout_events == []
+
+
+async def test_timeout_emits_extraction_timeout_event_with_budget_seconds() -> None:
+    """Issue #416: pipeline-budget timeout logs ``extraction_timeout`` with context.
+
+    A ``extraction_timeout`` event must be emitted alongside the
+    ``ExtractionBudgetExceededError`` raise so operators can distinguish
+    a pipeline-budget timeout from a caller-cancellation in structured logs.
+    The event carries the configured budget so triage can tell at a glance
+    how long the pipeline ran before hitting the cap.
+    """
+    engine = _FakeEngine(sleep_seconds=0.2)
+    settings = _build_settings(extraction_timeout_seconds=0.05)
+    service = _build_service(engine=engine, settings=settings)
+
+    with (
+        structlog.testing.capture_logs() as captured,
+        pytest.raises(ExtractionBudgetExceededError),
+    ):
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
+    assert len(timeout_events) == 1, (
+        f"Expected exactly one extraction_timeout event; got {captured!r}"
+    )
+    assert timeout_events[0]["budget_seconds"] == 0.05
+    # Must NOT masquerade as the cancellation event.
+    cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
+    assert cancelled_events == []
+
+
+async def test_inner_timeout_error_does_not_emit_extraction_timeout_event() -> None:
+    """Issue #416: the ``extraction_timeout`` event fires only for budget expiry.
+
+    A downstream component may raise a built-in ``TimeoutError`` for reasons
+    unrelated to the pipeline budget (e.g. a socket-layer timeout inside
+    Docling). That case re-raises the inner error as-is — without remapping
+    to ``ExtractionBudgetExceededError`` — so the ``extraction_timeout``
+    event, which is specifically the pipeline-budget breadcrumb, must not
+    fire either. Keeping the two concerns paired avoids a misleading
+    "budget exceeded" log line when the real failing component is elsewhere.
+    """
+    settings = _build_settings(extraction_timeout_seconds=60.0)
+    service = _build_service(parser=_InnerTimeoutParser(), settings=settings)
+
+    with structlog.testing.capture_logs() as captured, pytest.raises(TimeoutError):
+        await service.extract(_PDF_BYTES, "invoice", "1", OutputMode.JSON_ONLY)
+
+    timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
+    assert timeout_events == []
+    cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
+    assert cancelled_events == []

--- a/apps/backend/tests/unit/features/extraction/test_extraction_service.py
+++ b/apps/backend/tests/unit/features/extraction/test_extraction_service.py
@@ -1114,6 +1114,13 @@ async def test_cancelled_error_emits_extraction_cancelled_event_and_reraises() -
     assert len(cancelled_events) == 1, (
         f"Expected exactly one extraction_cancelled event; got {captured!r}"
     )
+    # Pin the structured context fields the PR relies on for operability.
+    # These keys drive on-call triage dashboards; silent renames/drops
+    # would degrade the fix without failing any other test (#439 review).
+    cancelled_event = cancelled_events[0]
+    assert cancelled_event["skill_name"] == "invoice"
+    assert cancelled_event["skill_version"] == "1"
+    assert isinstance(cancelled_event["duration_ms"], int)
     # Must NOT masquerade as the timeout event.
     timeout_events = [e for e in captured if e["event"] == "extraction_timeout"]
     assert timeout_events == []
@@ -1142,7 +1149,14 @@ async def test_timeout_emits_extraction_timeout_event_with_budget_seconds() -> N
     assert len(timeout_events) == 1, (
         f"Expected exactly one extraction_timeout event; got {captured!r}"
     )
-    assert timeout_events[0]["budget_seconds"] == 0.05
+    # Pin the structured context fields the PR relies on for operability.
+    # These keys drive on-call triage dashboards; silent renames/drops
+    # would degrade the fix without failing any other test (#439 review).
+    timeout_event = timeout_events[0]
+    assert timeout_event["skill_name"] == "invoice"
+    assert timeout_event["skill_version"] == "1"
+    assert timeout_event["budget_seconds"] == 0.05
+    assert isinstance(timeout_event["duration_ms"], int)
     # Must NOT masquerade as the cancellation event.
     cancelled_events = [e for e in captured if e["event"] == "extraction_cancelled"]
     assert cancelled_events == []


### PR DESCRIPTION
## Summary
- Adds a dedicated `except asyncio.CancelledError` branch in `ExtractionService._run_pipeline` (FIRST, before `TimeoutError`). Logs a distinct `extraction_cancelled` structlog event with `skill_name`, `skill_version`, and `duration_ms`, then re-raises unchanged so cooperative task cancellation continues to work.
- The existing `TimeoutError` branch now logs `extraction_timeout` with `budget_seconds` and `duration_ms` alongside the `ExtractionBudgetExceededError` raise, so operators can tell a pipeline-budget timeout apart from caller-cancellation (or a disconnected client) in structured logs.
- Inner `TimeoutError` from downstream components (already re-raised as-is without remapping to the pipeline-budget error) does NOT emit `extraction_timeout`, keeping the breadcrumb paired with actual budget-expiry.

Closes #416.

## Test plan
- [x] TDD red step: three new unit tests added in `tests/unit/features/extraction/test_extraction_service.py`, each failed before the fix. Tests assert log events via a monkey-patched `_SpyLogger` that replaces `service_module._logger`, rather than `structlog.testing.capture_logs()`. Rationale: the service module binds `_logger = structlog.get_logger(__name__)` at import time and `configure_logging()` registers `cache_logger_on_first_use=True`, so whichever earlier test first touches the service's `_logger` outside a `capture_logs()` context can cache a bound logger that later `capture_logs()` contexts do not observe — making log-capture assertions order-dependent. The monkey-patched spy sidesteps structlog's global state entirely and matches the pattern in `tests/unit/features/extraction/skills/test_skill_loader.py`. Each test additionally pins structured context fields (`skill_name`, `skill_version`, `duration_ms`; `budget_seconds` for the timeout case) so silent renames would fail the test.
  - `test_cancelled_error_emits_extraction_cancelled_event_and_reraises`
  - `test_timeout_emits_extraction_timeout_event_with_budget_seconds`
  - `test_inner_timeout_error_does_not_emit_extraction_timeout_event`
- [x] Green: all 29 extraction-service unit tests pass.
- [x] `task check` passes end-to-end (lint, format, types, arch, skills, unit, integration, contract, errors:check, errors:test).

AI-assisted with Claude.
