### PR TITLE
chore(error-contracts): add regenerate-command provenance to Python docstring (closes #373)

### DIFF
--- a/apps/backend/app/exceptions/_generated/__init__.py
+++ b/apps/backend/app/exceptions/_generated/__init__.py
@@ -1,4 +1,7 @@
-"""Generated error classes. Do not edit."""
+"""Generated error classes. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from app.exceptions._generated.extraction_budget_exceeded_error import ExtractionBudgetExceededError
 from app.exceptions._generated.extraction_budget_exceeded_params import (

--- a/apps/backend/app/exceptions/_generated/_registry.py
+++ b/apps/backend/app/exceptions/_generated/_registry.py
@@ -1,4 +1,7 @@
-"""Generated error registry. Do not edit."""
+"""Generated error registry. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from __future__ import annotations
 

--- a/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_error.py
+++ b/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_params.py
+++ b/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/extraction_overloaded_error.py
+++ b/apps/backend/app/exceptions/_generated/extraction_overloaded_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/extraction_overloaded_params.py
+++ b/apps/backend/app/exceptions/_generated/extraction_overloaded_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/intelligence_timeout_error.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_timeout_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/intelligence_timeout_params.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_timeout_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/intelligence_unavailable_error.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_unavailable_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/internal_error.py
+++ b/apps/backend/app/exceptions/_generated/internal_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/not_found_error.py
+++ b/apps/backend/app/exceptions/_generated/not_found_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_invalid_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_invalid_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_no_text_extractable_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_no_text_extractable_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/pdf_password_protected_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_password_protected_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_large_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_large_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_large_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_large_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_many_pages_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_many_pages_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_many_pages_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_many_pages_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/skill_not_found_error.py
+++ b/apps/backend/app/exceptions/_generated/skill_not_found_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/skill_not_found_params.py
+++ b/apps/backend/app/exceptions/_generated/skill_not_found_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/skill_validation_failed_error.py
+++ b/apps/backend/app/exceptions/_generated/skill_validation_failed_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/skill_validation_failed_params.py
+++ b/apps/backend/app/exceptions/_generated/skill_validation_failed_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/structured_output_failed_error.py
+++ b/apps/backend/app/exceptions/_generated/structured_output_failed_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/validation_failed_error.py
+++ b/apps/backend/app/exceptions/_generated/validation_failed_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/packages/error-contracts/scripts/generate.py
+++ b/packages/error-contracts/scripts/generate.py
@@ -240,7 +240,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
                 for name, ptype in sorted_param_items
             )
             params_file.write_text(
-                f'"""Generated from errors.yaml. Do not edit."""\n\n'
+                f'"""Generated from errors.yaml. Do not edit.\n\n'
+                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+                f'"""\n\n'
                 f"from pydantic import BaseModel\n\n\n"
                 f"class {params_class_name}(BaseModel):\n"
                 f'    """Parameters for {code} error."""\n\n'
@@ -279,7 +281,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
                 f"app.exceptions._generated.{params_file_stem}", params_class_name
             )
             error_content = (
-                f'"""Generated from errors.yaml. Do not edit."""\n\n'
+                f'"""Generated from errors.yaml. Do not edit.\n\n'
+                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+                f'"""\n\n'
                 f"from typing import ClassVar\n\n"
                 f"{params_import_line}\n"
                 f"from app.exceptions.base import DomainError\n\n\n"
@@ -291,7 +295,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
             )
         else:
             error_content = (
-                f'"""Generated from errors.yaml. Do not edit."""\n\n'
+                f'"""Generated from errors.yaml. Do not edit.\n\n'
+                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+                f'"""\n\n'
                 f"from typing import ClassVar\n\n"
                 f"from app.exceptions.base import DomainError\n\n\n"
                 f"class {error_class_name}(DomainError):\n"
@@ -315,7 +321,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
     sorted_imports = sorted(init_imports, key=lambda entry: entry[1])
     init_file = output_dir / "__init__.py"
     init_content = (
-        '"""Generated error classes. Do not edit."""\n\n'
+        '"""Generated error classes. Do not edit.\n\n'
+        "Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+        '"""\n\n'
         + "\n".join(_py_import_line(module, name) for module, name in sorted_imports)
         + "\n\n__all__ = [\n"
         + "\n".join(f'    "{name}",' for _module, name in sorted_imports)
@@ -346,7 +354,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
     # affects the user-visible dict-key order.
     sorted_registry_entries = sorted(registry_entries)
     registry_content = (
-        '"""Generated error registry. Do not edit."""\n\n'
+        '"""Generated error registry. Do not edit.\n\n'
+        "Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+        '"""\n\n'
         "from __future__ import annotations\n\n"
         "from typing import TYPE_CHECKING\n\n"
         "if TYPE_CHECKING:\n"

--- a/packages/error-contracts/tests/test_generate.py
+++ b/packages/error-contracts/tests/test_generate.py
@@ -539,3 +539,62 @@ def test_generate_required_keys_is_deterministic_across_param_key_order(
     )
 
     assert json_forward.read_bytes() == json_swapped.read_bytes()
+
+
+# Provenance-in-docstring regression test for issue #373.
+#
+# The TypeScript generator output begins with:
+#   `// THIS FILE IS GENERATED FROM errors.yaml`
+#   `// DO NOT EDIT BY HAND. Run `task errors:generate` to regenerate.`
+# while the Python module docstrings only said
+#   `"""Generated from errors.yaml. Do not edit."""`
+# Contributors reading a generated Python file had no in-file pointer to
+# the regenerate command, forcing them to hunt for it. These tests pin
+# the regenerate-command mention in every Python artifact type the
+# generator emits (per-error class, params class, __init__.py, _registry.py)
+# so the provenance cannot silently regress.
+_PROVENANCE_YAML = """
+version: 1
+errors:
+  NOT_FOUND:
+    http_status: 404
+    description: Resource not found
+    params: {}
+  WIDGET_NOT_FOUND:
+    http_status: 404
+    description: Widget not found
+    params:
+      widget_id: string
+"""
+
+
+def test_generated_python_files_mention_regenerate_command(
+    tmp_path: Path, output_dir: Path
+):
+    """Every generated Python artifact's module docstring must reference
+    ``task errors:generate`` so a contributor reading the file sees the
+    regeneration command without having to check the TypeScript output or
+    the root Taskfile (issue #373).
+    """
+    from scripts.generate import generate_python
+
+    errors_path = tmp_path / "errors.yaml"
+    errors_path.write_text(_PROVENANCE_YAML)
+
+    generate_python(errors_path, output_dir)
+
+    # Every emitted file type: per-error class, params class, aggregate
+    # __init__.py, and _registry.py.
+    for py_file in (
+        "not_found_error.py",
+        "widget_not_found_error.py",
+        "widget_not_found_params.py",
+        "__init__.py",
+        "_registry.py",
+    ):
+        content = (output_dir / py_file).read_text()
+        assert "task errors:generate" in content, (
+            f"{py_file} docstring must mention `task errors:generate` "
+            f"so contributors find the regeneration command in-file "
+            f"(issue #373). Got:\n{content[:300]}"
+        )


### PR DESCRIPTION
Closes #373.

## Summary

- Python generator in `packages/error-contracts/scripts/generate.py` now emits module docstrings that mention `` `task errors:generate` ``, matching the existing TypeScript header's regenerate-command provenance.
- Contributors reading a generated Python file (per-error class, params class, `__init__.py`, or `_registry.py`) see the escape hatch in-file instead of having to cross-reference the TS output or the root Taskfile.
- All 26 generated Python files regenerated via `task errors:generate` to pick up the new template.

## Template change

Before (per-error/params class):
```python
"""Generated from errors.yaml. Do not edit."""
```

After:
```python
"""Generated from errors.yaml. Do not edit.

Run ``task errors:generate`` to regenerate after editing errors.yaml.
"""
```

(Same shape for the `__init__.py` and `_registry.py` aggregate docstrings, which keep their original first-line wording and gain the same regenerate hint.)

## Test plan

- [x] New TDD regression test `test_generated_python_files_mention_regenerate_command` in `packages/error-contracts/tests/test_generate.py` — asserts every emitted artifact type contains `task errors:generate`. Started RED on the old template, GREEN after the fix.
- [x] Full `packages/error-contracts/tests/` suite (66 tests) passes locally.
- [x] `apps/backend/tests/unit/` suite (1083 tests) passes — no downstream regression from the regenerated files.
- [x] `apps/backend/tests/unit/architecture/` (126 tests) passes.
- [x] `scripts.check.main()` (the `task errors:check` drift gate) reports "in sync with errors.yaml" — template change and regenerated files are consistent.
- [x] `ruff check` + `ruff format --check` pass on backend and error-contracts trees.
- [x] Pre-push hook (pyright strict + backend unit tests) passed on `git push`.

AI-assisted with Claude.
