### PR TITLE
fix(logging): preserve 32-char hex request_id in exception redaction

### DIFF
--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -49,6 +49,15 @@ _EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 _NUMERIC_PATTERN = re.compile(
     r"(?<!line )\b(?:\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?)\b"
 )
+# 32-char hex runs are request_id / uuid4().hex strings. They are load-bearing
+# for log correlation and must survive numeric redaction — a uuid4 whose hex
+# happens to be all 0-9 (e.g. ``uuid4().hex`` occasionally produces runs of
+# digits long enough that the standalone ``\d{4,}`` branch matches) would
+# otherwise be mangled to ``[REDACTED_NUMBER]``, defeating traceability. The
+# allowlist is applied by placeholder-substituting hex runs before the numeric
+# scrub, then restoring them after (issue #375).
+_HEX_REQUEST_ID_PATTERN = re.compile(r"\b[0-9a-fA-F]{32}\b")
+_HEX_PLACEHOLDER_TEMPLATE = "\x00HEX{index}\x00"
 
 
 class LogRedactionFilter:
@@ -105,7 +114,22 @@ class LogRedactionFilter:
 
     def _scrub_exception_string(self, value: str) -> str:
         scrubbed = _EMAIL_PATTERN.sub(_REDACTED_EMAIL, value)
-        return _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, scrubbed)
+        # Stash 32-char hex runs (request_id / uuid4().hex) behind opaque
+        # placeholders so the numeric scrub cannot mangle an all-digit uuid.
+        hex_runs: list[str] = []
+
+        def _stash(match: re.Match[str]) -> str:
+            hex_runs.append(match.group(0))
+            return _HEX_PLACEHOLDER_TEMPLATE.format(index=len(hex_runs) - 1)
+
+        stashed = _HEX_REQUEST_ID_PATTERN.sub(_stash, scrubbed)
+        numeric_scrubbed = _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, stashed)
+        # Restore every stashed hex run in place of its placeholder.
+        for index, original in enumerate(hex_runs):
+            numeric_scrubbed = numeric_scrubbed.replace(
+                _HEX_PLACEHOLDER_TEMPLATE.format(index=index), original
+            )
+        return numeric_scrubbed
 
     def _is_redacted_key(self, key: Any) -> bool:
         # Non-string keys cannot be case-folded and are not in the denylist.

--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -56,7 +56,21 @@ _NUMERIC_PATTERN = re.compile(
 # otherwise be mangled to ``[REDACTED_NUMBER]``, defeating traceability. The
 # allowlist is applied by placeholder-substituting hex runs before the numeric
 # scrub, then restoring them after (issue #375).
-_HEX_REQUEST_ID_PATTERN = re.compile(r"\b[0-9a-fA-F]{32}\b")
+#
+# The pattern is *prefix-restricted* to contexts that strongly indicate a
+# request id: ``request_id=``, ``request-id=``, and the ``X-Request-Id:``
+# header form (with or without the trailing space). A bare 32-char run that
+# happens to be all hex is deliberately NOT allowlisted — otherwise a 32-digit
+# numeric identifier (e.g. an account number) appearing free-standing in an
+# exception string would escape the numeric scrub (PR #509 review, Copilot).
+# The ``re.IGNORECASE`` flag makes every prefix case-insensitive, so
+# ``Request_Id=``, ``X-REQUEST-ID:``, etc. all work. Variable-width lookbehind
+# across the alternation is supported on Python >=3.7.
+_HEX_REQUEST_ID_PATTERN = re.compile(
+    r"(?:(?<=request_id=)|(?<=request-id=)|(?<=x-request-id: )|(?<=x-request-id:))"
+    r"[0-9a-fA-F]{32}\b",
+    re.IGNORECASE,
+)
 _HEX_PLACEHOLDER_TEMPLATE = "\x00HEX{index}\x00"
 
 

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -370,13 +370,19 @@ def test_bare_32_digit_numeric_identifier_is_still_redacted() -> None:
     assert _REDACTED_NUMBER in out["exception"]
 
 
-def test_request_id_equals_hex_survives_redaction() -> None:
-    """``request_id=<hex>`` context preserves the id through redaction."""
-    request_id = "12345678901234567890123456789012"
+def test_exception_key_preserves_32char_hex_request_id_with_hyphenated_prefix() -> None:
+    """The ``request-id=`` (hyphen) prefix also preserves 32-char hex ids.
+
+    The allowlist pattern accepts both ``request_id=`` (underscore) and
+    ``request-id=`` (hyphen) forms, but the main parametrized test above
+    only exercises the underscore form. Pin the hyphenated variant so it
+    can't regress when the regex is adjusted (PR #509 review).
+    """
+    request_id = "abcdef0123456789abcdef0123456789"
     traceback = (
         "Traceback (most recent call last):\n"
         '  File "<string>", line 1, in <module>\n'
-        f"ValueError: failed for request_id={request_id}"
+        f"ValueError: failed for request-id={request_id}"
     )
     out = _call(_filter(), event="unhandled_exception", exception=traceback)
     assert request_id in out["exception"]

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from app.core.log_redaction_filter import LogRedactionFilter
+from app.core.log_redaction_filter import _REDACTED_NUMBER, LogRedactionFilter
 
 DEFAULT_DENYLIST = ["pdf_bytes", "raw_output", "extracted_value", "prompt", "field_values"]
 
@@ -298,16 +298,13 @@ def test_exception_key_still_redacts_long_numbers_not_after_line_keyword() -> No
 @pytest.mark.parametrize(
     "request_id",
     [
-        # Mixed hex — embedded digit runs already survive via word boundaries.
-        "a1b2c3d40000abcd000000001234567890abcdef1",  # >32 chars mixed
         "abcdef0123456789abcdef0123456789",  # 32 hex, alpha-leading
         # Pure-digit 32-char request_id: uuid4().hex can produce all-digit runs
-        # across the full 32-char window; without the hex allowlist the current
-        # numeric pattern would mangle it because word boundaries fire at the
-        # non-hex neighbours of the whole run.
+        # across the full 32-char window; without the hex allowlist the numeric
+        # pattern would mangle it because word boundaries fire at the non-hex
+        # neighbours (``request_id=`` prefix) of the whole run.
         "12345678901234567890123456789012",
-        # Digit-leading 32-char hex mix — survives via word boundaries but
-        # pinned here to guard against future regex tightening.
+        # Digit-leading 32-char hex mix — the allowlist must cover this shape.
         "12345678abcdef0123456789abcdef01",
     ],
 )
@@ -319,11 +316,93 @@ def test_exception_key_preserves_32char_hex_request_id(request_id: str) -> None:
     call (CLAUDE.md forbids f-string log messages, but a reviewer might miss
     one) would leak the id into the rendered exception string. The numeric
     pattern must not mangle the id — otherwise correlation breaks silently.
+
+    The allowlist is prefix-restricted (``request_id=``) so the id is only
+    preserved when the context textually marks it as a request id — a bare
+    32-digit identifier is NOT allowlisted and is scrubbed as numeric PII
+    (see ``test_bare_32_digit_numeric_identifier_is_still_redacted``).
     """
     traceback = (
         "Traceback (most recent call last):\n"
         '  File "<string>", line 1, in <module>\n'
         f"ValueError: failed for request_id={request_id}"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+
+
+def test_exception_key_preserves_long_mixed_hex_request_id() -> None:
+    """A >32-char mixed hex id in a ``request_id=`` context survives redaction.
+
+    The ``>32 chars`` value doesn't match the 32-char allowlist pattern (the
+    trailing ``\\b`` fails inside an unbroken hex run), but it also doesn't
+    match the numeric pattern (digit subruns have no word-boundary neighbours
+    inside a long hex sequence). It therefore passes the scrubber verbatim.
+    Pinned in its own test so the name/intent don't drift (PR #509 review).
+    """
+    request_id = "a1b2c3d40000abcd000000001234567890abcdef1"  # 41 chars mixed
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: failed for request_id={request_id}"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+
+
+def test_bare_32_digit_numeric_identifier_is_still_redacted() -> None:
+    """A 32-digit numeric id free-standing in an exception is scrubbed.
+
+    Copilot's PR #509 review flagged the broad ``\\b[0-9a-fA-F]{32}\\b``
+    allowlist as a potential PII leak: a 32-digit account/identifier in an
+    exception string would have been preserved verbatim. The narrowed
+    allowlist requires a ``request_id=`` / ``x-request-id:`` prefix, so a
+    bare 32-digit run falls back to the numeric scrub and is redacted.
+    """
+    account = "12345678901234567890123456789012"  # 32 digits, no prefix
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: account {account} has overdraft"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert account not in out["exception"]
+    assert _REDACTED_NUMBER in out["exception"]
+
+
+def test_request_id_equals_hex_survives_redaction() -> None:
+    """``request_id=<hex>`` context preserves the id through redaction."""
+    request_id = "12345678901234567890123456789012"
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: failed for request_id={request_id}"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "X-Request-Id: ",
+        "X-Request-Id:",
+        "x-request-id: ",
+        "X-REQUEST-ID: ",
+    ],
+)
+def test_x_request_id_header_hex_survives_redaction(prefix: str) -> None:
+    """The ``X-Request-Id:`` header form preserves the id case-insensitively.
+
+    Exception messages may embed an HTTP header line; the allowlist pattern
+    covers the header prefix (with or without trailing space) under
+    ``re.IGNORECASE`` so any casing of the header name is recognised.
+    """
+    request_id = "12345678901234567890123456789012"
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: upstream returned header {prefix}{request_id}"
     )
     out = _call(_filter(), event="unhandled_exception", exception=traceback)
     assert request_id in out["exception"]

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -293,3 +293,53 @@ def test_exception_key_still_redacts_long_numbers_not_after_line_keyword() -> No
     out = _call(_filter(), event="unhandled_exception", exception=traceback)
     assert "987654321" not in out["exception"]
     assert "4321" not in out["exception"]
+
+
+@pytest.mark.parametrize(
+    "request_id",
+    [
+        # Mixed hex — embedded digit runs already survive via word boundaries.
+        "a1b2c3d40000abcd000000001234567890abcdef1",  # >32 chars mixed
+        "abcdef0123456789abcdef0123456789",  # 32 hex, alpha-leading
+        # Pure-digit 32-char request_id: uuid4().hex can produce all-digit runs
+        # across the full 32-char window; without the hex allowlist the current
+        # numeric pattern would mangle it because word boundaries fire at the
+        # non-hex neighbours of the whole run.
+        "12345678901234567890123456789012",
+        # Digit-leading 32-char hex mix — survives via word boundaries but
+        # pinned here to guard against future regex tightening.
+        "12345678abcdef0123456789abcdef01",
+    ],
+)
+def test_exception_key_preserves_32char_hex_request_id(request_id: str) -> None:
+    """Issue #375: 32-char hex request_id strings survive exception redaction.
+
+    `request_id` is a `uuid4().hex` — 32 hex chars — and is load-bearing for
+    log correlation. A forbidden `logger.error(f"failed for {request_id}")`
+    call (CLAUDE.md forbids f-string log messages, but a reviewer might miss
+    one) would leak the id into the rendered exception string. The numeric
+    pattern must not mangle the id — otherwise correlation breaks silently.
+    """
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: failed for request_id={request_id}"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+
+
+def test_exception_key_preserves_hex_but_still_scrubs_nearby_numeric_pii() -> None:
+    """Hex allowlist must not swallow adjacent numeric PII in the same message."""
+    request_id = "12345678901234567890123456789012"
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"ValueError: request_id={request_id} total was 1847.50 dollars"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    # Hex run is preserved verbatim.
+    assert request_id in out["exception"]
+    # Standalone monetary amount is still scrubbed.
+    assert "1847.50" not in out["exception"]
+    assert "1847" not in out["exception"]


### PR DESCRIPTION
## Summary

- Pure-digit `uuid4().hex` request_ids were being mangled by the `\b\d{4,}\b` scrubber in `_scrub_exception_string`, silently breaking log correlation for any forbidden `logger.error(f"... {request_id}")` call that leaks into a rendered traceback.
- Stash 32-char hex runs behind opaque placeholders before numeric scrubbing and restore them afterwards, so request_ids always survive verbatim while standalone numeric PII still gets redacted.
- Five new pinning tests: four parametrized 32-char hex cases (mixed, alpha-leading, all-digit, digit-leading) plus an adjacent-PII guard that confirms the allowlist does not swallow nearby monetary amounts.

Closes #375

## Test plan

- [x] `uv run pytest apps/backend/tests/unit/core/test_log_redaction_filter.py` — 55 passed (50 pre-existing + 5 new)
- [x] `task check` from `apps/backend/` — all gates green (lint, format, pyright strict, import-linter, unit, integration, contract, error-contracts)
- [x] New failing tests confirmed red before implementation (pure-digit uuid case and adjacent-PII guard)

AI-assisted with Claude.

---
Supersedes #504 (closed and re-opened under @ioanaecaterinastan-collab to utilise the Copilot Pro seat on this repo). Commit carries a `Co-authored-by: cosminneamtiu02` trailer so contribution credit flows to both accounts.
