### PR TITLE
test(benchmark): tighten unreachable-host assertion (closes #406)

### DIFF
--- a/apps/backend/tests/integration/scripts/test_benchmark.py
+++ b/apps/backend/tests/integration/scripts/test_benchmark.py
@@ -277,7 +277,7 @@ def test_benchmark_unreachable_service_exits_nonzero(tmp_path: Path) -> None:
 
     assert code != 0
     assert elapsed < 30.0, f"benchmark hung for {elapsed:.1f}s"
-    assert "127.0.0.1" in err or "connect" in err.lower() or "error" in err.lower()
+    assert "127.0.0.1" in err, f"expected error message to name unreachable host: {err!r}"
 
 
 def test_benchmark_missing_fixtures_exits_nonzero(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Replaces the permissive `'127.0.0.1' in err or 'connect' in err.lower() or 'error' in err.lower()` assertion (which passed against any stderr containing the word "error") with `'127.0.0.1' in err` plus an f-string diagnostic that prints the actual error payload on failure. The `run_benchmark` connect-refusal path in `apps/backend/scripts/benchmark.py` embeds `config.url` (and therefore `127.0.0.1`) into the `ConnectionError` message that `main()` writes to stderr, so the host substring is reliably present.
- Test-only change; no production-code change.

## Test plan
- [x] `task check` green locally
- [ ] CI passes
- [ ] Copilot review threads resolved (if any)

Closes #406.