### PR TITLE
fix(api): rename errors.py logger to _logger for paradigm consistency (closes #368)

### DIFF
--- a/apps/backend/app/api/errors.py
+++ b/apps/backend/app/api/errors.py
@@ -11,7 +11,7 @@ from app.exceptions import InternalError, ValidationFailedError
 from app.exceptions.base import DomainError
 from app.schemas import ErrorBody, ErrorResponse
 
-logger = structlog.get_logger(__name__)
+_logger = structlog.get_logger(__name__)
 
 
 def _get_request_id(request: Request) -> str:
@@ -42,7 +42,7 @@ def register_exception_handlers(app: FastAPI) -> None:
         # without paging and omits the traceback.
         http_5xx_floor = 500
         if exc.http_status >= http_5xx_floor:
-            logger.warning(
+            _logger.warning(
                 "domain_error",
                 code=exc.code,
                 http_status=exc.http_status,
@@ -50,7 +50,7 @@ def register_exception_handlers(app: FastAPI) -> None:
                 exc_info=True,  # noqa: LOG014 — this function IS a FastAPI exception handler
             )
         else:
-            logger.info(
+            _logger.info(
                 "domain_error",
                 code=exc.code,
                 http_status=exc.http_status,
@@ -92,7 +92,7 @@ def register_exception_handlers(app: FastAPI) -> None:
         # the bug is visible and actionable instead of silently masked.
         if not errors:
             # ``InternalError`` is parameterless (see ``errors.yaml``); the
-            # anomaly context is emitted via the structured ``logger.warning``
+            # anomaly context is emitted via the structured ``_logger.warning``
             # call in ``handle_domain_error`` (code, http_status, request_id,
             # exc_info) which gives on-call responders the traceback. Adding
             # a log line here would duplicate the observability event.
@@ -135,7 +135,7 @@ def register_exception_handlers(app: FastAPI) -> None:
         exc: Exception,
     ) -> JSONResponse:
         request_id = _get_request_id(request)
-        logger.exception(
+        _logger.exception(
             "unhandled_exception",
             request_id=request_id,
             exc_type=type(exc).__name__,

--- a/apps/backend/tests/unit/architecture/test_errors_module_private_logger.py
+++ b/apps/backend/tests/unit/architecture/test_errors_module_private_logger.py
@@ -1,0 +1,97 @@
+"""Architecture gate: `app/api/errors.py` binds the module logger as `_logger`, not `logger`.
+
+Sacred Rule #3 (no paradigm drift) in CLAUDE.md requires one way to do each
+thing. Every other module in the backend binds its structlog logger as a
+private `_logger` symbol (see `access_log_middleware.py`,
+`probe_cache.py`, `upload_size_limit_middleware.py`, `main.py`). Issue #368
+identified `app/api/errors.py` as the lone outlier: it used a public
+`logger` binding, which invites other modules to `from app.api.errors
+import logger` and spreads the module-logger pattern beyond its owner.
+
+This test pins the invariant by AST-scanning `errors.py` for module-level
+`Assign` / `AnnAssign` nodes and asserting no target is named `logger`. A
+future refactor that reintroduces the public form (or forgets to rename
+the binding after copy-pasting from a feature slice) fails this test
+deterministically — a substring grep on the file would also match
+docstrings / comments that merely *mention* the name, hence the AST walk.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+from ._linter_subprocess import BACKEND_DIR
+
+_ERRORS_MODULE: Final[Path] = BACKEND_DIR / "app" / "api" / "errors.py"
+
+
+def _module_level_assign_targets(tree: ast.Module) -> list[str]:
+    """Return every name bound at module scope by `Assign` / `AnnAssign` nodes.
+
+    Walks only the immediate body of the module — nested scopes (function
+    bodies, class bodies, `if TYPE_CHECKING:` blocks, etc.) are intentionally
+    skipped so that a local `logger = ...` inside a helper never accidentally
+    masks the real top-level check. Tuple-unpacking targets (`a, b = ...`) are
+    flattened so each bound name is surfaced independently.
+    """
+    names: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                names.extend(_names_in_target(target))
+        elif isinstance(node, ast.AnnAssign):
+            names.extend(_names_in_target(node.target))
+    return names
+
+
+def _names_in_target(target: ast.expr) -> list[str]:
+    """Flatten a single assignment target into the concrete names it binds.
+
+    Handles three shapes: plain `Name` (`x = ...`), `Tuple` / `List`
+    destructuring (`a, b = ...`), and nested combinations thereof. Non-name
+    targets (`self.x = ...`, `d[k] = ...`) contribute no module-level name
+    and are skipped.
+    """
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Tuple | ast.List):
+        out: list[str] = []
+        for elt in target.elts:
+            out.extend(_names_in_target(elt))
+        return out
+    return []
+
+
+def test_errors_module_does_not_define_public_logger() -> None:
+    """`app/api/errors.py` must not bind a public top-level `logger` symbol.
+
+    CLAUDE.md Sacred Rule #3 forbids paradigm drift. Every other backend
+    module uses `_logger = structlog.get_logger(__name__)`. `errors.py`
+    must follow the same convention; the public form invites cross-module
+    imports of a symbol that should be private to its defining module.
+    """
+    tree = ast.parse(_ERRORS_MODULE.read_text(encoding="utf-8"), filename=str(_ERRORS_MODULE))
+    top_level_names = _module_level_assign_targets(tree)
+    assert "logger" not in top_level_names, (
+        f"{_ERRORS_MODULE} binds a public `logger` at module scope, "
+        "breaking Sacred Rule #3 (no paradigm drift). Rename to `_logger` "
+        "to match every other backend module (issue #368)."
+    )
+
+
+def test_errors_module_defines_private_logger() -> None:
+    """Sanity check: `_logger` is the actual binding that replaced the public form.
+
+    Guards against an accidental total deletion of the module logger (the
+    "fix" shouldn't remove the log calls, just rename the binding). If this
+    assertion fails, the rename drifted into a deletion.
+    """
+    tree = ast.parse(_ERRORS_MODULE.read_text(encoding="utf-8"), filename=str(_ERRORS_MODULE))
+    top_level_names = _module_level_assign_targets(tree)
+    assert "_logger" in top_level_names, (
+        f"{_ERRORS_MODULE} must bind the module logger as `_logger` at "
+        "module scope. If the rename was intentional to a different name, "
+        "update this test accordingly."
+    )

--- a/apps/backend/tests/unit/exceptions/test_error_handler.py
+++ b/apps/backend/tests/unit/exceptions/test_error_handler.py
@@ -212,7 +212,7 @@ def test_handle_validation_error_empty_errors_logs_traceback(
     must fire with ``exc_info=True`` so the framework-level anomaly is
     actionable rather than silently masked.
     """
-    with patch.object(errors_module, "logger") as mock_logger:
+    with patch.object(errors_module, "_logger") as mock_logger:
         response = test_client.get("/trigger-empty-validation-error")
 
     assert response.status_code == InternalError.http_status
@@ -232,7 +232,7 @@ async def test_handle_validation_error_empty_errors_chains_original_cause() -> N
     and leaves ``__cause__`` as ``None``. Aggregators and debuggers that
     walk ``__cause__`` to reconstruct the "caused by" line therefore lose
     the original ``RequestValidationError`` entirely, even though
-    ``logger.warning(..., exc_info=True)`` in ``handle_domain_error``
+    ``_logger.warning(..., exc_info=True)`` in ``handle_domain_error``
     prints an ``exc_info`` block -- because ``exc_info`` captures the
     ``InternalError`` currently being raised, not the original. The fix
     is ``raise InternalError from exc`` so ``__cause__`` carries the
@@ -379,12 +379,12 @@ def test_handle_domain_error_emits_warning_with_exc_info_for_5xx(
     line with no code, no params, no traceback. Observers had to
     correlate the request_id against the exception's origin by hand.
 
-    Spies directly on ``errors_module.logger`` because
+    Spies directly on ``errors_module._logger`` because
     ``structlog.testing.capture_logs`` depends on structlog's own processor
     chain and is bypassed when earlier tests in the suite reroute structlog
     through stdlib logging.
     """
-    with patch.object(errors_module, "logger") as mock_logger:
+    with patch.object(errors_module, "_logger") as mock_logger:
         response = test_client.get("/trigger-5xx-domain-error")
 
     assert response.status_code == InternalError.http_status
@@ -407,7 +407,7 @@ def test_handle_domain_error_emits_info_for_4xx(test_client: TestClient) -> None
     high-volume by design. Info level keeps them visible in aggregation
     without paging, and ``exc_info`` is omitted to avoid noise in logs.
     """
-    with patch.object(errors_module, "logger") as mock_logger:
+    with patch.object(errors_module, "_logger") as mock_logger:
         response = test_client.get("/trigger-domain-error")
 
     assert response.status_code == 404  # NotFoundError
@@ -501,7 +501,7 @@ def test_handle_domain_error_logs_warning_for_each_named_5xx_subclass(
 
     client = TestClient(app, raise_server_exceptions=False)
 
-    with patch.object(errors_module, "logger") as mock_logger:
+    with patch.object(errors_module, "_logger") as mock_logger:
         response = client.get("/boom")
 
     assert response.status_code == error_cls.http_status, (


### PR DESCRIPTION
## Summary

Every other backend module (`access_log_middleware.py`, `probe_cache.py`, `upload_size_limit_middleware.py`, `main.py`) binds its structlog logger as a private `_logger`. `app/api/errors.py` was the lone outlier — Sacred Rule #3 (no paradigm drift) forbids this. Renames the module-scope binding and all three call sites (5xx warning, 4xx info, unhandled `exception.exception`), updates the four `patch.object(errors_module, "logger")` spies in `test_error_handler.py`, and pins the invariant with a new AST-based architecture test at `apps/backend/tests/unit/architecture/test_errors_module_private_logger.py` so a future regression fails deterministically.

Closes #368

## Test plan

- [x] New arch test fails in the red state (before rename), passes after
- [x] `task check` green end-to-end locally (lint, format, pyright, import-linter, skills, unit, integration, contract, errors)
- [x] Unit tests: 1063 passed
- [x] Integration tests: 102 passed
- [x] Contract tests: 25 passed
- [x] Error-contract tests: 65 passed
- [ ] CI mirrors the local green state

AI-assisted with Claude.