### PR TITLE
fix(logging): preserve 32-char hex request_id in exception redaction

### DIFF
--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -49,6 +49,15 @@ _EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 _NUMERIC_PATTERN = re.compile(
     r"(?<!line )\b(?:\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?)\b"
 )
+# 32-char hex runs are request_id / uuid4().hex strings. They are load-bearing
+# for log correlation and must survive numeric redaction — a uuid4 whose hex
+# happens to be all 0-9 (e.g. ``uuid4().hex`` occasionally produces runs of
+# digits long enough that the standalone ``\d{4,}`` branch matches) would
+# otherwise be mangled to ``[REDACTED_NUMBER]``, defeating traceability. The
+# allowlist is applied by placeholder-substituting hex runs before the numeric
+# scrub, then restoring them after (issue #375).
+_HEX_REQUEST_ID_PATTERN = re.compile(r"\b[0-9a-fA-F]{32}\b")
+_HEX_PLACEHOLDER_TEMPLATE = "\x00HEX{index}\x00"
 
 
 class LogRedactionFilter:
@@ -105,7 +114,22 @@ class LogRedactionFilter:
 
     def _scrub_exception_string(self, value: str) -> str:
         scrubbed = _EMAIL_PATTERN.sub(_REDACTED_EMAIL, value)
-        return _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, scrubbed)
+        # Stash 32-char hex runs (request_id / uuid4().hex) behind opaque
+        # placeholders so the numeric scrub cannot mangle an all-digit uuid.
+        hex_runs: list[str] = []
+
+        def _stash(match: re.Match[str]) -> str:
+            hex_runs.append(match.group(0))
+            return _HEX_PLACEHOLDER_TEMPLATE.format(index=len(hex_runs) - 1)
+
+        stashed = _HEX_REQUEST_ID_PATTERN.sub(_stash, scrubbed)
+        numeric_scrubbed = _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, stashed)
+        # Restore every stashed hex run in place of its placeholder.
+        for index, original in enumerate(hex_runs):
+            numeric_scrubbed = numeric_scrubbed.replace(
+                _HEX_PLACEHOLDER_TEMPLATE.format(index=index), original
+            )
+        return numeric_scrubbed
 
     def _is_redacted_key(self, key: Any) -> bool:
         # Non-string keys cannot be case-folded and are not in the denylist.

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -293,3 +293,53 @@ def test_exception_key_still_redacts_long_numbers_not_after_line_keyword() -> No
     out = _call(_filter(), event="unhandled_exception", exception=traceback)
     assert "987654321" not in out["exception"]
     assert "4321" not in out["exception"]
+
+
+@pytest.mark.parametrize(
+    "request_id",
+    [
+        # Mixed hex — embedded digit runs already survive via word boundaries.
+        "a1b2c3d40000abcd000000001234567890abcdef1",  # >32 chars mixed
+        "abcdef0123456789abcdef0123456789",  # 32 hex, alpha-leading
+        # Pure-digit 32-char request_id: uuid4().hex can produce all-digit runs
+        # across the full 32-char window; without the hex allowlist the current
+        # numeric pattern would mangle it because word boundaries fire at the
+        # non-hex neighbours of the whole run.
+        "12345678901234567890123456789012",
+        # Digit-leading 32-char hex mix — survives via word boundaries but
+        # pinned here to guard against future regex tightening.
+        "12345678abcdef0123456789abcdef01",
+    ],
+)
+def test_exception_key_preserves_32char_hex_request_id(request_id: str) -> None:
+    """Issue #375: 32-char hex request_id strings survive exception redaction.
+
+    `request_id` is a `uuid4().hex` — 32 hex chars — and is load-bearing for
+    log correlation. A forbidden `logger.error(f"failed for {request_id}")`
+    call (CLAUDE.md forbids f-string log messages, but a reviewer might miss
+    one) would leak the id into the rendered exception string. The numeric
+    pattern must not mangle the id — otherwise correlation breaks silently.
+    """
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: failed for request_id={request_id}"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+
+
+def test_exception_key_preserves_hex_but_still_scrubs_nearby_numeric_pii() -> None:
+    """Hex allowlist must not swallow adjacent numeric PII in the same message."""
+    request_id = "12345678901234567890123456789012"
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: request_id={request_id} total was 1847.50 dollars"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    # Hex run is preserved verbatim.
+    assert request_id in out["exception"]
+    # Standalone monetary amount is still scrubbed.
+    assert "1847.50" not in out["exception"]
+    assert "1847" not in out["exception"]


### PR DESCRIPTION
## Summary

- Pure-digit `uuid4().hex` request_ids were being mangled by the `\b\d{4,}\b` scrubber in `_scrub_exception_string`, silently breaking log correlation for any forbidden `logger.error(f"... {request_id}")` call that leaks into a rendered traceback.
- Stash 32-char hex runs behind opaque placeholders before numeric scrubbing and restore them afterwards, so request_ids always survive verbatim while standalone numeric PII still gets redacted.
- Five new pinning tests: four parametrized 32-char hex cases (mixed, alpha-leading, all-digit, digit-leading) plus an adjacent-PII guard that confirms the allowlist does not swallow nearby monetary amounts.

Closes #375

## Test plan

- [x] `uv run pytest apps/backend/tests/unit/core/test_log_redaction_filter.py` — 55 passed (50 pre-existing + 5 new)
- [x] `task check` from `apps/backend/` — all gates green (lint, format, pyright strict, import-linter, unit, integration, contract, error-contracts)
- [x] New failing tests confirmed red before implementation (pure-digit uuid case and adjacent-PII guard)

AI-assisted with Claude.