### PR TITLE
test(conftest): FakeProbe raises AssertionError not pytest.fail (closes #396)

### DIFF
--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -8,6 +8,28 @@ from app.features.extraction.skills import Skill, SkillDoclingConfig, SkillExamp
 from app.features.extraction.skills.deep_freeze import deep_freeze_mapping
 
 
+class FakeProbeExhausted(BaseException):
+    """Raised by ``FakeProbe.check`` when scripted results are exhausted.
+
+    Subclasses ``BaseException`` — *not* ``Exception`` — deliberately.
+
+    Production code paths that consume ``probe.check()`` (``ProbeCache.is_ready``
+    and ``app.main._lifespan``) wrap the call in a broad ``except Exception``
+    so that any unexpected ``Exception`` subclass is degraded into a cached
+    ``False`` instead of propagating and turning ``/ready`` into a 500 (issue
+    #144). That guard is load-bearing for the ``/ready`` contract — but it
+    would silently swallow an ``AssertionError`` from an exhausted ``FakeProbe``,
+    converting a misconfigured test into a green ``False`` result instead of a
+    loud pytest failure.
+
+    Making the exhaustion signal a ``BaseException`` subclass means ``except
+    Exception`` does not match it (same reason ``asyncio.CancelledError`` isn't
+    caught by those guards on Python 3.8+), so the signal propagates all the
+    way up to pytest and the test fails at the offending ``await`` site with a
+    readable stack. (Issues #396 and the Copilot review on PR #483.)
+    """
+
+
 class FakeProbe:
     """Controllable probe returning scripted boolean results.
 
@@ -22,14 +44,18 @@ class FakeProbe:
 
     async def check(self) -> bool:
         if self.call_count >= len(self._results):
-            # Raise AssertionError rather than calling pytest.fail(): under
-            # pytest-asyncio's session-scoped event loop, pytest.fail()
-            # surfaces a Failed report on whichever async test consumed the
-            # probe, not the logically-wrong call site. A plain
-            # AssertionError propagates through the await and pytest reports
-            # the stack at the offending caller. (Issue #396.)
+            # Raise ``FakeProbeExhausted`` (a ``BaseException`` subclass) rather
+            # than ``AssertionError`` or ``pytest.fail``: production code wraps
+            # ``probe.check()`` in ``except Exception`` to degrade rather than
+            # crash on unexpected failures (issue #144). An ``AssertionError``
+            # would be caught by that guard and silently converted into a
+            # cached ``False``, turning a misconfigured test into a green
+            # result. ``FakeProbeExhausted`` bypasses ``except Exception`` the
+            # same way ``asyncio.CancelledError`` does, so the exhaustion
+            # signal surfaces at the offending ``await`` site. (Issue #396,
+            # Copilot review on PR #483.)
             msg = f"FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
-            raise AssertionError(msg)
+            raise FakeProbeExhausted(msg)
         result = self._results[self.call_count]
         self.call_count += 1
         return result

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from app.features.extraction.skills import Skill, SkillDoclingConfig, SkillExample
 from app.features.extraction.skills.deep_freeze import deep_freeze_mapping
 
@@ -24,9 +22,14 @@ class FakeProbe:
 
     async def check(self) -> bool:
         if self.call_count >= len(self._results):
-            pytest.fail(
-                f"FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
-            )
+            # Raise AssertionError rather than calling pytest.fail(): under
+            # pytest-asyncio's session-scoped event loop, pytest.fail()
+            # surfaces a Failed report on whichever async test consumed the
+            # probe, not the logically-wrong call site. A plain
+            # AssertionError propagates through the await and pytest reports
+            # the stack at the offending caller. (Issue #396.)
+            msg = f"FakeProbe.check called more times than scripted (call #{self.call_count + 1})"
+            raise AssertionError(msg)
         result = self._results[self.call_count]
         self.call_count += 1
         return result

--- a/apps/backend/tests/unit/meta/test_fakeprobe_exhaustion_propagates_through_probecache.py
+++ b/apps/backend/tests/unit/meta/test_fakeprobe_exhaustion_propagates_through_probecache.py
@@ -1,0 +1,75 @@
+"""Hygiene test: FakeProbe exhaustion propagates through production guards.
+
+Issue #396 / Copilot review on PR #483 round 2.
+
+Both ``ProbeCache.is_ready()`` and ``app.main._lifespan`` wrap
+``await probe.check()`` in a broad ``except Exception`` so that any
+unexpected ``Exception`` subclass degrades into a cached ``False``
+instead of escaping and turning ``/ready`` into a 500. That guard is
+load-bearing for the ``/ready`` contract across the full process
+lifetime (issue #144, ``probe_check_failed_on_refresh`` WARNING).
+
+It is *also* load-bearing that a misconfigured test — one where
+``FakeProbe`` is scripted with too few results for the code under test —
+fails loudly rather than silently being converted into a cached ``False``.
+A plain ``AssertionError`` from ``FakeProbe.check()`` would be caught by
+``except Exception`` and turned into ``False``, and the misconfiguration
+would ship as green.
+
+The fix: ``FakeProbe`` raises ``FakeProbeExhausted``, a ``BaseException``
+subclass that ``except Exception`` does not match (same reason
+``asyncio.CancelledError`` isn't caught by those guards on Python 3.8+).
+
+This test pins the no-silent-swallow invariant on the actual production
+code path. If ``FakeProbe`` ever regresses to raise an ``Exception``
+subclass (``AssertionError``, ``RuntimeError``, ``pytest.fail``, ...),
+``ProbeCache.is_ready()`` will silently return ``False`` and this test
+will fail with a clear message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.probe_cache import ProbeCache
+from tests.conftest import FakeProbe, FakeProbeExhausted
+
+
+async def test_probecache_does_not_swallow_fakeprobe_exhaustion() -> None:
+    # Empty script — the first ``is_ready()`` refresh call exhausts the probe
+    # on the very first ``check()`` invocation.
+    probe = FakeProbe(results=[])
+    cache = ProbeCache(probe=probe, ttl_seconds=60.0)  # type: ignore[arg-type]  # test seam
+
+    # ``ProbeCache.is_ready()`` wraps the probe call in ``except Exception``.
+    # If ``FakeProbe`` raises a plain ``Exception`` subclass (e.g. the old
+    # ``AssertionError`` behaviour), that guard silently converts it to
+    # cached ``False`` and ``is_ready()`` returns ``False`` with no exception
+    # propagating. The ``pytest.raises`` block would then fail with
+    # "DID NOT RAISE", catching the regression.
+    with pytest.raises(FakeProbeExhausted) as excinfo:
+        await cache.is_ready()
+
+    assert excinfo.type is FakeProbeExhausted
+    # The sentinel must remain outside the ``Exception`` hierarchy, otherwise
+    # the except-Exception guard in ``ProbeCache.is_ready()`` would match it
+    # and we would not have reached this ``pytest.raises`` block at all.
+    assert not isinstance(excinfo.value, Exception)
+    assert "FakeProbe.check called more times than scripted" in str(excinfo.value)
+
+
+async def test_probecache_still_degrades_real_exception_subclasses() -> None:
+    """Complement to the test above: ``except Exception`` must still degrade
+    genuine ``Exception`` subclasses. Without this invariant, the ``/ready``
+    500-vs-503 contract (issue #144) silently regresses."""
+
+    class _BadProbe:
+        async def check(self) -> bool:  # pragma: no cover - raises unconditionally
+            msg = "simulated production fault"
+            raise RuntimeError(msg)
+
+    cache = ProbeCache(probe=_BadProbe(), ttl_seconds=60.0)  # type: ignore[arg-type]  # test seam
+    # Must NOT raise — the production guard converts RuntimeError into a
+    # cached ``False`` so ``/ready`` stays on the documented 503 contract.
+    result = await cache.is_ready()
+    assert result is False

--- a/apps/backend/tests/unit/meta/test_fakeprobe_exhaustion_raises_assertion_error.py
+++ b/apps/backend/tests/unit/meta/test_fakeprobe_exhaustion_raises_assertion_error.py
@@ -1,0 +1,43 @@
+"""Hygiene test: ``FakeProbe.check`` must raise ``AssertionError`` on exhaustion.
+
+Issue #396: the shared ``FakeProbe`` in ``apps/backend/tests/conftest.py``
+originally called ``pytest.fail(...)`` when scripted results were exhausted.
+Under pytest-asyncio's session-scoped event loop, the resulting ``Failed``
+report surfaces on the async test that happened to consume the probe, not
+on the logically-wrong call site — the stack becomes opaque.
+
+Raising a plain ``AssertionError`` instead makes pytest report the stack
+at the offending ``await`` site, which is what you want when diagnosing a
+misconfigured probe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests.conftest import FakeProbe
+
+
+def test_fakeprobe_check_raises_assertion_error_when_exhausted() -> None:
+    probe = FakeProbe(results=[True])
+
+    # First call consumes the only scripted result — must succeed.
+    first = asyncio.run(probe.check())
+    assert first is True
+
+    # Second call exhausts the script. Must raise AssertionError (NOT
+    # pytest.outcomes.Failed) so the stack surfaces at the caller under
+    # pytest-asyncio's session-scoped loop propagation.
+    with pytest.raises(AssertionError) as excinfo:
+        asyncio.run(probe.check())
+
+    # Guard against silent regression to ``pytest.fail``, which raises a
+    # ``Failed`` exception that is NOT a subclass of ``AssertionError``.
+    assert type(excinfo.value) is AssertionError, (
+        f"Expected plain AssertionError, got {type(excinfo.value).__name__}. "
+        "If this is pytest.outcomes.Failed, #396 has regressed — FakeProbe "
+        "is calling pytest.fail(...) again."
+    )
+    assert "FakeProbe.check called more times than scripted" in str(excinfo.value)

--- a/apps/backend/tests/unit/meta/test_fakeprobe_exhaustion_raises_assertion_error.py
+++ b/apps/backend/tests/unit/meta/test_fakeprobe_exhaustion_raises_assertion_error.py
@@ -1,14 +1,32 @@
-"""Hygiene test: ``FakeProbe.check`` must raise ``AssertionError`` on exhaustion.
+"""Hygiene test: ``FakeProbe.check`` raises a ``BaseException`` sentinel on exhaustion.
 
-Issue #396: the shared ``FakeProbe`` in ``apps/backend/tests/conftest.py``
+Issue #396 (round 1): the shared ``FakeProbe`` in ``apps/backend/tests/conftest.py``
 originally called ``pytest.fail(...)`` when scripted results were exhausted.
 Under pytest-asyncio's session-scoped event loop, the resulting ``Failed``
-report surfaces on the async test that happened to consume the probe, not
-on the logically-wrong call site — the stack becomes opaque.
+report surfaced on the async test that happened to consume the probe, not
+on the logically-wrong call site — the stack became opaque.
 
-Raising a plain ``AssertionError`` instead makes pytest report the stack
-at the offending ``await`` site, which is what you want when diagnosing a
-misconfigured probe.
+Copilot review on PR #483 (round 2): switching to a plain ``AssertionError``
+fixed the stack-propagation issue but left a silent-swallow bug in place.
+Production code wraps ``probe.check()`` in a broad ``except Exception``
+inside ``ProbeCache.is_ready()`` and ``app.main._lifespan`` so that any
+unexpected ``Exception`` subclass degrades into a cached ``False`` instead
+of escaping and turning ``/ready`` into a 500 (issue #144). ``AssertionError``
+inherits from ``Exception``, so an exhausted ``FakeProbe`` inside a test
+that went through those guards would be converted into ``False`` and the
+misconfiguration would ship as green.
+
+The current contract — pinned here — is: ``FakeProbe`` raises
+``FakeProbeExhausted``, a ``BaseException`` subclass. ``except Exception``
+does not match it, the signal propagates, and the test fails loudly with
+the stack at the offending ``await`` site. A sibling meta test
+(``test_fakeprobe_exhaustion_propagates_through_probecache``) pins the
+no-silent-swallow invariant on the actual production path so that both
+halves of the contract are locked in.
+
+The filename preserves "raises_assertion_error" for git-blame continuity
+with the original #396 fix; the assertion below now pins the stricter
+``BaseException``-sentinel contract.
 """
 
 from __future__ import annotations
@@ -17,27 +35,40 @@ import asyncio
 
 import pytest
 
-from tests.conftest import FakeProbe
+from tests.conftest import FakeProbe, FakeProbeExhausted
 
 
-def test_fakeprobe_check_raises_assertion_error_when_exhausted() -> None:
+def test_fakeprobe_check_raises_exhaustion_sentinel_when_exhausted() -> None:
     probe = FakeProbe(results=[True])
 
     # First call consumes the only scripted result — must succeed.
     first = asyncio.run(probe.check())
     assert first is True
 
-    # Second call exhausts the script. Must raise AssertionError (NOT
-    # pytest.outcomes.Failed) so the stack surfaces at the caller under
-    # pytest-asyncio's session-scoped loop propagation.
-    with pytest.raises(AssertionError) as excinfo:
+    # Second call exhausts the script. Must raise ``FakeProbeExhausted``
+    # (NOT ``AssertionError``, NOT ``pytest.outcomes.Failed``) so the
+    # signal propagates through production ``except Exception`` guards.
+    with pytest.raises(FakeProbeExhausted) as excinfo:
         asyncio.run(probe.check())
 
-    # Guard against silent regression to ``pytest.fail``, which raises a
-    # ``Failed`` exception that is NOT a subclass of ``AssertionError``.
-    assert type(excinfo.value) is AssertionError, (
-        f"Expected plain AssertionError, got {type(excinfo.value).__name__}. "
-        "If this is pytest.outcomes.Failed, #396 has regressed — FakeProbe "
-        "is calling pytest.fail(...) again."
+    # Guard against silent regression to either of the older failure modes:
+    #   - ``pytest.fail`` → ``Failed`` (opaque stack under pytest-asyncio)
+    #   - plain ``AssertionError`` (swallowed by ``except Exception``)
+    # ``excinfo.type is FakeProbeExhausted`` is preferred over
+    # ``type(excinfo.value) is FakeProbeExhausted`` per ruff E721.
+    assert excinfo.type is FakeProbeExhausted, (
+        f"Expected FakeProbeExhausted, got {excinfo.type.__name__}. "
+        "If this is AssertionError or pytest.outcomes.Failed, the #483 "
+        "review fix has regressed — FakeProbe is no longer a BaseException-only "
+        "signal and ProbeCache's except-Exception guard will silently swallow "
+        "exhaustion again."
+    )
+    # The sentinel must remain outside the ``Exception`` hierarchy so that
+    # production ``except Exception`` blocks do not catch it. This is the
+    # load-bearing invariant the rename to ``BaseException`` was for.
+    assert not isinstance(excinfo.value, Exception), (
+        "FakeProbeExhausted must NOT be an Exception subclass; otherwise "
+        "ProbeCache.is_ready()'s except-Exception guard will silently swallow "
+        "exhaustion and convert a misconfigured test into a cached False."
     )
     assert "FakeProbe.check called more times than scripted" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Swap `pytest.fail(...)` for `raise AssertionError(...)` in FakeProbe.check exhaustion path
- Pytest now reports the stack at the offending await site under async-loop propagation

## Test plan
- [x] `task check` green
- [x] new test asserts AssertionError (not Failed) when scripted results are exhausted

Closes #396.