### PR TITLE
docs(reshape-plan): add Historical banner and reconcile new-project-setup disposition

### DIFF
--- a/apps/backend/tests/unit/architecture/test_historical_docs_banner.py
+++ b/apps/backend/tests/unit/architecture/test_historical_docs_banner.py
@@ -1,0 +1,49 @@
+"""Hygiene check: allowlisted historical docs must carry the canonical banner.
+
+Issue #414 observed that a new contributor browsing ``docs/*.md``
+alphabetically cannot distinguish current operational guidance from
+historical artifacts unless each historical document explicitly
+self-declares its status. ``docs/bootstrap-decisions.md`` set the
+precedent with a ``> **Document status: Historical**`` blockquote
+directly under the title; ``docs/reshape-plan.md`` was brought into
+line by #414.
+
+This meta-test pins the banner on the small allowlist below so a future
+edit cannot silently strip the marker and re-introduce the "looks
+current, is actually historical" ambiguity. It deliberately checks only
+the exact, byte-for-byte phrase — anything softer (e.g. "Status:
+Historical" without the ``Document`` prefix) would split the convention
+into two near-duplicates, which is itself a paradigm-drift hazard under
+CLAUDE.md Sacred Rule 3.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+from ._linter_subprocess import REPO_ROOT
+
+_DOCS_DIR: Final[Path] = REPO_ROOT / "docs"
+_BANNER_MARKER: Final[str] = "> **Document status: Historical**"
+_HISTORICAL_DOCS: Final[frozenset[str]] = frozenset(
+    {
+        "bootstrap-decisions.md",
+        "reshape-plan.md",
+    }
+)
+
+
+def test_historical_docs_carry_canonical_banner() -> None:
+    """Every allowlisted historical doc must contain the exact banner marker."""
+    missing: list[str] = []
+    for filename in sorted(_HISTORICAL_DOCS):
+        doc_path = _DOCS_DIR / filename
+        assert doc_path.is_file(), f"expected historical doc at {doc_path}"
+        text = doc_path.read_text(encoding="utf-8")
+        if _BANNER_MARKER not in text:
+            missing.append(filename)
+    assert not missing, (
+        f"historical doc(s) {missing} must carry the exact banner "
+        f"{_BANNER_MARKER!r} directly under the title (see issue #414)"
+    )

--- a/docs/reshape-plan.md
+++ b/docs/reshape-plan.md
@@ -1,6 +1,6 @@
 # Reshape Plan
 
-> **Status: Historical** — this document captures the plan from the template-reshape phase
+> **Document status: Historical** — this document captures the plan from the template-reshape phase
 > of the project. It is preserved for context and traceability but is not
 > current operational guidance. For current architecture, see
 > [docs/architecture.md](./architecture.md).
@@ -167,7 +167,7 @@ Angular 21, standalone components. One feature (example page), one shared compon
 | `docs/database-model.md` | **Delete, rewrite** | Claims SQLAlchemy in use |
 | `docs/development.md` | **Delete, rewrite** | Angular-centric, references deleted `.ai/` |
 | `docs/domain-model.md` | **Delete, rewrite** | References ExampleModule |
-| `docs/new-project-setup.md` | **Delete, rewrite** | References `.ai/`, wrong tooling |
+| `docs/new-project-setup.md` | **Superseded: kept as live documentation, cited by automerge.md and CLAUDE.md.** (Original recommendation was "Delete, rewrite" for referencing `.ai/` and wrong tooling; that recommendation was not taken — the file was retained and revised in place instead.) |
 | `docs/project-structure.md` | **Delete, rewrite** | Lists `.ai/` that doesn't exist |
 | `CONTRIBUTING.md` | **Delete, rewrite** | References `.ai/` |
 | `README.md` | **Delete, rewrite** | Angular-centric |


### PR DESCRIPTION
## Summary

- Normalises the status header in `docs/reshape-plan.md` from `> **Status: Historical**` to the byte-identical `> **Document status: Historical**` form used by `docs/bootstrap-decisions.md`, so a new contributor browsing `docs/*.md` alphabetically can immediately tell historical artefacts apart from current operational guidance.
- Updates the `docs/new-project-setup.md` row in the 2.6 Documentation Audit table from "Delete, rewrite" to a one-line "Superseded: kept as live documentation, cited by automerge.md and CLAUDE.md." The edit is made in-place inside the (now historical) reshape-plan.md so the historical record reflects that the original recommendation was not taken.
- Adds a meta-test at `apps/backend/tests/unit/architecture/test_historical_docs_banner.py` asserting every allowlisted historical doc carries the exact `> **Document status: Historical**` marker, so a future edit cannot silently strip it.

**Scope note:** `new-project-setup.md` is kept as live documentation; the only narrative change is the in-place note inside `reshape-plan.md` marking its prior "Delete, rewrite" recommendation as superseded. `new-project-setup.md` itself is not rewritten here (out of scope).

Closes #414.

## Test plan

- [x] `task check` passes locally (all gates green, including the new meta-test).
- [x] `docs/bootstrap-decisions.md` and `docs/reshape-plan.md` both contain the canonical banner (verified by the new test).
- [x] `new-project-setup.md` is unchanged on disk and still referenced correctly by `CLAUDE.md`, `docs/automerge.md`, `.github/workflows/*`, and backend module docstrings.

AI-assisted with Claude.