### PR TITLE
test(architecture): tighten contract-enforcement predicate to fail-loud on subprocess crash

### DIFF
--- a/apps/backend/tests/unit/architecture/test_contract_enforcement.py
+++ b/apps/backend/tests/unit/architecture/test_contract_enforcement.py
@@ -201,6 +201,9 @@ def test_clean_scratch_tree_passes_all_contracts(tmp_path: Path) -> None:
         f"lint-imports unexpectedly broke on an unmodified scratch tree.\n"
         f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
-    assert "0 broken" in result.stdout.lower() or "broken" not in result.stdout.lower(), (
-        f"unexpected 'broken' mention in clean-run output:\n{result.stdout}"
+    assert "0 broken" in result.stdout.lower(), (
+        f"expected lint-imports to report '0 broken' on a clean scratch tree; "
+        f"the previous 'or \"broken\" not in ...' clause was permissive enough to "
+        f"pass on degenerate output that never mentions 'broken' at all (issue #399)\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )


### PR DESCRIPTION
## Summary

The `test_clean_scratch_tree_passes_all_contracts` assertion on line 204 used a weak `or`-predicate that silently accepted degenerate `lint-imports` output. `result.returncode == 0` already guards against crashes on the line above, but the `or "broken" not in result.stdout.lower()` arm weakened the invariant into "if the output happens to never mention the word 'broken' at all, accept it" — which would quietly pass if lint-imports ever shipped a report format without that literal substring, even with real contract breaks present.

Collapse to the strict check the issue prescribes.

### Before

```python
assert result.returncode == 0, (...)
assert "0 broken" in result.stdout.lower() or "broken" not in result.stdout.lower(), (
    f"unexpected 'broken' mention in clean-run output:\n{result.stdout}"
)
```

### After

```python
assert result.returncode == 0, (...)
assert "0 broken" in result.stdout.lower(), (
    f"expected lint-imports to report '0 broken' on a clean scratch tree; "
    f"the previous 'or \"broken\" not in ...' clause was permissive enough to "
    f"pass on degenerate output that never mentions 'broken' at all (issue #399)\n"
    f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
)
```

Scope: one predicate site tightened. No other weak `or`-predicates in this file.

Closes #399

## Test plan

- [x] `task check` — every gate green (lint, format, types, arch, skills, unit, integration, contract, errors)
- [x] `test_clean_scratch_tree_passes_all_contracts` itself: PASSED
- [x] Sibling `test_third_party_containment_catches_injected_violations` + `test_layer_dag_catches_injected_illegal_edges` parametrized cases: all PASSED (no regression in the shared `_assert_violation_caught` harness)

AI-assisted with Claude

---
Supersedes #503 (closed and re-opened under @ioanaecaterinastan-collab to utilise the Copilot Pro seat on this repo). Commit carries a `Co-authored-by: cosminneamtiu02` trailer so contribution credit flows to both accounts.
