### PR TITLE
fix(intelligence): plumb ollama_temperature through Settings (closes #384)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -89,6 +89,13 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 # OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=gemma4:e2b
 OLLAMA_TIMEOUT_SECONDS=30.0
+# Sampling temperature forwarded to Ollama's /api/generate baseline
+# (issue #384). Range 0.0-2.0 matches Ollama's advertised domain; values
+# outside the range are rejected at Settings construction. Default 0.0
+# preserves deterministic sampling for StructuredOutputValidator retries
+# (issue #136). Raise above 0.0 only when a skill deliberately wants
+# creative-mode outputs (e.g. inferred descriptions).
+OLLAMA_TEMPERATURE=0.0
 # Readiness probe TTL in seconds. The /ready endpoint caches probe results
 # for this duration before re-probing Ollama. 0 disables caching (every
 # /ready call probes). Defaults to 10.

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -283,6 +283,18 @@ class Settings(BaseSettings):
     ollama_probe_ttl_seconds: Annotated[float, Field(ge=0)] = 10.0
     ollama_probe_timeout_seconds: Annotated[float, Field(gt=0)] = 5.0
 
+    # Sampling temperature forwarded to Ollama's ``/api/generate`` ``options``
+    # baseline. ``0.0`` preserves the original deterministic-sampling contract
+    # from issue #136 — ``StructuredOutputValidator`` retries repeat from a
+    # stable baseline rather than drifting between attempts. Skill authors who
+    # want creative-mode behavior (e.g. non-determinism for inferred
+    # descriptions) raise this knob without editing source; the
+    # LangExtract-forwarded sampling allowlist (issue #385) still overrides
+    # per-call. Upper bound ``2.0`` matches Ollama's advertised range — values
+    # above that are rejected by Ollama with a 400, so we fail fast at config
+    # load instead. Issue #384.
+    ollama_temperature: Annotated[float, Field(ge=0.0, le=2.0)] = 0.0
+
     # Extraction pipeline (PDFX-E006-F002)
     extraction_timeout_seconds: Annotated[float, Field(gt=0)] = 180.0
 

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -99,8 +99,9 @@ _STALE_CLIENT_ACLOSE_TIMEOUT_SECONDS = 2.0
 #   * unknown / future Ollama options do not leak into the payload without a
 #     deliberate code change (and a matching test),
 #   * the ``generate()`` path is unaffected — it never receives caller kwargs,
-#     so the module-level ``_DEFAULT_SAMPLING_OPTIONS`` baseline (below)
-#     remains in force for validator retries.
+#     so the per-provider ``_default_sampling_options`` baseline built from
+#     ``Settings.ollama_temperature`` (issue #384) remains in force for
+#     validator retries.
 #
 # Sampling keys only (seed, temperature, top_p, top_k, num_ctx, num_predict,
 # repeat_penalty, mirostat family). Streaming / format / keep_alive / raw are
@@ -121,13 +122,17 @@ _OLLAMA_SAMPLING_OPTION_KEYS: frozenset[str] = frozenset(
     },
 )
 
+
 # Default sampling options applied when the caller does not override them.
-# Pinning ``temperature=0`` keeps the validator-retry determinism contract from
-# issue #136 intact for callers (including the ``generate()`` path and plain
-# ``infer()`` with no kwargs). This is a module-level constant, not a
-# ``Settings``-backed field — operators who need to change the baseline do so
-# here, not via env var. Caller overrides win — see ``_merge_sampling_options``.
-_DEFAULT_SAMPLING_OPTIONS: dict[str, Any] = {"temperature": 0}
+# ``temperature`` is seeded from ``Settings.ollama_temperature`` at provider
+# construction time (issue #384) rather than hardcoded — operators can now
+# tune the baseline via env var. The default value of that Settings field is
+# ``0.0``, which preserves the validator-retry determinism contract from
+# issue #136 for any deployment that does not override it. This helper builds
+# the per-instance baseline once in ``__init__``; ``_merge_sampling_options``
+# layers caller overrides on top (see below).
+def _default_sampling_options(settings: Settings) -> dict[str, Any]:
+    return {"temperature": settings.ollama_temperature}
 
 
 def _build_generate_url(base_url: str) -> str:
@@ -138,28 +143,31 @@ def build_tags_url(base_url: str) -> str:
     return f"{base_url.rstrip('/')}/api/tags"
 
 
-def _merge_sampling_options(**kwargs: Any) -> tuple[dict[str, Any], list[str]]:
+def _merge_sampling_options(
+    baseline: dict[str, Any],
+    **kwargs: Any,
+) -> tuple[dict[str, Any], list[str]]:
     """Return the merged Ollama ``options`` dict plus the ignored-kwarg key list.
 
     Splits the raw LangExtract-forwarded kwargs dict into two buckets:
 
     * keys in ``_OLLAMA_SAMPLING_OPTION_KEYS`` whose value is not ``None``
-      are copied over the ``_DEFAULT_SAMPLING_OPTIONS`` baseline (caller
-      wins) and returned as the first element of the tuple. An allowlisted
-      key whose value IS ``None`` is treated as "not provided" — the
-      default is preserved rather than being clobbered with ``None``.
-      Forwarding ``null`` to Ollama would break the determinism contract
-      for ``temperature`` and risks a server-side 400 for keys Ollama
-      validates (e.g. ``seed``),
+      are copied over the *baseline* (caller wins) and returned as the
+      first element of the tuple. An allowlisted key whose value IS
+      ``None`` is treated as "not provided" — the baseline is preserved
+      rather than being clobbered with ``None``. Forwarding ``null`` to
+      Ollama would break the determinism contract for ``temperature`` and
+      risks a server-side 400 for keys Ollama validates (e.g. ``seed``),
     * keys NOT in the allowlist are collected into a list and returned as
       the second element so the caller can log them for observability
       (issue #385: operators need to see drift when LangExtract forwards
       something new).
 
-    The default baseline is copied rather than mutated so concurrent
-    ``infer()`` calls do not race on a shared dict.
+    The baseline is copied rather than mutated so concurrent ``infer()``
+    calls do not race on a shared dict. ``baseline`` is the per-provider
+    default built from ``Settings.ollama_temperature`` (issue #384).
     """
-    options: dict[str, Any] = dict(_DEFAULT_SAMPLING_OPTIONS)
+    options: dict[str, Any] = dict(baseline)
     ignored: list[str] = []
     for key, value in kwargs.items():
         if key in _OLLAMA_SAMPLING_OPTION_KEYS:
@@ -175,19 +183,21 @@ def _build_payload(
     prompt: str,
     *,
     sampling_options: dict[str, Any] | None = None,
+    default_sampling_options: dict[str, Any],
 ) -> dict[str, Any]:
     # ``format="json"`` engages Ollama's native JSON-constrained decoding so the
     # server returns well-formed JSON on the first attempt instead of forcing
     # ``StructuredOutputValidator`` to re-prompt for parse errors on every
     # request. ``options`` pins sampling parameters; without overrides it keeps
-    # the module-level ``_DEFAULT_SAMPLING_OPTIONS`` baseline (``temperature=0``
-    # from issue #136) so validator retries repeat from a stable baseline
-    # rather than drifting between attempts. When the caller supplies
+    # the per-provider ``default_sampling_options`` baseline — seeded from
+    # ``Settings.ollama_temperature`` (issue #384), defaulting to ``0.0`` so
+    # validator retries repeat from a stable baseline rather than drifting
+    # between attempts (issue #136). When the caller supplies
     # ``sampling_options`` (the ``infer()`` path on a LangExtract-forwarded
     # kwarg — issue #385), those values replace the baseline per-key. The
     # validator still enforces our downstream schema shape, but it no longer
     # pays the malformed-output retry cost on the happy path.
-    options = sampling_options if sampling_options is not None else dict(_DEFAULT_SAMPLING_OPTIONS)
+    options = sampling_options if sampling_options is not None else dict(default_sampling_options)
     return {
         "model": model,
         "prompt": prompt,
@@ -246,6 +256,17 @@ class OllamaGemmaProvider(BaseLanguageModel):
         self._timeout_seconds = effective_settings.ollama_timeout_seconds
         self._timeout = httpx.Timeout(self._timeout_seconds)
         self._validator = effective_validator
+        # ``Settings.ollama_temperature`` (issue #384) seeds the sampling
+        # baseline for BOTH the ``generate()`` path (which never receives
+        # caller kwargs) and the ``infer()`` path (which layers
+        # LangExtract-forwarded overrides on top). Built once here so every
+        # request reuses the same snapshot instead of re-reading Settings on
+        # the hot path — the dict is copied at the point of use in
+        # ``_build_payload`` / ``_merge_sampling_options`` so in-place mutation
+        # cannot leak across requests.
+        self._default_sampling_options: dict[str, Any] = _default_sampling_options(
+            effective_settings,
+        )
         # `http_client` is eagerly created (matching the long-standing contract
         # that `.http_client` is a plain attribute) OR taken from `http_client`
         # if injected. `_get_http_client` rebuilds it when the running event
@@ -502,9 +523,15 @@ class OllamaGemmaProvider(BaseLanguageModel):
         # ``sampling_options`` is threaded through from ``infer()`` so
         # LangExtract-forwarded sampling kwargs land in the Ollama payload
         # (issue #385). When ``None`` (the ``generate()`` path), ``_build_payload``
-        # falls back to the module-level default sampling options, including
-        # ``temperature=0``.
-        payload = _build_payload(self._model, prompt, sampling_options=sampling_options)
+        # falls back to the per-provider baseline built from
+        # ``Settings.ollama_temperature`` (issue #384), defaulting to
+        # ``temperature=0.0``.
+        payload = _build_payload(
+            self._model,
+            prompt,
+            sampling_options=sampling_options,
+            default_sampling_options=self._default_sampling_options,
+        )
         try:
             response = await client.post(self._generate_url, json=payload)
             response.raise_for_status()
@@ -654,7 +681,10 @@ class OllamaGemmaProvider(BaseLanguageModel):
         ``ollama_provider_ignored_kwargs`` event so operators can see drift
         and add it to the allowlist deliberately if it turns out to matter.
         """
-        sampling_options, ignored_keys = _merge_sampling_options(**kwargs)
+        sampling_options, ignored_keys = _merge_sampling_options(
+            self._default_sampling_options,
+            **kwargs,
+        )
         if ignored_keys:
             _logger.debug(
                 "ollama_provider_ignored_kwargs",

--- a/apps/backend/tests/unit/core/test_config.py
+++ b/apps/backend/tests/unit/core/test_config.py
@@ -60,6 +60,39 @@ def test_settings_ollama_probe_timeout_default() -> None:
     assert s.ollama_probe_timeout_seconds == 5.0
 
 
+# -- ollama_temperature validation (issue #384) ---------------------------
+
+
+def test_settings_ollama_temperature_default() -> None:
+    """ollama_temperature defaults to 0.0 so the pre-issue-#384 behavior
+    (deterministic sampling for validator retries, issue #136) is preserved
+    for any deployment that does not override the field.
+    """
+    s = Settings()
+    assert s.ollama_temperature == 0.0
+
+
+def test_settings_ollama_temperature_accepts_override() -> None:
+    """Non-default sampling temperatures in the supported range must load."""
+    s = Settings(ollama_temperature=0.7)
+    assert s.ollama_temperature == 0.7
+
+
+def test_settings_ollama_temperature_negative_rejected() -> None:
+    """Negative sampling temperatures are not meaningful; fail at load."""
+    with pytest.raises(ValidationError):
+        Settings(ollama_temperature=-0.1)
+
+
+def test_settings_ollama_temperature_above_upper_bound_rejected() -> None:
+    """Temperatures above Ollama's 2.0 cap would be rejected by the server
+    with a 400 at runtime; fail fast at config load so operators see the
+    misconfiguration before the first request.
+    """
+    with pytest.raises(ValidationError):
+        Settings(ollama_temperature=2.5)
+
+
 # -- ollama_base_url validation (issue #64) --------------------------------
 
 

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_ollama_gemma_provider.py
@@ -122,13 +122,17 @@ def _build_settings(
     model: str = "gemma4:e2b",
     timeout_seconds: float = 30.0,
     max_retries: int = 3,
+    temperature: float | None = None,
 ) -> Settings:
-    return Settings(
-        ollama_base_url=base_url,
-        ollama_model=model,
-        ollama_timeout_seconds=timeout_seconds,
-        structured_output_max_retries=max_retries,
-    )
+    kwargs: dict[str, Any] = {
+        "ollama_base_url": base_url,
+        "ollama_model": model,
+        "ollama_timeout_seconds": timeout_seconds,
+        "structured_output_max_retries": max_retries,
+    }
+    if temperature is not None:
+        kwargs["ollama_temperature"] = temperature
+    return Settings(**kwargs)
 
 
 def _build_validator(settings: Settings) -> StructuredOutputValidator:
@@ -231,6 +235,59 @@ async def test_generate_payload_includes_format_json_and_zero_temperature() -> N
     assert payload["format"] == "json"
     assert isinstance(payload["options"], dict)
     assert payload["options"]["temperature"] == 0
+
+
+async def test_generate_payload_honors_ollama_temperature_from_settings() -> None:
+    """Regression guard for issue #384.
+
+    ``Settings.ollama_temperature`` is the operator knob for sampling
+    temperature on the ``/api/generate`` baseline. Before the fix,
+    ``_build_payload`` hardcoded ``options={"temperature": 0}`` with no way
+    to tune it short of editing source — skill authors who wanted
+    non-deterministic sampling (e.g. for creative inferred descriptions) had
+    no runtime path to set it. The fix threads the Settings value through
+    the provider into the default sampling options so the payload carries
+    the configured temperature instead of a hardcoded zero. The
+    ``infer()``-path allowlist (issue #385) still lets LangExtract callers
+    override per-call if they want a different value for a specific batch.
+    """
+    fake = _FakeAsyncClient(
+        post_outcomes=[_FakeResponse(body={"response": '{"name":"Alice"}'})],
+    )
+    settings = _build_settings(temperature=0.7)
+    provider = _build_provider(settings=settings, fake_client=fake)
+
+    await provider.generate("hi", _NAME_STRING_SCHEMA)
+
+    _, payload = fake.post_calls[0]
+    assert payload["options"]["temperature"] == 0.7
+
+
+async def test_generate_payload_preserves_zero_temperature_default_from_settings() -> None:
+    """Regression guard for issue #384: default Settings preserve the legacy
+    ``temperature=0`` baseline.
+
+    When operators do not override ``ollama_temperature``, the payload must
+    still carry ``temperature == 0.0`` so the existing determinism contract
+    from issue #136 (``test_generate_payload_includes_format_json_and_zero_temperature``)
+    continues to hold. This guards against a future change that defaults the
+    Settings field to anything other than 0.0 and silently destabilizes
+    ``StructuredOutputValidator``'s retry-from-stable-baseline invariant.
+    """
+    fake = _FakeAsyncClient(
+        post_outcomes=[_FakeResponse(body={"response": '{"name":"Alice"}'})],
+    )
+    # Explicit default Settings construction (no ``temperature=`` override),
+    # so the assertion pins the value read from Settings, not a module-level
+    # constant.
+    settings = _build_settings()
+    assert settings.ollama_temperature == 0.0
+    provider = _build_provider(settings=settings, fake_client=fake)
+
+    await provider.generate("hi", _NAME_STRING_SCHEMA)
+
+    _, payload = fake.post_calls[0]
+    assert payload["options"]["temperature"] == 0.0
 
 
 async def test_generate_strips_trailing_slash_from_base_url() -> None:


### PR DESCRIPTION
## Summary

- Adds `ollama_temperature: Annotated[float, Field(ge=0.0, le=2.0)] = 0.0` to `Settings` so operators can tune Ollama's `/api/generate` sampling temperature via env var instead of editing source.
- Plumbs the value through `OllamaGemmaProvider.__init__` into a per-instance `_default_sampling_options` baseline that both `generate()` (no caller kwargs) and `infer()` (LangExtract-forwarded allowlist overrides on top, issue #385) consume via `_build_payload` / `_merge_sampling_options`.
- `OLLAMA_TEMPERATURE=0.0` mirrored into `apps/backend/.env.example` so the parity test passes; default `0.0` preserves the validator-retry determinism contract from issue #136.

Closes #384

## Test plan

- [x] `task lint` (ruff check + format:check) — passed
- [x] `task check:types` — pyright strict passes on backend and error-contracts (0 errors)
- [x] `task check:arch` — import-linter: 11 kept, 0 broken
- [x] `task skills:validate` — passes
- [x] `task test:unit` — 1089 passed; added two provider tests (`test_generate_payload_honors_ollama_temperature_from_settings` and `test_generate_payload_preserves_zero_temperature_default_from_settings`) plus four Settings tests covering default, override, and range bounds
- [x] `task test:integration` — 106 passed, 6 skipped
- [x] `task test:contract` — 25 passed (schemathesis + extract contract)
- [x] `task check:errors` — generated contracts in sync with errors.yaml; 65 error-contract tests passed
- [x] Full `task check` green end-to-end

AI-assisted with Claude.