### PR TITLE
test(contract): register hypothesis profile for schemathesis runs (closes #353)

### DIFF
--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -32,16 +32,32 @@ Hypothesis profiles
 - ``dev`` : larger example budget (200), default deadline, non-
   derandomized for local fuzzing exploration.
 
-Selection order (resolved in our own ``pytest_configure`` hook below,
-registered with ``@pytest.hookimpl(trylast=True)`` so it runs after
-the Hypothesis plugin's own ``pytest_configure``): pytest
-``--hypothesis-profile=<name>`` flag wins; otherwise
-``HYPOTHESIS_PROFILE`` env var; otherwise default ``ci`` (safest
-tightest budget for fresh clones and forgetful CI pipelines). We
-register profiles at import time (idempotent name/value storage) but
-defer the ``load_profile`` call to ``pytest_configure`` so plain
+Selection order: pytest ``--hypothesis-profile=<name>`` flag wins;
+otherwise ``HYPOTHESIS_PROFILE`` env var; otherwise default ``ci``
+(safest tightest budget for fresh clones and forgetful CI pipelines).
+
+Pytest may import this ``conftest.py`` either before or after the
+Hypothesis plugin's ``pytest_configure`` runs, depending on whether
+it is loaded as an initial conftest or discovered during collection,
+so conftest-import ordering alone is not what guarantees CLI
+precedence. The guarantee comes from two cooperating mechanisms in
+our own ``pytest_configure`` hook below:
+
+* ``@pytest.hookimpl(trylast=True)`` pins our hook to run AFTER every
+  other ``pytest_configure``, including the Hypothesis plugin's —
+  regardless of import order — so by the time we look at
+  ``config.getoption("hypothesis_profile")`` the CLI value is final.
+* If that option is set, we ``return`` without calling ``load_profile``,
+  leaving the plugin's CLI-driven selection intact.
+
+We register profiles at import time (idempotent name/value storage)
+but defer the ``load_profile`` call to ``pytest_configure`` so plain
 ``import tests.contract.conftest`` from a unit meta-test does not
-mutate Hypothesis' global active profile.
+mutate Hypothesis' global active profile. The
+``_default_profile_is_still_active()`` helper exposed below is a
+fingerprint probe used by the unit meta-suite to assert that the
+hook actually switched profiles; it is NOT part of the CLI-precedence
+path.
 
 Why ``ci`` is the default and not ``dev``: an unknown caller (a fresh
 clone, an IDE test-runner, a forgetful CI pipeline) should get the
@@ -149,9 +165,11 @@ def _default_profile_is_still_active() -> bool:
     ``tests/unit/meta/test_hypothesis_profile_selection.py``) because it
     is the fingerprint used to prove that the ``pytest_configure`` hook
     below actually switched the active profile away from Hypothesis'
-    ``default``. The hook is the sole caller in this module — see the
-    note there for why we prefer ``config.getoption`` over this
-    fingerprint for CLI-flag detection.
+    ``default``. Not called from this module — the hook uses
+    ``config.getoption("hypothesis_profile")`` for CLI-flag detection,
+    which is a reliable public pytest API and does not need a
+    fingerprint heuristic. See the ``pytest_configure`` docstring for
+    the full rationale.
 
     The fingerprint uses only public Hypothesis API
     (``settings()`` for the active instance, ``settings.get_profile("default")``

--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -1,23 +1,58 @@
-"""Shared fixtures for the contract-test suite — issue #352.
+"""Shared fixtures and Hypothesis profile for the contract-test suite.
 
-Houses the session-scoped ``extract_schema`` fixture that builds the
-schemathesis ``BaseSchema`` against a throwaway FastAPI app. The
-schema is loaded exactly once per pytest session rather than once per
-test (or, worse, at module import time — the pre-#352 behavior that
-leaked a ``tempfile.mkdtemp`` skills directory on every invocation,
-including bare ``--collect-only`` runs).
+Combines two concerns for the contract tree (kept together so there is
+only one ``conftest.py`` at this level):
 
-The loader is a ``@contextmanager`` named ``_build_extract_schema_session``
-so the session-scoped fixture is a thin three-line wrapper and the
-cleanup contract is also directly exercisable from
-``tests/unit/meta/test_contract_schema_fixture_cleanup.py``. Driving
-the context manager directly (rather than through ``pytest.Pytester``)
-keeps the meta-test fast and avoids coupling the finalizer-leak probe
-to pytest's own ``tmp_path_factory`` retention policy.
+1. Issue #352 — session-scoped ``extract_schema`` fixture that builds
+   the schemathesis ``BaseSchema`` against a throwaway FastAPI app
+   exactly once per pytest session (not once per test, and not at
+   module import time — the pre-#352 behavior leaked a
+   ``tempfile.mkdtemp`` skills directory on every invocation, including
+   bare ``--collect-only`` runs). The loader is a ``@contextmanager``
+   named ``_build_extract_schema_session`` so the fixture is a thin
+   three-line wrapper and the cleanup contract is directly exercisable
+   from ``tests/unit/meta/test_contract_schema_fixture_cleanup.py``.
+
+2. Issue #353 — Hypothesis profile registration. Schemathesis builds
+   on Hypothesis, so every ``@schema.parametrize`` + stateful strategy
+   introduced in this contract suite inherits whatever Hypothesis
+   profile is active at collection time. Today the suite is hand-rolled
+   (each ``test_extract_*`` is one-shot and ``validate_response`` is
+   called directly), so zero Hypothesis examples actually run — but
+   the moment a future PR adds ``@schema.parametrize``, the decorator
+   silently inherits Hypothesis defaults (``max_examples=100``,
+   ``deadline=200ms``) which would flake on CI and blow
+   ``task test:contract``'s 300 s timeout. Registering named profiles
+   here pins a known, bounded, deterministic budget.
+
+Hypothesis profiles
+-------------------
+- ``ci``  : tight example budget (50), generous deadline (5 s),
+  ``derandomize=True`` so a failure on CI reproduces locally bit-for-bit.
+- ``dev`` : larger example budget (200), default deadline, non-
+  derandomized for local fuzzing exploration.
+
+Selection order: pytest ``--hypothesis-profile=<name>`` flag (the
+Hypothesis pytest plugin reads this in ``pytest_configure``, which
+runs AFTER conftest import, so CLI wins), then ``HYPOTHESIS_PROFILE``
+env var, then default ``ci`` (safest tightest budget for fresh clones
+and forgetful CI pipelines).
+
+Why ``ci`` is the default and not ``dev``: an unknown caller (a fresh
+clone, an IDE test-runner, a forgetful CI pipeline) should get the
+safe profile automatically. Local developers who want the fuzzier
+``dev`` profile opt in explicitly.
+
+Why this lives in ``tests/contract/conftest.py`` and not the top-level
+``tests/conftest.py``: Hypothesis has no footprint in the unit or
+integration suites today, and scoping the profile registration to the
+contract tree documents the intent (Hypothesis is only relevant to
+Schemathesis) and avoids surprising anyone reading unit-test output.
 """
 
 from __future__ import annotations
 
+import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -25,6 +60,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 import schemathesis
+from hypothesis import settings as hypothesis_settings
 
 from app.main import create_app
 from tests.contract._helpers import settings as _settings
@@ -32,6 +68,63 @@ from tests.contract._helpers import write_valid_skill as _write_valid_skill
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+
+# --- Hypothesis profile registration (issue #353) -----------------------------
+
+_CI_PROFILE = "ci"
+_DEV_PROFILE = "dev"
+_HYPOTHESIS_PROFILE_ENV_VAR = "HYPOTHESIS_PROFILE"
+
+# Register once at module import. `register_profile` is idempotent —
+# calling it twice with the same name just overwrites the earlier entry —
+# so repeated imports (e.g. from pytest collection walking the tree) are
+# safe.
+hypothesis_settings.register_profile(
+    _CI_PROFILE,
+    max_examples=50,
+    deadline=5000,  # milliseconds; generous so CI's noisy runner doesn't flake
+    derandomize=True,  # bit-for-bit reproducibility between CI and local runs
+)
+hypothesis_settings.register_profile(
+    _DEV_PROFILE,
+    max_examples=200,
+    # `deadline` is intentionally left at the Hypothesis default (200 ms)
+    # for ``dev``: locally, developers want the usual fast-fail loop;
+    # they'd rather know a slow strategy exists than wait 5 s per example.
+    derandomize=False,  # randomized locally — local devs want exploratory fuzzing
+)
+
+
+def _select_profile() -> str:
+    """Return the Hypothesis profile name to activate at collection time.
+
+    Resolution order:
+    1. ``--hypothesis-profile=<name>`` on the pytest command line — NOT
+       read here. The Hypothesis pytest plugin reads the flag itself
+       during ``pytest_configure``, which runs AFTER this conftest
+       import. If the flag was passed, the plugin will overwrite
+       whatever profile we loaded below, so CLI wins.
+    2. ``HYPOTHESIS_PROFILE`` environment variable. Used by local
+       tooling and CI jobs that want a specific profile without
+       threading a pytest flag through every invocation.
+    3. Default: ``ci``. Safest because it has the tightest budget.
+    """
+    env_choice = os.environ.get(_HYPOTHESIS_PROFILE_ENV_VAR)
+    if env_choice:
+        return env_choice
+    return _CI_PROFILE
+
+
+# Load a profile at import time so any future ``@schema.parametrize``
+# decorator inherits a bounded budget from the moment pytest collects
+# it. The Hypothesis pytest plugin overwrites this in
+# ``pytest_configure`` when ``--hypothesis-profile=<name>`` is passed —
+# that's the intended behaviour: CLI wins over our default.
+hypothesis_settings.load_profile(_select_profile())
+
+
+# --- schemathesis extract_schema fixture (issue #352) -------------------------
 
 
 @contextmanager

--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -32,11 +32,16 @@ Hypothesis profiles
 - ``dev`` : larger example budget (200), default deadline, non-
   derandomized for local fuzzing exploration.
 
-Selection order: pytest ``--hypothesis-profile=<name>`` flag (the
-Hypothesis pytest plugin reads this in ``pytest_configure``, which
-runs AFTER conftest import, so CLI wins), then ``HYPOTHESIS_PROFILE``
-env var, then default ``ci`` (safest tightest budget for fresh clones
-and forgetful CI pipelines).
+Selection order (resolved in our own ``pytest_configure`` hook below,
+registered with ``@pytest.hookimpl(trylast=True)`` so it runs after
+the Hypothesis plugin's own ``pytest_configure``): pytest
+``--hypothesis-profile=<name>`` flag wins; otherwise
+``HYPOTHESIS_PROFILE`` env var; otherwise default ``ci`` (safest
+tightest budget for fresh clones and forgetful CI pipelines). We
+register profiles at import time (idempotent name/value storage) but
+defer the ``load_profile`` call to ``pytest_configure`` so plain
+``import tests.contract.conftest`` from a unit meta-test does not
+mutate Hypothesis' global active profile.
 
 Why ``ci`` is the default and not ``dev``: an unknown caller (a fresh
 clone, an IDE test-runner, a forgetful CI pipeline) should get the
@@ -105,20 +110,17 @@ def _select_profile() -> str:
     for the "is the built-in default still active?" guard that decides
     whether the caller should honour the returned name.
 
-    Resolution order:
-    1. ``--hypothesis-profile=<name>`` on the pytest command line — NOT
-       read here. The Hypothesis pytest plugin reads the flag itself
-       during ``pytest_configure``. See ``_default_profile_is_still_active`` for
-       the guard that yields to the plugin's selection when the CLI
-       flag was passed.
-    2. ``HYPOTHESIS_PROFILE`` environment variable. Used by local
+    Resolution order (called only when ``--hypothesis-profile`` was
+    NOT passed — the CLI-flag branch short-circuits the caller in
+    ``pytest_configure`` before this helper runs):
+    1. ``HYPOTHESIS_PROFILE`` environment variable. Used by local
        tooling and CI jobs that want a specific profile without
        threading a pytest flag through every invocation. The value is
        validated against the allow-list in ``_REGISTERED_PROFILES`` —
        an unknown name raises ``ValueError`` here rather than
        propagating through ``hypothesis_settings.load_profile`` as a
        terse ``InvalidArgument`` from the library.
-    3. Default: ``ci``. Safest because it has the tightest budget.
+    2. Default: ``ci``. Safest because it has the tightest budget.
 
     Raises:
         ValueError: if ``HYPOTHESIS_PROFILE`` is set to something other
@@ -143,16 +145,13 @@ def _select_profile() -> str:
 def _default_profile_is_still_active() -> bool:
     """True iff Hypothesis' built-in ``default`` profile is the currently active one.
 
-    Read by the module-level loader below as the "has the Hypothesis pytest
-    plugin already loaded a non-default profile?" probe. The plugin runs
-    ``load_profile`` in ``pytest_configure`` when
-    ``--hypothesis-profile=<name>`` is passed, and this sub-conftest may
-    import either before or after ``pytest_configure`` depending on
-    whether pytest treats it as an "initial" conftest (rootdir/testpaths
-    arg) or discovers it via collection walk. Checking the active
-    settings fingerprint decouples us from that ordering: if a non-default
-    profile is already active, the plugin has won and we must not
-    overwrite its choice.
+    Kept as a public helper (imported by
+    ``tests/unit/meta/test_hypothesis_profile_selection.py``) because it
+    is the fingerprint used to prove that the ``pytest_configure`` hook
+    below actually switched the active profile away from Hypothesis'
+    ``default``. The hook is the sole caller in this module — see the
+    note there for why we prefer ``config.getoption`` over this
+    fingerprint for CLI-flag detection.
 
     The fingerprint uses only public Hypothesis API
     (``settings()`` for the active instance, ``settings.get_profile("default")``
@@ -169,17 +168,56 @@ def _default_profile_is_still_active() -> bool:
     )
 
 
-# Load a profile at import time so any future ``@schema.parametrize``
-# decorator inherits a bounded budget from the moment pytest collects
-# it. Only do so while Hypothesis' built-in ``default`` profile is
-# still active: then ``_select_profile()`` can honor an explicit
-# ``HYPOTHESIS_PROFILE`` env var or choose our normal ``ci`` fallback.
-# But if the pytest plugin has already loaded a non-default profile
-# via ``--hypothesis-profile=<name>``, we leave that selection alone
-# so the CLI flag keeps precedence over both our default AND the env
-# var (matching the documented resolution order at the top of this
-# file: CLI > env > default).
-if _default_profile_is_still_active():
+@pytest.hookimpl(trylast=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """Load the Hypothesis profile at pytest-configure time, honouring the CLI flag.
+
+    Why a ``pytest_configure`` hook and not a module-import ``load_profile``
+    call:
+
+    * An explicit ``--hypothesis-profile=<name>`` on the pytest command
+      line must win over our ``HYPOTHESIS_PROFILE`` / ``ci`` fallback.
+      The Hypothesis pytest plugin's own ``pytest_configure`` reads that
+      flag and calls ``settings.load_profile(...)`` itself. Running our
+      own ``load_profile`` at conftest *import* time races the plugin:
+      if the plugin ran first (initial-conftest ordering), our call
+      overwrites the CLI choice. ``@pytest.hookimpl(trylast=True)``
+      guarantees we run AFTER every other ``pytest_configure`` hook,
+      including the Hypothesis plugin's, so ``config.getoption`` reads
+      the final CLI-resolved state.
+    * Querying ``config.getoption("hypothesis_profile")`` is a reliable,
+      public pytest API. It returns the raw CLI value (``None`` if the
+      flag was not passed), independent of whether the Hypothesis plugin
+      has already acted on it. No fingerprint heuristic needed.
+    * Deferring the ``load_profile`` call keeps conftest import itself
+      side-effect-free. Plain ``import tests.contract.conftest`` from a
+      unit meta-test no longer mutates Hypothesis' global active profile
+      — the mutation now happens inside ``pytest_configure``, which the
+      unit suite never triggers for the contract conftest.
+
+    Registration (``register_profile`` calls at module top) stays at
+    import time because it is idempotent key/value storage — registering
+    the same name twice just overwrites the earlier entry, and the meta
+    tests that import this module need the profiles to exist for
+    ``settings.get_profile("ci")`` to succeed without running pytest.
+
+    The ``ValueError`` from ``_select_profile()`` for a bogus
+    ``HYPOTHESIS_PROFILE`` still surfaces here (same friendly message
+    as before) because the selector is the same helper; the only
+    difference is *when* it runs.
+    """
+    # ``config.getoption`` returns ``None`` when ``--hypothesis-profile``
+    # was not passed, and the Hypothesis pytest plugin is what registers
+    # the option. ``default=None`` protects against the vanishingly
+    # unlikely case where the plugin is disabled (``-p no:hypothesispytest``):
+    # pytest would otherwise raise ``ValueError: no option named
+    # 'hypothesis_profile'``.
+    explicit_profile = config.getoption("hypothesis_profile", default=None)
+    if explicit_profile:
+        # The Hypothesis plugin has already loaded this profile in its
+        # own ``pytest_configure``; ``trylast=True`` pins us after it.
+        # Honor the CLI flag by leaving that selection intact.
+        return
     hypothesis_settings.load_profile(_select_profile())
 
 

--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -101,14 +101,14 @@ def _select_profile() -> str:
     """Return the Hypothesis profile name chosen by env var, or the ``ci`` default.
 
     This helper is a pure function of ``HYPOTHESIS_PROFILE``: it does
-    NOT inspect Hypothesis' live global state. See ``_should_load_default``
+    NOT inspect Hypothesis' live global state. See ``_default_profile_is_still_active``
     for the "is the built-in default still active?" guard that decides
     whether the caller should honour the returned name.
 
     Resolution order:
     1. ``--hypothesis-profile=<name>`` on the pytest command line — NOT
        read here. The Hypothesis pytest plugin reads the flag itself
-       during ``pytest_configure``. See ``_should_load_default`` for
+       during ``pytest_configure``. See ``_default_profile_is_still_active`` for
        the guard that yields to the plugin's selection when the CLI
        flag was passed.
     2. ``HYPOTHESIS_PROFILE`` environment variable. Used by local
@@ -171,13 +171,15 @@ def _default_profile_is_still_active() -> bool:
 
 # Load a profile at import time so any future ``@schema.parametrize``
 # decorator inherits a bounded budget from the moment pytest collects
-# it. An explicit ``HYPOTHESIS_PROFILE`` env var always wins (our
-# loader is the only code that reads it, so no race with the plugin).
-# Otherwise, only load the ``ci`` default if Hypothesis' built-in
-# ``default`` profile is still active — if the pytest plugin has
-# already loaded a non-default profile via ``--hypothesis-profile=<name>``,
-# we leave its selection alone so CLI wins.
-if os.environ.get(_HYPOTHESIS_PROFILE_ENV_VAR) or _default_profile_is_still_active():
+# it. Only do so while Hypothesis' built-in ``default`` profile is
+# still active: then ``_select_profile()`` can honor an explicit
+# ``HYPOTHESIS_PROFILE`` env var or choose our normal ``ci`` fallback.
+# But if the pytest plugin has already loaded a non-default profile
+# via ``--hypothesis-profile=<name>``, we leave that selection alone
+# so the CLI flag keeps precedence over both our default AND the env
+# var (matching the documented resolution order at the top of this
+# file: CLI > env > default).
+if _default_profile_is_still_active():
     hypothesis_settings.load_profile(_select_profile())
 
 

--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -98,14 +98,19 @@ hypothesis_settings.register_profile(
 
 
 def _select_profile() -> str:
-    """Return the Hypothesis profile name to activate at collection time.
+    """Return the Hypothesis profile name chosen by env var, or the ``ci`` default.
+
+    This helper is a pure function of ``HYPOTHESIS_PROFILE``: it does
+    NOT inspect Hypothesis' live global state. See ``_should_load_default``
+    for the "is the built-in default still active?" guard that decides
+    whether the caller should honour the returned name.
 
     Resolution order:
     1. ``--hypothesis-profile=<name>`` on the pytest command line — NOT
        read here. The Hypothesis pytest plugin reads the flag itself
-       during ``pytest_configure``, which runs AFTER this conftest
-       import. If the flag was passed, the plugin will overwrite
-       whatever profile we loaded below, so CLI wins.
+       during ``pytest_configure``. See ``_should_load_default`` for
+       the guard that yields to the plugin's selection when the CLI
+       flag was passed.
     2. ``HYPOTHESIS_PROFILE`` environment variable. Used by local
        tooling and CI jobs that want a specific profile without
        threading a pytest flag through every invocation. The value is
@@ -135,12 +140,45 @@ def _select_profile() -> str:
     return env_choice
 
 
+def _default_profile_is_still_active() -> bool:
+    """True iff Hypothesis' built-in ``default`` profile is the currently active one.
+
+    Read by the module-level loader below as the "has the Hypothesis pytest
+    plugin already loaded a non-default profile?" probe. The plugin runs
+    ``load_profile`` in ``pytest_configure`` when
+    ``--hypothesis-profile=<name>`` is passed, and this sub-conftest may
+    import either before or after ``pytest_configure`` depending on
+    whether pytest treats it as an "initial" conftest (rootdir/testpaths
+    arg) or discovers it via collection walk. Checking the active
+    settings fingerprint decouples us from that ordering: if a non-default
+    profile is already active, the plugin has won and we must not
+    overwrite its choice.
+
+    The fingerprint uses only public Hypothesis API
+    (``settings()`` for the active instance, ``settings.get_profile("default")``
+    for the built-in default) rather than the private
+    ``settings._current_profile`` attribute — see the matching rationale
+    in ``tests/contract/test_hypothesis_profile_registered.py``.
+    """
+    active = hypothesis_settings()
+    default = hypothesis_settings.get_profile("default")
+    return (
+        active.max_examples == default.max_examples
+        and active.deadline == default.deadline
+        and active.derandomize == default.derandomize
+    )
+
+
 # Load a profile at import time so any future ``@schema.parametrize``
 # decorator inherits a bounded budget from the moment pytest collects
-# it. The Hypothesis pytest plugin overwrites this in
-# ``pytest_configure`` when ``--hypothesis-profile=<name>`` is passed —
-# that's the intended behaviour: CLI wins over our default.
-hypothesis_settings.load_profile(_select_profile())
+# it. An explicit ``HYPOTHESIS_PROFILE`` env var always wins (our
+# loader is the only code that reads it, so no race with the plugin).
+# Otherwise, only load the ``ci`` default if Hypothesis' built-in
+# ``default`` profile is still active — if the pytest plugin has
+# already loaded a non-default profile via ``--hypothesis-profile=<name>``,
+# we leave its selection alone so CLI wins.
+if os.environ.get(_HYPOTHESIS_PROFILE_ENV_VAR) or _default_profile_is_still_active():
+    hypothesis_settings.load_profile(_select_profile())
 
 
 # --- schemathesis extract_schema fixture (issue #352) -------------------------

--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
 _CI_PROFILE = "ci"
 _DEV_PROFILE = "dev"
 _HYPOTHESIS_PROFILE_ENV_VAR = "HYPOTHESIS_PROFILE"
+_REGISTERED_PROFILES: tuple[str, ...] = (_CI_PROFILE, _DEV_PROFILE)
 
 # Register once at module import. `register_profile` is idempotent —
 # calling it twice with the same name just overwrites the earlier entry —
@@ -107,13 +108,31 @@ def _select_profile() -> str:
        whatever profile we loaded below, so CLI wins.
     2. ``HYPOTHESIS_PROFILE`` environment variable. Used by local
        tooling and CI jobs that want a specific profile without
-       threading a pytest flag through every invocation.
+       threading a pytest flag through every invocation. The value is
+       validated against the allow-list in ``_REGISTERED_PROFILES`` —
+       an unknown name raises ``ValueError`` here rather than
+       propagating through ``hypothesis_settings.load_profile`` as a
+       terse ``InvalidArgument`` from the library.
     3. Default: ``ci``. Safest because it has the tightest budget.
+
+    Raises:
+        ValueError: if ``HYPOTHESIS_PROFILE`` is set to something other
+            than a registered profile name. The message names the
+            offending value AND the allow-list so the caller knows
+            exactly what to fix.
     """
     env_choice = os.environ.get(_HYPOTHESIS_PROFILE_ENV_VAR)
-    if env_choice:
-        return env_choice
-    return _CI_PROFILE
+    if not env_choice:
+        return _CI_PROFILE
+    if env_choice not in _REGISTERED_PROFILES:
+        allowed = ", ".join(repr(name) for name in _REGISTERED_PROFILES)
+        msg = (
+            f"{_HYPOTHESIS_PROFILE_ENV_VAR}={env_choice!r} is not a registered "
+            f"Hypothesis profile. Allowed values: {allowed}. "
+            f"Unset the variable to use the default 'ci' profile."
+        )
+        raise ValueError(msg)
+    return env_choice
 
 
 # Load a profile at import time so any future ``@schema.parametrize``

--- a/apps/backend/tests/contract/test_hypothesis_profile_registered.py
+++ b/apps/backend/tests/contract/test_hypothesis_profile_registered.py
@@ -71,6 +71,15 @@ def test_ci_profile_budget_is_bounded() -> None:
     to tighten the example budget (so contract tests stay within the 300 s
     timeout declared on ``task test:contract``) AND loosen the deadline
     (so a slow CI runner doesn't fail an otherwise-valid example).
+
+    The deadline must be an actual positive duration, not ``None``.
+    ``deadline=None`` disables the per-example time limit entirely, which
+    is the opposite of "raise it" — a Hypothesis strategy that gets
+    pathologically slow (e.g. an unbounded text generator) would then
+    consume the entire 300 s contract-test budget before the runner
+    flagged anything. Requiring a concrete floor makes the invariant
+    match the docstring and catches a regression where somebody "fixes"
+    a flake by turning the deadline off entirely instead of raising it.
     """
     ci_profile = hypothesis_settings.get_profile("ci")
 
@@ -79,12 +88,17 @@ def test_ci_profile_budget_is_bounded() -> None:
         f"must be <= {_CI_MAX_EXAMPLES_CEILING} (Hypothesis default). Issue #353."
     )
 
-    deadline_ms = (
-        ci_profile.deadline.total_seconds() * 1000 if ci_profile.deadline is not None else None
+    assert ci_profile.deadline is not None, (
+        "ci Hypothesis profile has deadline=None (no deadline). The profile "
+        "must RAISE the deadline above Hypothesis' 200 ms default, not "
+        f"disable it — set deadline >= {_CI_DEADLINE_FLOOR_MS} ms so a "
+        "pathologically slow strategy still fails within the contract-test "
+        "budget. Issue #353."
     )
-    assert deadline_ms is None or deadline_ms >= _CI_DEADLINE_FLOOR_MS, (
+    deadline_ms = ci_profile.deadline.total_seconds() * 1000
+    assert deadline_ms >= _CI_DEADLINE_FLOOR_MS, (
         f"ci Hypothesis profile has deadline={deadline_ms} ms, "
-        f"must be None or >= {_CI_DEADLINE_FLOOR_MS} ms to survive a noisy CI runner. "
+        f"must be >= {_CI_DEADLINE_FLOOR_MS} ms to survive a noisy CI runner. "
         f"Issue #353."
     )
 

--- a/apps/backend/tests/contract/test_hypothesis_profile_registered.py
+++ b/apps/backend/tests/contract/test_hypothesis_profile_registered.py
@@ -126,18 +126,43 @@ def test_active_profile_is_one_of_the_registered_profiles() -> None:
     ``dev`` (bounded example count, generous deadline, deterministic
     seed) is undone the moment a future ``@schema.parametrize`` decorator
     lands.
+
+    Implementation note: we compare a *fingerprint* (tuple of
+    ``max_examples``/``deadline``/``derandomize``) of the active settings
+    object against the fingerprints of the registered profiles, using
+    only public Hypothesis APIs (``settings()`` for the active instance
+    and ``settings.get_profile(name)`` for each registered name).
+    Reading ``settings._current_profile`` directly would be shorter but
+    relies on a private module-level attribute that Hypothesis can
+    rename across versions — the contract suite would then start
+    failing for reasons unrelated to our profiles. The fingerprint
+    approach stays stable because the ``ci`` profile pins
+    ``max_examples=50`` (!= default 100), ``deadline=5000ms`` (!= default
+    200ms), and ``derandomize=True`` (!= default False), so a genuine
+    "default profile is still active" regression always shows up on at
+    least one fingerprint field.
     """
-    # `_current_profile` is the single source of truth for the active
-    # profile name (the `hypothesis.settings` module stores it as a
-    # module-level string after `load_profile` runs). Reading it
-    # directly rather than round-tripping through `settings()` is what
-    # makes this assertion load-bearing — any substitute check (like
-    # comparing `settings().max_examples` to the ci profile's value)
-    # would pass accidentally if the ci value happened to match the
-    # default.
-    active_profile_name = hypothesis_settings._current_profile  # noqa: SLF001
-    assert active_profile_name in _REQUIRED_PROFILES, (
-        f"Active Hypothesis profile is {active_profile_name!r}; expected one of "
-        f"{_REQUIRED_PROFILES!r}. The contract conftest.py must call "
-        f"`settings.load_profile(...)` with a registered name. Issue #353."
+    active_settings = hypothesis_settings()
+    default_settings = hypothesis_settings.get_profile("default")
+    fingerprint_fields = ("max_examples", "deadline", "derandomize")
+
+    def _fingerprint(profile: hypothesis_settings) -> tuple[object, ...]:
+        return tuple(getattr(profile, field_name) for field_name in fingerprint_fields)
+
+    active_fingerprint = _fingerprint(active_settings)
+    registered_fingerprints = {
+        name: _fingerprint(hypothesis_settings.get_profile(name)) for name in _REQUIRED_PROFILES
+    }
+
+    assert active_fingerprint != _fingerprint(default_settings), (
+        "Active Hypothesis settings still match the built-in default profile on "
+        f"{fingerprint_fields!r}; the contract conftest.py must call "
+        "`settings.load_profile(...)` with a non-default registered profile. Issue #353."
+    )
+
+    assert active_fingerprint in registered_fingerprints.values(), (
+        "Active Hypothesis settings do not match any registered contract-test profile on "
+        f"{fingerprint_fields!r}. Expected one of {registered_fingerprints!r}, got "
+        f"{active_fingerprint!r}. The contract conftest.py must call "
+        "`settings.load_profile(...)` with a registered name. Issue #353."
     )

--- a/apps/backend/tests/contract/test_hypothesis_profile_registered.py
+++ b/apps/backend/tests/contract/test_hypothesis_profile_registered.py
@@ -1,0 +1,129 @@
+"""Meta-test: contract-test conftest must register Hypothesis settings profiles.
+
+Why this guardrail exists (issue #353)
+--------------------------------------
+Today every test in ``apps/backend/tests/contract/test_schemathesis.py``
+is a hand-rolled one-shot request + ``schema[...].validate_response``
+check — no ``@schema.parametrize`` decorator, no stateful Hypothesis
+strategy. That means the Hypothesis plugin currently contributes zero
+examples per run, so the library's defaults (``max_examples=100``,
+``deadline=200ms``) never fire.
+
+The moment a future PR adds ``@schema.parametrize`` for a simpler
+endpoint (``/health`` is the obvious next target), the schemathesis/
+Hypothesis stack silently inherits those defaults. A
+``deadline=200ms`` limit will flake on CI's noisier runner even for a
+trivial JSON endpoint, and ``max_examples=100`` per operation will
+blow the contract-test budget (``task test:contract`` has a 300 s
+timeout). Fixing it after it flakes means chasing retry loops; pinning
+a registered profile up front means the first PR that adds
+``@schema.parametrize`` lands with a known, bounded, deterministic
+budget.
+
+What this test pins
+-------------------
+1. The contract ``conftest.py`` registers at least the ``ci`` profile
+   (low ``max_examples``, generous ``deadline``, deterministic seed via
+   ``derandomize=True``) and the ``dev`` profile (larger
+   ``max_examples`` for local exploration).
+2. One of those profiles is loaded at test-collection time, so future
+   ``@schema.parametrize`` decorators run under an explicit budget
+   rather than Hypothesis defaults.
+3. The loaded profile is selectable via either the
+   ``HYPOTHESIS_PROFILE`` environment variable or pytest's
+   ``--hypothesis-profile=<name>`` flag (the standard Hypothesis
+   integration surface — see
+   https://hypothesis.readthedocs.io/en/latest/reference/integrations.html).
+
+When this test fails, either ``conftest.py`` dropped its
+``register_profile`` call (re-add it) or a sibling PR renamed the
+profile without updating the allow-list below (keep the name and the
+test in sync).
+"""
+
+from __future__ import annotations
+
+from hypothesis import settings as hypothesis_settings
+
+_REQUIRED_PROFILES = ("ci", "dev")
+_CI_MAX_EXAMPLES_CEILING = 100  # Hypothesis default; CI profile must stay at or below it.
+_CI_DEADLINE_FLOOR_MS = 1000  # CI profile deadline must exceed Hypothesis' 200 ms default.
+
+
+def test_ci_and_dev_profiles_are_registered() -> None:
+    """``settings.get_profile`` must succeed for every profile we pin."""
+    for name in _REQUIRED_PROFILES:
+        # `get_profile` raises `InvalidArgument` if the profile was never
+        # registered. Letting it raise surfaces the exact missing name in
+        # the pytest failure report, which is what we want.
+        profile = hypothesis_settings.get_profile(name)
+        assert profile is not None, (
+            f"Hypothesis profile {name!r} returned None from get_profile; "
+            f"re-register it in apps/backend/tests/contract/conftest.py (issue #353)."
+        )
+
+
+def test_ci_profile_budget_is_bounded() -> None:
+    """The ``ci`` profile must cap ``max_examples`` and raise ``deadline``.
+
+    Rationale: Hypothesis' default ``max_examples=100`` + ``deadline=200ms``
+    will flake on CI's noisier runner. The ``ci`` profile exists precisely
+    to tighten the example budget (so contract tests stay within the 300 s
+    timeout declared on ``task test:contract``) AND loosen the deadline
+    (so a slow CI runner doesn't fail an otherwise-valid example).
+    """
+    ci_profile = hypothesis_settings.get_profile("ci")
+
+    assert ci_profile.max_examples <= _CI_MAX_EXAMPLES_CEILING, (
+        f"ci Hypothesis profile has max_examples={ci_profile.max_examples}, "
+        f"must be <= {_CI_MAX_EXAMPLES_CEILING} (Hypothesis default). Issue #353."
+    )
+
+    deadline_ms = (
+        ci_profile.deadline.total_seconds() * 1000 if ci_profile.deadline is not None else None
+    )
+    assert deadline_ms is None or deadline_ms >= _CI_DEADLINE_FLOOR_MS, (
+        f"ci Hypothesis profile has deadline={deadline_ms} ms, "
+        f"must be None or >= {_CI_DEADLINE_FLOOR_MS} ms to survive a noisy CI runner. "
+        f"Issue #353."
+    )
+
+
+def test_ci_profile_is_deterministic() -> None:
+    """The ``ci`` profile must run ``derandomize=True``.
+
+    Deterministic seeds matter on CI because a flaky property-based test
+    that only reproduces under one random seed is practically undiagnosable
+    from the CI logs. Pinning ``derandomize=True`` makes every run of the
+    same commit use the same seed, so a failure on CI reproduces locally.
+    """
+    ci_profile = hypothesis_settings.get_profile("ci")
+    assert ci_profile.derandomize is True, (
+        "ci Hypothesis profile must set derandomize=True so CI runs are "
+        "reproducible locally. Issue #353."
+    )
+
+
+def test_active_profile_is_one_of_the_registered_profiles() -> None:
+    """Something must have called ``load_profile`` during collection.
+
+    Otherwise the active settings instance is Hypothesis' built-in
+    ``default`` profile, and the whole point of registering ``ci`` and
+    ``dev`` (bounded example count, generous deadline, deterministic
+    seed) is undone the moment a future ``@schema.parametrize`` decorator
+    lands.
+    """
+    # `_current_profile` is the single source of truth for the active
+    # profile name (the `hypothesis.settings` module stores it as a
+    # module-level string after `load_profile` runs). Reading it
+    # directly rather than round-tripping through `settings()` is what
+    # makes this assertion load-bearing — any substitute check (like
+    # comparing `settings().max_examples` to the ci profile's value)
+    # would pass accidentally if the ci value happened to match the
+    # default.
+    active_profile_name = hypothesis_settings._current_profile  # noqa: SLF001
+    assert active_profile_name in _REQUIRED_PROFILES, (
+        f"Active Hypothesis profile is {active_profile_name!r}; expected one of "
+        f"{_REQUIRED_PROFILES!r}. The contract conftest.py must call "
+        f"`settings.load_profile(...)` with a registered name. Issue #353."
+    )

--- a/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
+++ b/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
@@ -20,28 +20,22 @@ These tests pin the friendlier behaviour:
    ``ci`` default.
 
 Importing ``tests.contract.conftest`` from a unit test is a deliberate
-choice here: ``_select_profile`` is private to that module, and the
-module's side effects (two ``register_profile`` calls and one
-``load_profile`` call for ``ci``) are idempotent and don't leak into
-other unit tests — Hypothesis isn't exercised by the unit suite.
+choice here: ``_select_profile`` is private to that module. The module
+import is now side-effect-free with respect to Hypothesis' active
+profile — ``load_profile`` is deferred to a ``pytest_configure`` hook,
+so importing the conftest from the unit suite registers the ``ci`` and
+``dev`` profiles (idempotent) but does not mutate which profile is
+active. That means these unit tests no longer need a module-scope
+``os.environ.pop`` to protect conftest import from a typoed
+``HYPOTHESIS_PROFILE`` in the developer's shell — ``_select_profile``
+is a pure function now invoked only from inside each test under
+``monkeypatch`` control.
 """
 
 from __future__ import annotations
 
-import os
-
 import pytest
-
-# Hermetic unit-test contract: clear ``HYPOTHESIS_PROFILE`` *before* the
-# first ``tests.contract.conftest`` import. That conftest reads the env
-# var and calls ``hypothesis_settings.load_profile`` at module-import
-# time, which raises ``ValueError`` if the developer's shell has
-# ``HYPOTHESIS_PROFILE`` set to an unregistered value (e.g. a typo like
-# ``cii``). Per-test ``monkeypatch`` fixtures apply in the test body,
-# AFTER conftest import, so they cannot protect against this failure
-# mode. Popping at module scope keeps these unit tests reproducible
-# across developer shells and CI runners.
-os.environ.pop("HYPOTHESIS_PROFILE", None)
+from hypothesis import settings as hypothesis_settings
 
 
 def test_select_profile_returns_ci_default_when_env_var_unset(
@@ -74,11 +68,11 @@ def test_select_profile_rejects_unknown_env_var_with_helpful_message(
     """A typoed ``HYPOTHESIS_PROFILE`` must raise ``ValueError`` listing allowed names.
 
     Without the allow-list guard, ``hypothesis_settings.load_profile("cii")``
-    would raise ``InvalidArgument`` at conftest import time with a terse
-    Hypothesis-library message. The wrapper guard replaces that with a
-    ``ValueError`` whose message names the offending value AND every
-    registered profile, so bare ``--collect-only`` output tells the
-    caller both what broke and how to fix it.
+    would raise ``InvalidArgument`` when the ``pytest_configure`` hook
+    called it, with a terse Hypothesis-library message. The wrapper
+    guard replaces that with a ``ValueError`` whose message names the
+    offending value AND every registered profile, so the pytest startup
+    error tells the caller both what broke and how to fix it.
     """
     from tests.contract.conftest import _select_profile
 
@@ -100,29 +94,36 @@ def test_select_profile_rejects_unknown_env_var_with_helpful_message(
     )
 
 
-def test_default_profile_is_still_active_is_false_after_ci_load() -> None:
-    """After the contract conftest loads ``ci``, the default-active probe must say ``False``.
+def test_default_profile_is_still_active_detects_mismatched_fingerprint() -> None:
+    """``_default_profile_is_still_active`` must return ``False`` while a non-default profile is loaded.
 
-    This is the guard that makes the CLI flag ``--hypothesis-profile=<name>``
-    win over this conftest's own default-loading. If the Hypothesis pytest
-    plugin ran first (e.g. because the contract conftest is imported via
-    collection walk rather than as an "initial" conftest), the plugin
-    will have loaded a non-default profile and the fingerprint match
-    must report False so the conftest skips its own ``load_profile``
-    call.
+    The helper's one job is to be a reliable fingerprint probe: when a
+    non-default profile (e.g. ``ci``) is the active one, the fingerprint
+    must NOT match Hypothesis' built-in default. The unit suite now
+    exercises that invariant by loading ``ci`` explicitly inside the
+    test body and restoring the previously-active profile on teardown.
+    The contract conftest import no longer triggers ``load_profile`` as
+    a side effect (the load is deferred to a ``pytest_configure`` hook
+    the unit suite never runs), so without the in-test load step this
+    test would only ever see Hypothesis' default profile.
 
-    The contract conftest is imported unconditionally at the top of this
-    module (via ``_select_profile``'s module-level import inside the
-    other tests), which triggers a ``load_profile("ci")`` side effect.
-    By the time this test runs, ``ci`` is active, so the probe must
-    return False — otherwise the guard would be a no-op and we'd be
-    back to racing the plugin.
+    ``try/finally`` restores whatever profile was active when the test
+    started, so a failure here does not leak ``ci`` into the rest of
+    the unit suite and flake unrelated property-based tests.
     """
+    # Importing the contract conftest registers ``ci`` and ``dev``
+    # idempotently; ``load_profile`` below would raise if ``ci`` were
+    # not registered.
     from tests.contract.conftest import _default_profile_is_still_active
 
-    assert _default_profile_is_still_active() is False, (
-        "_default_profile_is_still_active() returned True after the contract "
-        "conftest loaded its 'ci' profile. The fingerprint check is broken — "
-        "see apps/backend/tests/contract/conftest.py _default_profile_is_still_active. "
-        "Issue #353."
-    )
+    previous_profile = hypothesis_settings.get_current_profile_name()
+    hypothesis_settings.load_profile("ci")
+    try:
+        assert _default_profile_is_still_active() is False, (
+            "_default_profile_is_still_active() returned True while the "
+            "'ci' profile was the active one. The fingerprint probe is "
+            "broken — see apps/backend/tests/contract/conftest.py "
+            "_default_profile_is_still_active. Issue #353."
+        )
+    finally:
+        hypothesis_settings.load_profile(previous_profile)

--- a/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
+++ b/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
@@ -28,7 +28,20 @@ other unit tests — Hypothesis isn't exercised by the unit suite.
 
 from __future__ import annotations
 
+import os
+
 import pytest
+
+# Hermetic unit-test contract: clear ``HYPOTHESIS_PROFILE`` *before* the
+# first ``tests.contract.conftest`` import. That conftest reads the env
+# var and calls ``hypothesis_settings.load_profile`` at module-import
+# time, which raises ``ValueError`` if the developer's shell has
+# ``HYPOTHESIS_PROFILE`` set to an unregistered value (e.g. a typo like
+# ``cii``). Per-test ``monkeypatch`` fixtures apply in the test body,
+# AFTER conftest import, so they cannot protect against this failure
+# mode. Popping at module scope keeps these unit tests reproducible
+# across developer shells and CI runners.
+os.environ.pop("HYPOTHESIS_PROFILE", None)
 
 
 def test_select_profile_returns_ci_default_when_env_var_unset(

--- a/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
+++ b/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
@@ -1,0 +1,87 @@
+"""Meta-test for ``_select_profile`` env-var validation (issue #353 follow-up).
+
+Copilot review on PR #458 flagged that the contract conftest's
+``_select_profile()`` helper handed the raw ``HYPOTHESIS_PROFILE``
+environment variable straight to ``hypothesis_settings.load_profile``
+without any allow-list check. A typoed value (``HYPOTHESIS_PROFILE=cii``)
+would fail at import time with Hypothesis' generic ``InvalidArgument``
+stack trace, which is hard to diagnose from bare pytest collection
+output.
+
+These tests pin the friendlier behaviour:
+
+1. ``_select_profile()`` rejects an unregistered env-var value with a
+   ``ValueError`` that names the offender AND lists the allowed
+   profile names, so the failure message tells the caller exactly what
+   to fix.
+2. ``_select_profile()`` still accepts the two registered profile
+   names (``ci`` and ``dev``) without raising.
+3. When the env var is unset, ``_select_profile()`` returns the safe
+   ``ci`` default.
+
+Importing ``tests.contract.conftest`` from a unit test is a deliberate
+choice here: ``_select_profile`` is private to that module, and the
+module's side effects (two ``register_profile`` calls and one
+``load_profile`` call for ``ci``) are idempotent and don't leak into
+other unit tests — Hypothesis isn't exercised by the unit suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_select_profile_returns_ci_default_when_env_var_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``HYPOTHESIS_PROFILE`` must resolve to the safe ``ci`` default."""
+    from tests.contract.conftest import _select_profile
+
+    monkeypatch.delenv("HYPOTHESIS_PROFILE", raising=False)
+
+    assert _select_profile() == "ci"
+
+
+@pytest.mark.parametrize("profile_name", ["ci", "dev"])
+def test_select_profile_accepts_registered_profile_names(
+    monkeypatch: pytest.MonkeyPatch,
+    profile_name: str,
+) -> None:
+    """``HYPOTHESIS_PROFILE`` set to a registered name passes through unchanged."""
+    from tests.contract.conftest import _select_profile
+
+    monkeypatch.setenv("HYPOTHESIS_PROFILE", profile_name)
+
+    assert _select_profile() == profile_name
+
+
+def test_select_profile_rejects_unknown_env_var_with_helpful_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typoed ``HYPOTHESIS_PROFILE`` must raise ``ValueError`` listing allowed names.
+
+    Without the allow-list guard, ``hypothesis_settings.load_profile("cii")``
+    would raise ``InvalidArgument`` at conftest import time with a terse
+    Hypothesis-library message. The wrapper guard replaces that with a
+    ``ValueError`` whose message names the offending value AND every
+    registered profile, so bare ``--collect-only`` output tells the
+    caller both what broke and how to fix it.
+    """
+    from tests.contract.conftest import _select_profile
+
+    bogus = "cii"
+    monkeypatch.setenv("HYPOTHESIS_PROFILE", bogus)
+
+    # `match=bogus` pins the offending value into the message; the
+    # remaining per-component assertions below pin the allow-list names
+    # and the env-var name so a regression that keeps the exception
+    # type but drops guidance still fails this test.
+    with pytest.raises(ValueError, match=bogus) as exc_info:
+        _select_profile()
+
+    message = str(exc_info.value)
+    assert "ci" in message, "error message must list 'ci' as an allowed profile"
+    assert "dev" in message, "error message must list 'dev' as an allowed profile"
+    assert "HYPOTHESIS_PROFILE" in message, (
+        "error message must identify the env var so the caller knows where to look"
+    )

--- a/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
+++ b/apps/backend/tests/unit/meta/test_hypothesis_profile_selection.py
@@ -85,3 +85,31 @@ def test_select_profile_rejects_unknown_env_var_with_helpful_message(
     assert "HYPOTHESIS_PROFILE" in message, (
         "error message must identify the env var so the caller knows where to look"
     )
+
+
+def test_default_profile_is_still_active_is_false_after_ci_load() -> None:
+    """After the contract conftest loads ``ci``, the default-active probe must say ``False``.
+
+    This is the guard that makes the CLI flag ``--hypothesis-profile=<name>``
+    win over this conftest's own default-loading. If the Hypothesis pytest
+    plugin ran first (e.g. because the contract conftest is imported via
+    collection walk rather than as an "initial" conftest), the plugin
+    will have loaded a non-default profile and the fingerprint match
+    must report False so the conftest skips its own ``load_profile``
+    call.
+
+    The contract conftest is imported unconditionally at the top of this
+    module (via ``_select_profile``'s module-level import inside the
+    other tests), which triggers a ``load_profile("ci")`` side effect.
+    By the time this test runs, ``ci`` is active, so the probe must
+    return False — otherwise the guard would be a no-op and we'd be
+    back to racing the plugin.
+    """
+    from tests.contract.conftest import _default_profile_is_still_active
+
+    assert _default_profile_is_still_active() is False, (
+        "_default_profile_is_still_active() returned True after the contract "
+        "conftest loaded its 'ci' profile. The fingerprint check is broken — "
+        "see apps/backend/tests/contract/conftest.py _default_profile_is_still_active. "
+        "Issue #353."
+    )


### PR DESCRIPTION
## Summary

- Adds `apps/backend/tests/contract/conftest.py` registering two Hypothesis settings profiles: `ci` (`max_examples=50`, `deadline=5s`, `derandomize=True`) and `dev` (`max_examples=200`, default deadline, randomized). Active profile is selected by `--hypothesis-profile=` flag, `HYPOTHESIS_PROFILE` env var, or defaults to `ci` as the safest budget.
- Adds `apps/backend/tests/contract/test_hypothesis_profile_registered.py` meta-test pinning the invariant: both profiles must be registered, `ci` budget must be bounded (`max_examples<=100`) and derandomized, and a named profile must be actively loaded (not Hypothesis' builtin default).
- Closes #353. Rationale: the contract suite today is hand-rolled one-shot + `validate_response`, so zero Hypothesis examples run and the defaults (`max_examples=100`, `deadline=200ms`) never fire. The first future PR adding `@schema.parametrize` would silently inherit those defaults and flake on CI's noisier runner plus blow `task test:contract`'s 300s timeout.

## Test plan

- [x] `task check` green locally (946 unit / 97 integration / 24 contract / 60 error-contracts tests).
- [x] Meta-test fails BEFORE the conftest exists (verified TDD red).
- [x] Meta-test passes AFTER the conftest lands (verified green).
- [x] Pytest banner confirms profile load: `hypothesis profile 'ci' -> database=None, max_examples=50, derandomize=True, deadline=timedelta(milliseconds=5000)`.
- [x] Existing 24 contract tests still pass unchanged.

AI-assisted with Claude