### PR TITLE
test(e2e): make probe_settings fixture override APP_ENV explicitly (closes #405)

### DIFF
--- a/apps/backend/tests/integration/features/extraction/test_live_ollama_e2e.py
+++ b/apps/backend/tests/integration/features/extraction/test_live_ollama_e2e.py
@@ -169,7 +169,14 @@ def _ollama_reachable_fixture() -> None:
     as a function parameter, so the request is visible as a decorator on
     the test function (not in its signature).
     """
-    probe_settings: Settings = Settings()  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
+    # Pin ``app_env='development'`` explicitly (issue #405): the test body
+    # below constructs its own ``Settings(app_env='development', ...)`` to
+    # keep extraction running in development mode regardless of host env.
+    # If this probe fixture fell through to ambient ``APP_ENV`` (e.g. a
+    # CI host with ``APP_ENV=production`` leaked into the shell), the
+    # probe would silently diverge from the tested call. Pinning here
+    # matches the test body and makes the live-Ollama e2e reproducible.
+    probe_settings: Settings = Settings(app_env="development")  # type: ignore[reportCallIssue]  # pydantic-settings loads remaining fields from env
     ollama_ready, ollama_skip_reason = _ollama_reachable(probe_settings)
     if not ollama_ready:
         pytest.skip(ollama_skip_reason)

--- a/apps/backend/tests/integration/features/extraction/test_live_ollama_e2e_fixture_settings.py
+++ b/apps/backend/tests/integration/features/extraction/test_live_ollama_e2e_fixture_settings.py
@@ -1,0 +1,65 @@
+"""Regression guard for issue #405.
+
+The live-Ollama e2e fixture ``_ollama_reachable_fixture`` constructs a
+``Settings`` object to drive the reachability probe. The test body (in
+``test_live_ollama_e2e.py``) constructs its *own* ``Settings`` with
+``app_env="development"`` so extraction runs in development mode
+regardless of how the CI/dev host is configured. If the probe fixture
+reads ``APP_ENV`` from the ambient environment and the test body pins
+it to ``"development"``, the two are inconsistent — and on a host with
+``APP_ENV=production`` that inconsistency is silent.
+
+This module asserts the fixture pins ``app_env`` explicitly so it
+matches the test body and is reproducible regardless of host env.
+
+Kept separate from ``test_live_ollama_e2e.py`` because that module is
+``pytest.mark.slow`` at module scope and is excluded from the default
+``task check`` run; this assertion must run in the fast default suite
+so a regression is caught without requiring the slow gate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.integration.features.extraction import test_live_ollama_e2e as e2e
+
+if TYPE_CHECKING:
+    import pytest
+
+    from app.core.config import Settings
+
+
+def test_ollama_reachable_fixture_pins_app_env_to_development(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reachability fixture's ``Settings`` must pin ``app_env='development'``.
+
+    Simulates a CI/dev host leaking ``APP_ENV=production`` into the
+    process env, then invokes the fixture function directly and
+    inspects the ``Settings`` object handed to the probe. The fixture
+    must override the ambient env var so it matches the test body.
+    """
+    monkeypatch.setenv("APP_ENV", "production")
+
+    captured: dict[str, Settings] = {}
+
+    def _spy_reachable(settings: Settings) -> tuple[bool, str]:
+        captured["settings"] = settings
+        # Return reachable=True so the fixture does not call
+        # pytest.skip(...) and short-circuit the test.
+        return True, ""
+
+    monkeypatch.setattr(e2e, "_ollama_reachable", _spy_reachable)
+
+    # ``@pytest.fixture`` wraps the function; ``__wrapped__`` exposes the
+    # underlying callable for direct invocation (pytest forbids calling
+    # the wrapper directly). This is the standard unit-test pattern for
+    # asserting on a fixture's body without scheduling it via pytest.
+    e2e._ollama_reachable_fixture.__wrapped__()  # type: ignore[attr-defined]  # noqa: SLF001 — unit-testing a module-private fixture's body
+
+    assert "settings" in captured, "fixture did not call _ollama_reachable"
+    assert captured["settings"].app_env == "development", (
+        f"expected fixture to pin app_env='development' to match the test body; "
+        f"got {captured['settings'].app_env!r}"
+    )


### PR DESCRIPTION
## Summary

- `_ollama_reachable_fixture` at `test_live_ollama_e2e.py:164` was constructing `Settings()` with no explicit `app_env`, silently reading ambient `APP_ENV` from the test host.
- The test body at line ~226 already pins `app_env="development"`, so on a CI host with `APP_ENV=production` the fixture and the tested call would disagree.
- Fixture now passes `app_env="development"` explicitly, matching the test body.
- New unit-style regression test `test_ollama_reachable_fixture_pins_app_env_to_development` spies on the Settings the fixture builds under a `monkeypatch.setenv("APP_ENV", "production")` and asserts `app_env == "development"`. Red before the fix, green after.

**Meta-test scoping:** did NOT add an AST scanner for bare `Settings()` in tests. Survey showed ~14 call sites, many of them intentionally exercising env-var loading (e.g. `test_config.py`, `test_settings_extra_forbid.py`). A broad scanner would be noisy or require an allowlist that expands scope beyond #405. Per the default guidance, the targeted regression test is sufficient.

Closes #405

## Test plan

- [x] New regression test `test_ollama_reachable_fixture_pins_app_env_to_development` RED-first against the bare `Settings()`, GREEN after the fix
- [x] `task check` from `apps/backend/` — all gates green (lint, format, pyright strict, import-linter, unit, integration 103 passed / 10 slow deselected, contract 25, errors 65)

AI-assisted with Claude.