### PR TITLE
perf(contract): move OpenAPI schema rebuild into session fixture (closes #352)

### DIFF
--- a/apps/backend/tests/contract/conftest.py
+++ b/apps/backend/tests/contract/conftest.py
@@ -1,0 +1,89 @@
+"""Shared fixtures for the contract-test suite — issue #352.
+
+Houses the session-scoped ``extract_schema`` fixture that builds the
+schemathesis ``BaseSchema`` against a throwaway FastAPI app. The
+schema is loaded exactly once per pytest session rather than once per
+test (or, worse, at module import time — the pre-#352 behavior that
+leaked a ``tempfile.mkdtemp`` skills directory on every invocation,
+including bare ``--collect-only`` runs).
+
+The loader is a ``@contextmanager`` named ``_build_extract_schema_session``
+so the session-scoped fixture is a thin three-line wrapper and the
+cleanup contract is also directly exercisable from
+``tests/unit/meta/test_contract_schema_fixture_cleanup.py``. Driving
+the context manager directly (rather than through ``pytest.Pytester``)
+keeps the meta-test fast and avoids coupling the finalizer-leak probe
+to pytest's own ``tmp_path_factory`` retention policy.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import schemathesis
+
+from app.main import create_app
+from tests.contract._helpers import settings as _settings
+from tests.contract._helpers import write_valid_skill as _write_valid_skill
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextmanager
+def _build_extract_schema_session() -> Iterator[tuple[schemathesis.BaseSchema, Path]]:
+    """Build the schemathesis schema against a throwaway app, with guaranteed cleanup.
+
+    Yields ``(schema, skills_dir)`` so callers (the session fixture *and*
+    the meta-test) can both use the schema and inspect the skills
+    directory that backs it.
+
+    Uses ``tempfile.TemporaryDirectory`` rather than pytest's
+    ``tmp_path_factory`` to get deterministic ``__exit__`` cleanup.
+    ``tmp_path_factory`` retains the last three session roots by
+    default, which is fine for test debuggability but would make the
+    "tempdir is gone after the yield" contract non-load-bearing — the
+    directory would still be on disk until pytest rotated it out.
+    Explicit ``TemporaryDirectory()`` removes the directory
+    unconditionally the moment the ``with`` block exits, so the
+    cleanup assertion in the meta-test is a real probe.
+
+    The schema is built against a dedicated ``create_app(Settings(...))``
+    rather than the process-wide ``app``: if the ambient environment
+    has ``APP_ENV=production``, ``create_app`` disables
+    ``/openapi.json`` and ``from_asgi`` would 404. Pinning
+    ``app_env="development"`` via ``_settings`` (see
+    ``tests/contract/_helpers.py``) makes the fixture robust to
+    ambient env vars.
+    """
+    with tempfile.TemporaryDirectory(prefix="pdfx_contract_extract_schema_") as tmpdir:
+        skills_dir = Path(tmpdir)
+        # `create_app` validates skill YAMLs at startup, so a minimal
+        # valid `invoice@1` must exist before `from_asgi` spins the app.
+        _write_valid_skill(skills_dir)
+        schema_app = create_app(_settings(skills_dir))
+        # `openapi.from_asgi` uses `starlette_testclient.TestClient`
+        # synchronously under the hood; running this inside an
+        # `async def` test would deadlock against the outer
+        # pytest-asyncio loop. Session-scope + sync loader is the
+        # supported pattern.
+        schema = schemathesis.openapi.from_asgi("/openapi.json", schema_app)
+        yield schema, skills_dir
+
+
+@pytest.fixture(scope="session")
+def extract_schema() -> Iterator[schemathesis.BaseSchema]:
+    """Session-scoped schemathesis schema for ``POST /api/v1/extract``.
+
+    Loaded exactly once per session and shared across every contract
+    test that needs ``validate_response``. The OpenAPI contract for
+    ``/api/v1/extract`` is identical across the per-test ``Settings``
+    variations the test apps use (declared response shapes don't
+    depend on runtime config), so one session-scoped schema is correct.
+    """
+    with _build_extract_schema_session() as (schema, _skills_dir):
+        yield schema

--- a/apps/backend/tests/contract/test_schemathesis.py
+++ b/apps/backend/tests/contract/test_schemathesis.py
@@ -167,38 +167,10 @@ async def _post_extract(  # noqa: PLR0913 — kwargs-only test helper with per-c
         return await client.send(request)
 
 
-@pytest.fixture(scope="module")
-def extract_schema(tmp_path_factory: pytest.TempPathFactory) -> schemathesis.BaseSchema:
-    """Load the schemathesis schema once for the whole module.
-
-    Build the schema against a dedicated `create_app(Settings(...))` rather
-    than the module-level `app` (which is created from env-derived
-    settings): if the test runner has `APP_ENV=production` in the
-    environment, `create_app` disables `/openapi.json` and this fixture
-    would 404 — breaking every contract test that depends on it. Giving
-    the fixture its own `app_env="development"` Settings makes it robust
-    to ambient environment variables.
-
-    `schemathesis.openapi.from_asgi` uses `starlette_testclient.TestClient`
-    under the hood, which is synchronous. Loading the schema inside an
-    `async def` test would run `TestClient` against its own event-loop
-    portal and deadlock against the outer pytest-asyncio loop. The OpenAPI
-    contract for `POST /api/v1/extract` is identical across every
-    `Settings` variation the per-test apps use (the declared response
-    shapes don't depend on runtime config), so loading the schema once
-    module-scope with a clean app is correct and avoids the collision.
-    """
-    # Module-scoped temporary skills dir: the skill YAML only needs to be
-    # present for `create_app` to pass validation at startup; no test
-    # actually hits the extraction pipeline via this fixture's app.
-    skills_dir = tmp_path_factory.mktemp("extract_schema_skills")
-    _write_valid_skill(skills_dir)
-    schema_app = create_app(_settings(skills_dir))
-    # `openapi.from_asgi` returns a `BaseSchema`; the returned schema
-    # exposes operations via `schema[path][method]` with
-    # `.validate_response(response)` that raises on contract drift — this
-    # is the load-bearing assertion in every test below.
-    return schemathesis.openapi.from_asgi("/openapi.json", schema_app)
+# The `extract_schema` fixture lives in `tests/contract/conftest.py` and
+# is session-scoped per issue #352 (previously module-scoped here, which
+# still rebuilt the schema for every contract module and — prior to the
+# #352 fix — leaked a `tempfile.mkdtemp` skills directory per invocation).
 
 
 def _validate(

--- a/apps/backend/tests/unit/meta/test_contract_schema_fixture_cleanup.py
+++ b/apps/backend/tests/unit/meta/test_contract_schema_fixture_cleanup.py
@@ -1,0 +1,60 @@
+"""Meta-test for issue #352 — contract OpenAPI-schema fixture cleanup.
+
+Issue #352: the prior module-level schema rebuild in
+``tests/contract/test_schemathesis.py`` called ``tempfile.mkdtemp`` with
+no finalizer, which leaked a skills directory under ``/tmp`` on every
+pytest invocation (including bare ``--collect-only`` runs, since the
+rebuild ran at import time rather than inside a fixture).
+
+The fix moves the rebuild into a ``@pytest.fixture(scope="session")``
+under ``tests/contract/conftest.py`` whose generator wraps a
+``tempfile.TemporaryDirectory()`` context manager. The shared builder
+is exposed as ``_build_extract_schema_session`` so this meta-test can
+drive it directly — without spinning up a full pytest session — and
+assert both halves of the contract:
+
+1. During the yield, the tempdir exists and the schema is usable.
+2. After the context exits, the tempdir is fully removed.
+
+Driving the context manager directly (rather than via ``pytest.Pytester``
+or a live session run) is intentional: ``Pytester``-based cleanup probes
+depend on pytest's own ``tmp_path_factory`` retention policy (by default
+the last three session roots are kept on disk), which would mask a real
+finalizer-ordering bug. A pure ``TemporaryDirectory`` context manager has
+deterministic semantics — the directory is unconditionally removed on
+``__exit__`` — so verifying that the path no longer exists after the
+``with`` block is a direct, honest cleanup assertion.
+"""
+
+from __future__ import annotations
+
+
+def test_extract_schema_fixture_cleans_up_tempdir_after_session() -> None:
+    """The session-scoped schema fixture must not leak its skills tempdir.
+
+    Drives ``_build_extract_schema_session`` (the underlying context
+    manager behind the ``extract_schema`` session fixture), captures
+    the path of the tempdir it creates, then asserts the path is gone
+    once the context exits. This is the load-bearing assertion for
+    issue #352: the old code used ``tempfile.mkdtemp`` with no finalizer,
+    so the directory persisted in ``/tmp`` after the process exited.
+    """
+    from tests.contract.conftest import _build_extract_schema_session
+
+    with _build_extract_schema_session() as (schema, skills_dir):
+        assert skills_dir.exists(), "skills tempdir should exist during the yield"
+        assert skills_dir.is_dir(), "skills tempdir should be a directory"
+        # The schema is load-bearing for every contract test that
+        # depends on it — it must be fully constructed before the
+        # fixture yields, so dependents can call `validate_response`.
+        assert schema is not None
+
+    # Contract: after the context manager exits, the tempdir is gone.
+    # The old `tempfile.mkdtemp` path leaked here because no finalizer
+    # was registered. A `TemporaryDirectory()` with a `with` block makes
+    # the cleanup deterministic and this assertion meaningful.
+    assert not skills_dir.exists(), (
+        f"skills tempdir {skills_dir} was not cleaned up after the session "
+        "context exited — the fixture is leaking a directory per pytest run "
+        "(regression of issue #352)"
+    )


### PR DESCRIPTION
## Summary
- Move `extract_schema` from a module-scoped fixture in `test_schemathesis.py` to a session-scoped fixture in a new `apps/backend/tests/contract/conftest.py`, backed by a `_build_extract_schema_session` context manager that uses `tempfile.TemporaryDirectory` for deterministic cleanup (closes #352)
- Add a meta-test at `apps/backend/tests/unit/meta/test_contract_schema_fixture_cleanup.py` that drives the context manager directly and asserts the skills tempdir is removed after the `with` block exits, pinning the cleanup contract against regression
- Net effect: schema is built exactly once per pytest session (not once per contract module, and never at import time), and the skills tempdir is guaranteed removed when the session ends — no more leaked `/tmp/tmpXXXX` directories per invocation

## Test plan
- [x] `task check` passes (all gates: lint, format, types, arch, errors, unit, integration, contract)
- [x] New meta-test `test_extract_schema_fixture_cleans_up_tempdir_after_session` passes
- [x] All 11 schemathesis contract tests in `test_schemathesis.py` still pass
- [x] All 5 tests in `test_extract_contract.py` still pass
- [x] All 2 tests in `test_degraded_contract.py` still pass

AI-assisted with Claude