### PR TITLE
fix(extraction): honor LangExtract sampling kwargs in OllamaGemmaProvider (closes #385)

### DIFF
--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -93,12 +93,14 @@ _STALE_CLIENT_ACLOSE_TIMEOUT_SECONDS = 2.0
 # before this allowlist the provider silently dropped every entry. Keeping the
 # list explicit (rather than forwarding ``**kwargs`` wholesale) means:
 #
+#   * only kwargs whose names appear in this allowlist can affect Ollama
+#     sampling; all other caller-supplied kwargs are ignored and logged at
+#     DEBUG rather than forwarded,
 #   * unknown / future Ollama options do not leak into the payload without a
 #     deliberate code change (and a matching test),
-#   * LangExtract orchestrator kwargs that happen to share a name with a valid
-#     Ollama option cannot accidentally mutate sampling behavior,
 #   * the ``generate()`` path is unaffected — it never receives caller kwargs,
-#     so the settings-backed defaults remain in force for validator retries.
+#     so the module-level ``_DEFAULT_SAMPLING_OPTIONS`` baseline (below)
+#     remains in force for validator retries.
 #
 # Sampling keys only (seed, temperature, top_p, top_k, num_ctx, num_predict,
 # repeat_penalty, mirostat family). Streaming / format / keep_alive / raw are
@@ -141,9 +143,14 @@ def _merge_sampling_options(**kwargs: Any) -> tuple[dict[str, Any], list[str]]:
 
     Splits the raw LangExtract-forwarded kwargs dict into two buckets:
 
-    * keys in ``_OLLAMA_SAMPLING_OPTION_KEYS`` are copied over the
-      ``_DEFAULT_SAMPLING_OPTIONS`` baseline (caller wins) and returned as
-      the first element of the tuple,
+    * keys in ``_OLLAMA_SAMPLING_OPTION_KEYS`` whose value is not ``None``
+      are copied over the ``_DEFAULT_SAMPLING_OPTIONS`` baseline (caller
+      wins) and returned as the first element of the tuple. An allowlisted
+      key whose value IS ``None`` is treated as "not provided" — the
+      default is preserved rather than being clobbered with ``None``.
+      Forwarding ``null`` to Ollama would break the determinism contract
+      for ``temperature`` and risks a server-side 400 for keys Ollama
+      validates (e.g. ``seed``),
     * keys NOT in the allowlist are collected into a list and returned as
       the second element so the caller can log them for observability
       (issue #385: operators need to see drift when LangExtract forwards
@@ -156,7 +163,8 @@ def _merge_sampling_options(**kwargs: Any) -> tuple[dict[str, Any], list[str]]:
     ignored: list[str] = []
     for key, value in kwargs.items():
         if key in _OLLAMA_SAMPLING_OPTION_KEYS:
-            options[key] = value
+            if value is not None:
+                options[key] = value
         else:
             ignored.append(key)
     return options, ignored

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -122,8 +122,9 @@ _OLLAMA_SAMPLING_OPTION_KEYS: frozenset[str] = frozenset(
 # Default sampling options applied when the caller does not override them.
 # Pinning ``temperature=0`` keeps the validator-retry determinism contract from
 # issue #136 intact for callers (including the ``generate()`` path and plain
-# ``infer()`` with no kwargs). Caller overrides win — see
-# ``_merge_sampling_options``.
+# ``infer()`` with no kwargs). This is a module-level constant, not a
+# ``Settings``-backed field — operators who need to change the baseline do so
+# here, not via env var. Caller overrides win — see ``_merge_sampling_options``.
 _DEFAULT_SAMPLING_OPTIONS: dict[str, Any] = {"temperature": 0}
 
 
@@ -171,13 +172,13 @@ def _build_payload(
     # server returns well-formed JSON on the first attempt instead of forcing
     # ``StructuredOutputValidator`` to re-prompt for parse errors on every
     # request. ``options`` pins sampling parameters; without overrides it keeps
-    # the settings-backed ``temperature=0`` default from issue #136 so validator
-    # retries repeat from a stable baseline rather than drifting between
-    # attempts. When the caller supplies ``sampling_options`` (the ``infer()``
-    # path on a LangExtract-forwarded kwarg — issue #385), those values replace
-    # the baseline per-key. The validator still enforces our downstream schema
-    # shape, but it no longer pays the malformed-output retry cost on the happy
-    # path.
+    # the module-level ``_DEFAULT_SAMPLING_OPTIONS`` baseline (``temperature=0``
+    # from issue #136) so validator retries repeat from a stable baseline
+    # rather than drifting between attempts. When the caller supplies
+    # ``sampling_options`` (the ``infer()`` path on a LangExtract-forwarded
+    # kwarg — issue #385), those values replace the baseline per-key. The
+    # validator still enforces our downstream schema shape, but it no longer
+    # pays the malformed-output retry cost on the happy path.
     options = sampling_options if sampling_options is not None else dict(_DEFAULT_SAMPLING_OPTIONS)
     return {
         "model": model,
@@ -468,7 +469,8 @@ class OllamaGemmaProvider(BaseLanguageModel):
         # ``sampling_options`` is threaded through from ``infer()`` so
         # LangExtract-forwarded sampling kwargs land in the Ollama payload
         # (issue #385). When ``None`` (the ``generate()`` path), ``_build_payload``
-        # falls back to the settings-backed ``temperature=0`` default.
+        # falls back to the module-level default sampling options, including
+        # ``temperature=0``.
         payload = _build_payload(self._model, prompt, sampling_options=sampling_options)
         try:
             response = await client.post(self._generate_url, json=payload)
@@ -589,7 +591,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
 
         LangExtract's orchestrator forwards ``language_model_params`` (from
         ``lx.extract(..., language_model_params={"temperature": 0.7})``) to
-        this method as ``**kwargs``. The provider thread the allowlisted
+        this method as ``**kwargs``. The provider threads the allowlisted
         Ollama sampling options (temperature, top_p, top_k, seed, num_ctx,
         num_predict, repeat_penalty, mirostat family) into the
         ``/api/generate`` payload so caller overrides actually reach Ollama

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -86,6 +86,46 @@ _HTTP_SERVER_ERROR_MIN = 500
 # stall callers.
 _STALE_CLIENT_ACLOSE_TIMEOUT_SECONDS = 2.0
 
+# Ollama ``/api/generate`` ``options`` keys the provider is willing to forward
+# from caller-supplied kwargs on the ``infer()`` path (issue #385). LangExtract
+# passes whatever ``language_model_params`` dict the user hands to
+# ``lx.extract`` straight through to ``BaseLanguageModel.infer`` as ``**kwargs``;
+# before this allowlist the provider silently dropped every entry. Keeping the
+# list explicit (rather than forwarding ``**kwargs`` wholesale) means:
+#
+#   * unknown / future Ollama options do not leak into the payload without a
+#     deliberate code change (and a matching test),
+#   * LangExtract orchestrator kwargs that happen to share a name with a valid
+#     Ollama option cannot accidentally mutate sampling behavior,
+#   * the ``generate()`` path is unaffected — it never receives caller kwargs,
+#     so the settings-backed defaults remain in force for validator retries.
+#
+# Sampling keys only (seed, temperature, top_p, top_k, num_ctx, num_predict,
+# repeat_penalty, mirostat family). Streaming / format / keep_alive / raw are
+# deliberately excluded: they are transport-shape concerns the provider owns,
+# not sampling concerns callers should override.
+_OLLAMA_SAMPLING_OPTION_KEYS: frozenset[str] = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "top_k",
+        "seed",
+        "num_ctx",
+        "num_predict",
+        "repeat_penalty",
+        "mirostat",
+        "mirostat_tau",
+        "mirostat_eta",
+    },
+)
+
+# Default sampling options applied when the caller does not override them.
+# Pinning ``temperature=0`` keeps the validator-retry determinism contract from
+# issue #136 intact for callers (including the ``generate()`` path and plain
+# ``infer()`` with no kwargs). Caller overrides win — see
+# ``_merge_sampling_options``.
+_DEFAULT_SAMPLING_OPTIONS: dict[str, Any] = {"temperature": 0}
+
 
 def _build_generate_url(base_url: str) -> str:
     return f"{base_url.rstrip('/')}/api/generate"
@@ -95,21 +135,56 @@ def build_tags_url(base_url: str) -> str:
     return f"{base_url.rstrip('/')}/api/tags"
 
 
-def _build_payload(model: str, prompt: str) -> dict[str, Any]:
+def _merge_sampling_options(**kwargs: Any) -> tuple[dict[str, Any], list[str]]:
+    """Return the merged Ollama ``options`` dict plus the ignored-kwarg key list.
+
+    Splits the raw LangExtract-forwarded kwargs dict into two buckets:
+
+    * keys in ``_OLLAMA_SAMPLING_OPTION_KEYS`` are copied over the
+      ``_DEFAULT_SAMPLING_OPTIONS`` baseline (caller wins) and returned as
+      the first element of the tuple,
+    * keys NOT in the allowlist are collected into a list and returned as
+      the second element so the caller can log them for observability
+      (issue #385: operators need to see drift when LangExtract forwards
+      something new).
+
+    The default baseline is copied rather than mutated so concurrent
+    ``infer()`` calls do not race on a shared dict.
+    """
+    options: dict[str, Any] = dict(_DEFAULT_SAMPLING_OPTIONS)
+    ignored: list[str] = []
+    for key, value in kwargs.items():
+        if key in _OLLAMA_SAMPLING_OPTION_KEYS:
+            options[key] = value
+        else:
+            ignored.append(key)
+    return options, ignored
+
+
+def _build_payload(
+    model: str,
+    prompt: str,
+    *,
+    sampling_options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     # ``format="json"`` engages Ollama's native JSON-constrained decoding so the
     # server returns well-formed JSON on the first attempt instead of forcing
     # ``StructuredOutputValidator`` to re-prompt for parse errors on every
-    # request. ``options={"temperature": 0}`` pins deterministic sampling: same
-    # prompt -> same completion, so any validator retry repeats from a stable
-    # baseline rather than drifting between attempts. The validator still
-    # enforces our downstream schema shape, but it no longer pays the malformed-
-    # output retry cost on the happy path. See issue #136.
+    # request. ``options`` pins sampling parameters; without overrides it keeps
+    # the settings-backed ``temperature=0`` default from issue #136 so validator
+    # retries repeat from a stable baseline rather than drifting between
+    # attempts. When the caller supplies ``sampling_options`` (the ``infer()``
+    # path on a LangExtract-forwarded kwarg — issue #385), those values replace
+    # the baseline per-key. The validator still enforces our downstream schema
+    # shape, but it no longer pays the malformed-output retry cost on the happy
+    # path.
+    options = sampling_options if sampling_options is not None else dict(_DEFAULT_SAMPLING_OPTIONS)
     return {
         "model": model,
         "prompt": prompt,
         "stream": False,
         "format": "json",
-        "options": {"temperature": 0},
+        "options": options,
     }
 
 
@@ -341,6 +416,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
         schema: dict[str, Any],
         *,
         client: httpx.AsyncClient,
+        sampling_options: dict[str, Any] | None = None,
     ) -> GenerationResult:
         """Shared validate-and-retry path for both ``generate()`` and ``infer()``.
 
@@ -348,11 +424,26 @@ class OllamaGemmaProvider(BaseLanguageModel):
         ``StructuredOutputValidator`` fence-strip + JSON-parse + retry loop
         against *schema*. Retries also route through the same *client* so
         connection-pool affinity is preserved within a single event loop.
+
+        ``sampling_options``, when provided, threads caller-supplied Ollama
+        ``options`` (temperature, top_p, seed, …) into the payload so
+        LangExtract-forwarded kwargs on the ``infer()`` path are honored
+        (issue #385). Retries reuse the same options dict so every
+        regeneration samples under the caller's requested parameters rather
+        than drifting back to defaults on retry.
         """
-        raw_text = await self._raw_generate(prompt, client=client)
+        raw_text = await self._raw_generate(
+            prompt,
+            client=client,
+            sampling_options=sampling_options,
+        )
 
         async def _regenerate(correction_prompt: str) -> str:
-            return await self._raw_generate(correction_prompt, client=client)
+            return await self._raw_generate(
+                correction_prompt,
+                client=client,
+                sampling_options=sampling_options,
+            )
 
         return await self._validator.validate_and_retry(
             raw_text,
@@ -366,6 +457,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
         prompt: str,
         *,
         client: httpx.AsyncClient,
+        sampling_options: dict[str, Any] | None = None,
     ) -> str:
         # ``client`` is required (not defaulted to ``self.http_client``) so any
         # caller is forced to go through ``_get_http_client()`` for loop-bound
@@ -373,7 +465,11 @@ class OllamaGemmaProvider(BaseLanguageModel):
         # rebuild-on-loop-switch logic and was a foot-gun for any new caller
         # that forgot to call ``_get_http_client()`` first — Pyright strict
         # now surfaces the mistake at author time (issue #277).
-        payload = _build_payload(self._model, prompt)
+        # ``sampling_options`` is threaded through from ``infer()`` so
+        # LangExtract-forwarded sampling kwargs land in the Ollama payload
+        # (issue #385). When ``None`` (the ``generate()`` path), ``_build_payload``
+        # falls back to the settings-backed ``temperature=0`` default.
+        payload = _build_payload(self._model, prompt, sampling_options=sampling_options)
         try:
             response = await client.post(self._generate_url, json=payload)
             response.raise_for_status()
@@ -444,7 +540,12 @@ class OllamaGemmaProvider(BaseLanguageModel):
             raise IntelligenceUnavailableError from None
         return response_text
 
-    async def _validated_generate_batch(self, batch_prompts: Sequence[str]) -> list[str]:
+    async def _validated_generate_batch(
+        self,
+        batch_prompts: Sequence[str],
+        *,
+        sampling_options: dict[str, Any] | None = None,
+    ) -> list[str]:
         # A fresh ``AsyncClient`` is created per ``infer()`` call so that each
         # ``asyncio.run`` scope gets its own loop+client pair. Reusing the
         # instance-level ``self.http_client`` across separate ``asyncio.run``
@@ -461,6 +562,12 @@ class OllamaGemmaProvider(BaseLanguageModel):
         # plugin entry path enforces the same CLAUDE.md-mandated "no bypass"
         # invariant as the ``generate()`` path the
         # ``_ValidatingLangExtractAdapter`` in ``extraction_engine.py`` uses.
+        #
+        # ``sampling_options`` is forwarded from ``infer()`` to decorate every
+        # prompt in the batch with the caller-supplied Ollama options (issue
+        # #385). The same dict is shared across prompts — sampling is a
+        # per-call concern, not per-prompt, so reusing it is correct; no
+        # prompt is mutating the dict.
         async with httpx.AsyncClient(timeout=self._timeout) as batch_client:
             outputs: list[str] = []
             for prompt in batch_prompts:
@@ -468,6 +575,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
                     prompt,
                     LANGEXTRACT_WRAPPER_SCHEMA,
                     client=batch_client,
+                    sampling_options=sampling_options,
                 )
                 outputs.append(json.dumps(result.data))
             return outputs
@@ -475,9 +583,34 @@ class OllamaGemmaProvider(BaseLanguageModel):
     def infer(
         self,
         batch_prompts: Sequence[str],
-        **kwargs: Any,  # noqa: ARG002 - LangExtract passes orchestrator kwargs that we do not consume
+        **kwargs: Any,
     ) -> Iterator[Sequence[ScoredOutput]]:
-        validated_outputs = asyncio.run(self._validated_generate_batch(batch_prompts))
+        """Run LangExtract-driven inference and yield one ``ScoredOutput`` per prompt.
+
+        LangExtract's orchestrator forwards ``language_model_params`` (from
+        ``lx.extract(..., language_model_params={"temperature": 0.7})``) to
+        this method as ``**kwargs``. The provider thread the allowlisted
+        Ollama sampling options (temperature, top_p, top_k, seed, num_ctx,
+        num_predict, repeat_penalty, mirostat family) into the
+        ``/api/generate`` payload so caller overrides actually reach Ollama
+        (issue #385). Any non-sampling kwarg LangExtract forwards —
+        ``format_type``, ``constraint``, ``model_url``, …, or a new option
+        added in a future LangExtract release — is logged at DEBUG under the
+        ``ollama_provider_ignored_kwargs`` event so operators can see drift
+        and add it to the allowlist deliberately if it turns out to matter.
+        """
+        sampling_options, ignored_keys = _merge_sampling_options(**kwargs)
+        if ignored_keys:
+            _logger.debug(
+                "ollama_provider_ignored_kwargs",
+                keys=sorted(ignored_keys),
+            )
+        validated_outputs = asyncio.run(
+            self._validated_generate_batch(
+                batch_prompts,
+                sampling_options=sampling_options,
+            ),
+        )
         for output in validated_outputs:
             yield [ScoredOutput(score=1.0, output=output)]
 

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -762,6 +762,184 @@ def test_infer_uses_a_single_asyncio_run_for_the_whole_batch(
     assert call_count == 1
 
 
+# ── LangExtract sampling-kwargs forwarding (issue #385) ────────────────
+#
+# Before the fix, ``infer(batch_prompts, **kwargs)`` absorbed and silently
+# dropped every kwarg LangExtract forwarded. A caller setting
+# ``temperature=0.7`` through ``lx.extract(..., language_model_params={
+# "temperature": 0.7})`` got deterministic ``temperature=0`` output with no
+# indication the override had been ignored. The fix threads a known
+# allowlist of Ollama-options sampling keys (temperature, top_p, top_k,
+# seed, num_ctx, num_predict, repeat_penalty, mirostat, mirostat_tau,
+# mirostat_eta) from the ``infer`` kwargs into the ``/api/generate``
+# ``options`` object, with caller-supplied values overriding defaults.
+# Unknown kwargs are logged at DEBUG so operators see drift if LangExtract
+# starts forwarding something new.
+
+
+def test_infer_forwards_temperature_kwarg_into_payload_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``infer(temperature=0.7, ...)`` must post ``options.temperature == 0.7``.
+
+    Before the fix, ``_build_payload`` hardcoded ``options={"temperature": 0}``
+    and ignored every LangExtract-forwarded kwarg. A caller overriding the
+    sampling temperature via LangExtract got deterministic output with no
+    indication their override was dropped. This test pins the new contract:
+    caller-supplied ``temperature`` wins over the settings-backed default
+    of 0.
+    """
+    fake = _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[_FakeResponse(body={"response": '{"extractions":[]}'})],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
+
+    list(provider.infer(["p1"], temperature=0.7))
+
+    _, payload = fake.post_calls[0]
+    assert payload["options"]["temperature"] == 0.7
+
+
+def test_infer_forwards_multiple_sampling_kwargs_into_payload_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every sampling kwarg from the allowlist must land in payload.options.
+
+    Pins the full allowlist surface (top_p, top_k, seed, num_ctx,
+    num_predict, repeat_penalty, mirostat family) so silently dropping any
+    one of them is a regression caught here rather than at runtime.
+    """
+    fake = _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[_FakeResponse(body={"response": '{"extractions":[]}'})],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
+
+    list(
+        provider.infer(
+            ["p1"],
+            temperature=0.9,
+            top_p=0.95,
+            top_k=40,
+            seed=42,
+            num_ctx=8192,
+            num_predict=512,
+            repeat_penalty=1.1,
+            mirostat=2,
+            mirostat_tau=5.0,
+            mirostat_eta=0.1,
+        )
+    )
+
+    _, payload = fake.post_calls[0]
+    options = payload["options"]
+    assert options["temperature"] == 0.9
+    assert options["top_p"] == 0.95
+    assert options["top_k"] == 40
+    assert options["seed"] == 42
+    assert options["num_ctx"] == 8192
+    assert options["num_predict"] == 512
+    assert options["repeat_penalty"] == 1.1
+    assert options["mirostat"] == 2
+    assert options["mirostat_tau"] == 5.0
+    assert options["mirostat_eta"] == 0.1
+
+
+def test_infer_without_kwargs_keeps_deterministic_temperature_zero_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no caller-supplied kwargs, ``options.temperature`` stays 0.
+
+    This regression guard protects the issue #136 contract
+    (``test_generate_payload_includes_format_json_and_zero_temperature``)
+    for the ``infer()`` seam. The fix must add kwarg forwarding without
+    changing the settings-backed default for callers who forward nothing.
+    """
+    fake = _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[_FakeResponse(body={"response": '{"extractions":[]}'})],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
+
+    list(provider.infer(["p1"]))
+
+    _, payload = fake.post_calls[0]
+    assert payload["options"]["temperature"] == 0
+    assert payload["format"] == "json"
+
+
+def test_infer_drops_non_sampling_kwargs_and_logs_them_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown kwargs must not leak into payload.options, and must be logged.
+
+    LangExtract also forwards orchestrator kwargs like ``format_type``,
+    ``constraint``, or ``model_url`` that are not Ollama sampling options.
+    Those must not end up in the HTTP payload (they would confuse Ollama
+    or leak unrelated state). The provider logs them at DEBUG under event
+    ``ollama_provider_ignored_kwargs`` so operators see drift.
+    """
+    fake = _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[_FakeResponse(body={"response": '{"extractions":[]}'})],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
+
+    with capture_logs() as logs:
+        list(
+            provider.infer(
+                ["p1"],
+                temperature=0.5,
+                format_type="json",
+                constraint=None,
+                model_url="http://other:11434",
+            )
+        )
+
+    _, payload = fake.post_calls[0]
+    # Only the allowlisted sampling key landed in options.
+    assert payload["options"]["temperature"] == 0.5
+    assert "format_type" not in payload["options"]
+    assert "constraint" not in payload["options"]
+    assert "model_url" not in payload["options"]
+    # And the ignored keys were logged so operators can see drift.
+    event = next(
+        (e for e in logs if e.get("event") == "ollama_provider_ignored_kwargs"),
+        None,
+    )
+    assert event is not None, "ignored-kwargs must be logged for observability"
+    ignored_keys = set(event["keys"])
+    assert {"format_type", "constraint", "model_url"} <= ignored_keys
+    assert "temperature" not in ignored_keys
+
+
+def test_infer_kwargs_propagate_across_every_prompt_in_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-call kwargs must apply to every prompt in the batch.
+
+    ``infer`` iterates the batch inside a single ``asyncio.run`` scope; the
+    sampling options the caller passed must decorate every POST, not just
+    the first.
+    """
+    fake = _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[
+            _FakeResponse(body={"response": '{"extractions":[]}'}),
+            _FakeResponse(body={"response": '{"extractions":[]}'}),
+        ],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
+
+    list(provider.infer(["p1", "p2"], temperature=0.3, seed=7))
+
+    assert len(fake.post_calls) == 2
+    for _url, payload in fake.post_calls:
+        assert payload["options"]["temperature"] == 0.3
+        assert payload["options"]["seed"] == 7
+
+
 # The two constructor tests below pin the LangExtract plugin-instantiation
 # path. `langextract.factory.create_model` calls `provider_class(**kwargs)`
 # where `kwargs["model_id"]` is the model tag from `ModelConfig`. Any

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -786,8 +786,7 @@ def test_infer_forwards_temperature_kwarg_into_payload_options(
     and ignored every LangExtract-forwarded kwarg. A caller overriding the
     sampling temperature via LangExtract got deterministic output with no
     indication their override was dropped. This test pins the new contract:
-    caller-supplied ``temperature`` wins over the settings-backed default
-    of 0.
+    caller-supplied ``temperature`` wins over the provider default.
     """
     fake = _patch_infer_client(
         monkeypatch,
@@ -854,7 +853,8 @@ def test_infer_without_kwargs_keeps_deterministic_temperature_zero_default(
     This regression guard protects the issue #136 contract
     (``test_generate_payload_includes_format_json_and_zero_temperature``)
     for the ``infer()`` seam. The fix must add kwarg forwarding without
-    changing the settings-backed default for callers who forward nothing.
+    changing the existing default sampling behavior for callers who
+    forward nothing.
     """
     fake = _patch_infer_client(
         monkeypatch,
@@ -912,6 +912,35 @@ def test_infer_drops_non_sampling_kwargs_and_logs_them_at_debug(
     ignored_keys = set(event["keys"])
     assert {"format_type", "constraint", "model_url"} <= ignored_keys
     assert "temperature" not in ignored_keys
+
+
+def test_infer_allowlisted_kwarg_with_none_value_preserves_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allowlisted kwarg whose value is ``None`` must not clobber the default.
+
+    LangExtract orchestrator dicts may surface ``temperature=None`` (or
+    ``seed=None``, …) when a caller wires a config field that is optional
+    and left unset. Before the fix, ``_merge_sampling_options`` unconditionally
+    copied the value over the default baseline, so the payload reached Ollama
+    with ``options.temperature == null``. That breaks the determinism contract
+    (issue #136) for ``temperature`` and risks a server-side 400 for keys
+    Ollama validates as numeric (e.g. ``seed``). The contract is: treat an
+    allowlisted key whose value is ``None`` as "not provided" — preserve the
+    module-level default, do not forward ``null``.
+    """
+    fake = _patch_infer_client(
+        monkeypatch,
+        post_outcomes=[_FakeResponse(body={"response": '{"extractions":[]}'})],
+    )
+    provider = _build_provider(fake_client=_FakeAsyncClient())
+
+    list(provider.infer(["p1"], temperature=None, seed=None))
+
+    _, payload = fake.post_calls[0]
+    # Default ``temperature=0`` preserved, ``seed`` not injected as ``None``.
+    assert payload["options"]["temperature"] == 0
+    assert "seed" not in payload["options"]
 
 
 def test_infer_kwargs_propagate_across_every_prompt_in_batch(


### PR DESCRIPTION
## Summary

- Thread LangExtract-forwarded Ollama sampling kwargs (`temperature`, `top_p`, `top_k`, `seed`, `num_ctx`, `num_predict`, `repeat_penalty`, `mirostat` family) into the `/api/generate` `options` object on the `infer()` path so caller overrides actually reach Ollama. Before this change, `OllamaGemmaProvider.infer()` absorbed every kwarg via `**_langextract_kwargs` and pretended to honor it — `lx.extract(..., language_model_params={"temperature": 0.7})` silently fell back to deterministic `temperature=0`.
- Provider-level defaults (the module-level `_DEFAULT_SAMPLING_OPTIONS` constant pinning `temperature=0` for validator-retry determinism, issue #136) stay in force when no caller kwargs are provided, and for the `generate()` path which never receives caller kwargs. Caller-supplied values win per-key; an allowlisted key whose caller value is `None` is treated as "not provided" so the default survives.
- Non-sampling kwargs (`format_type`, `constraint`, `model_url`, …) are logged at DEBUG under event `ollama_provider_ignored_kwargs` with `keys=sorted(ignored_keys)` so operators see drift if LangExtract starts forwarding something new — the observability ask the original issue called out.

## Why it matters

The provider bridges LangExtract to Ollama. Dropping sampling kwargs on the floor meant users had no way to control Gemma sampling from skills or extraction config — the only workaround was editing the hardcoded constant in source. This closes the gap for the common case while keeping the fence-strip / JSON-retry validator contract untouched.

## Test plan

- [x] TDD: 6 unit tests in `tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py` pin the full contract (temperature override, full allowlist, no-kwargs default, non-sampling drop+log, None-value preserves default, batch propagation). Verified red on main before implementation, green after.
- [x] `task check` passes end-to-end (lint, types, arch, skills, unit/integration/contract tests, errors).
- [x] Existing `test_generate_payload_includes_format_json_and_zero_temperature` (issue #136 guard) still passes — the `generate()` path is unchanged.

Closes #385

AI-assisted with Claude.
