### PR TITLE
chore(github): disable blank issues via ISSUE_TEMPLATE/config.yml (closes #412)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+# GitHub Issue Template config.
+# blank_issues_enabled: false removes the "Open a blank issue" link at the bottom
+# of the template chooser, forcing all new issues through the structured templates
+# in this directory.
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false`, removing the "Open a blank issue" bypass beneath the template chooser.
- No new templates added in this PR — out of scope, follow-up can be a separate issue.

## Test plan
- [x] `yamllint` clean (pre-commit)
- [x] `task check` green locally
- [ ] CI passes
- [ ] Verify the "Open a blank issue" link is gone on the GitHub UI after merge

Closes #412.