### PR TITLE
fix(api): stream multipart/mixed response to avoid 2x memory (closes #387)

### DIFF
--- a/apps/backend/app/features/extraction/router.py
+++ b/apps/backend/app/features/extraction/router.py
@@ -12,11 +12,14 @@ form and spooled the upload to a temp file.  It does not reject at the
 HTTP framing level.  What it prevents is the downstream Docling +
 extraction pipeline from being invoked on an oversized document.
 
-The multipart/mixed builder (~15 lines) is inlined because it has exactly
-one consumer.  ``read_with_byte_limit`` is a public async helper (tested
-directly by unit tests) that reads the upload in 1 MB chunks and aborts
-early on the first chunk that pushes the total over
-``Settings.max_pdf_bytes``.
+The multipart/mixed builder is a generator that yields framing and body
+chunks without concatenating them (issue #387): concatenating
+``header + json + pdf + footer`` into one ``bytes`` blob would roughly
+double worker RSS per BOTH-mode request, and under
+``max_concurrent_extractions`` simultaneous requests that scales linearly.
+``read_with_byte_limit`` is a public async helper (tested directly by unit
+tests) that reads the upload in 1 MB chunks and aborts early on the first
+chunk that pushes the total over ``Settings.max_pdf_bytes``.
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ from typing import TYPE_CHECKING, Annotated, NoReturn, assert_never
 
 import structlog
 from fastapi import APIRouter, Depends, File, Form, Response, UploadFile
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from app.api.deps import get_extraction_service, get_settings
 from app.core.config import (
@@ -39,6 +42,8 @@ from app.features.extraction.service import ExtractionService  # noqa: TC001  # 
 from app.schemas.error_response import ErrorResponse
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from app.features.extraction.extraction_result import ExtractionResult
 
 _CHUNK_SIZE = 1024 * 1024  # 1 MB
@@ -74,34 +79,44 @@ async def read_with_byte_limit(upload: UploadFile, max_bytes: int) -> bytes:
     return bytes(buf)
 
 
-def build_multipart_mixed(json_body: bytes, pdf_body: bytes) -> tuple[bytes, str]:
-    """Build a ``multipart/mixed`` response body with two parts.
+def build_multipart_mixed(json_body: bytes, pdf_body: bytes) -> tuple[Iterator[bytes], str]:
+    """Build a streaming ``multipart/mixed`` response body with two parts.
 
-    Returns ``(body_bytes, boundary_string)``.  Uses CRLF line endings per
-    the multipart RFC.
+    Returns ``(chunk_iterator, boundary_string)``.  The iterator yields each
+    framing chunk, then the JSON body, then the separator, then the PDF body
+    by identity, then the terminator — WITHOUT concatenating them into a
+    single ``bytes`` blob (issue #387).  Uses CRLF line endings per the
+    multipart RFC.
+
+    The PDF body is yielded as-is (identity-preserved) so the memory
+    footprint of a BOTH-mode response is roughly ``PDF size + small framing``
+    rather than ``2 x PDF size`` that concatenation would cost.
     """
     boundary = secrets.token_hex(16)
     crlf = "\r\n"
-    parts = (
-        (
-            f"--{boundary}{crlf}"
-            f'Content-Disposition: form-data; name="result"{crlf}'
-            f"Content-Type: application/json{crlf}"
-            f"{crlf}"
-        ).encode()
-        + json_body
-        + (
-            f"{crlf}"
-            f"--{boundary}{crlf}"
-            f'Content-Disposition: form-data; name="pdf"; filename="annotated.pdf"{crlf}'
-            f"Content-Type: application/pdf{crlf}"
-            f"{crlf}"
-        ).encode()
-        + pdf_body
-        + f"{crlf}--{boundary}--{crlf}".encode()
-    )
+    header = (
+        f"--{boundary}{crlf}"
+        f'Content-Disposition: form-data; name="result"{crlf}'
+        f"Content-Type: application/json{crlf}"
+        f"{crlf}"
+    ).encode()
+    separator = (
+        f"{crlf}"
+        f"--{boundary}{crlf}"
+        f'Content-Disposition: form-data; name="pdf"; filename="annotated.pdf"{crlf}'
+        f"Content-Type: application/pdf{crlf}"
+        f"{crlf}"
+    ).encode()
+    footer = f"{crlf}--{boundary}--{crlf}".encode()
 
-    return parts, boundary
+    def _chunks() -> Iterator[bytes]:
+        yield header
+        yield json_body
+        yield separator
+        yield pdf_body
+        yield footer
+
+    return _chunks(), boundary
 
 
 def _raise_missing_annotated_pdf(output_mode: OutputMode) -> NoReturn:
@@ -147,8 +162,11 @@ def _serialize_result(result: ExtractionResult, output_mode: OutputMode) -> Resp
         if result.annotated_pdf_bytes is None:
             _raise_missing_annotated_pdf(output_mode)
         json_bytes = result.response.model_dump_json().encode()
-        body, boundary = build_multipart_mixed(json_bytes, result.annotated_pdf_bytes)
-        return Response(content=body, media_type=f'multipart/mixed; boundary="{boundary}"')
+        chunks, boundary = build_multipart_mixed(json_bytes, result.annotated_pdf_bytes)
+        return StreamingResponse(
+            chunks,
+            media_type=f'multipart/mixed; boundary="{boundary}"',
+        )
 
     assert_never(output_mode)
 

--- a/apps/backend/tests/unit/features/extraction/test_router.py
+++ b/apps/backend/tests/unit/features/extraction/test_router.py
@@ -5,14 +5,17 @@ Tests cover:
 - ``build_multipart_mixed`` response builder (scenarios 5-6)
 - Handler output-mode branching (scenarios 7-9)
 - Structured log context on ``InternalError`` raises (issue #337)
+- Streaming (chunked) shape of ``build_multipart_mixed`` (issue #387)
 """
 
 from __future__ import annotations
 
 import io
+from collections.abc import Iterable, Iterator
 
 import pytest
 from fastapi import UploadFile
+from fastapi.responses import StreamingResponse
 
 from app.features.extraction.extraction_result import ExtractionResult
 from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
@@ -118,8 +121,8 @@ def test_multipart_builder_produces_two_parts_with_correct_headers() -> None:
 
     json_body = b'{"skill_name":"invoice"}'
     pdf_body = b"%PDF-1.4 fake"
-    body, boundary = build_multipart_mixed(json_body, pdf_body)
-    body_str = body.decode("utf-8", errors="replace")
+    chunks, boundary = build_multipart_mixed(json_body, pdf_body)
+    body_str = b"".join(chunks).decode("utf-8", errors="replace")
 
     # Verify both content types are present
     assert "Content-Type: application/json" in body_str
@@ -139,14 +142,85 @@ def test_multipart_builder_boundary_appears_exactly_three_times() -> None:
 
     json_body = b'{"key":"value"}'
     pdf_body = b"%PDF-1.4 content"
-    body, boundary = build_multipart_mixed(json_body, pdf_body)
-    body_str = body.decode("utf-8", errors="replace")
+    chunks, boundary = build_multipart_mixed(json_body, pdf_body)
+    body_str = b"".join(chunks).decode("utf-8", errors="replace")
 
     # Count the opener and separator (--boundary\r\n) and the closer (--boundary--)
     opener_sep_count = body_str.count(f"--{boundary}\r\n")
     closer_count = body_str.count(f"--{boundary}--")
     assert opener_sep_count == 2, f"expected 2 opener/separator, got {opener_sep_count}"
     assert closer_count == 1, f"expected 1 closer, got {closer_count}"
+
+
+# ---------------------------------------------------------------------------
+# Streaming (chunked) shape — issue #387
+# ---------------------------------------------------------------------------
+
+
+def test_multipart_builder_yields_iterable_of_chunks_without_concatenating() -> None:
+    """Builder returns an iterable that yields multiple chunks, not a single bytes blob.
+
+    Issue #387: previously the BOTH-mode handler built ``header + json +
+    separator + pdf + footer`` as a single ``bytes`` blob, bloating worker RSS
+    to roughly ``N x (PDF size + JSON size)`` under concurrent BOTH requests.
+    The fix must yield the PDF chunk WITHOUT copying it into a combined
+    framing blob — verified here by checking the PDF body bytes are emitted
+    as their own standalone chunk (``is`` identity) rather than a substring
+    of a larger bytes object.
+    """
+    from app.features.extraction.router import build_multipart_mixed
+
+    json_body = b'{"skill_name":"invoice"}'
+    pdf_body = b"%PDF-1.4 fake pdf content that should not be copied"
+    chunks, _boundary = build_multipart_mixed(json_body, pdf_body)
+
+    # Must be a non-bytes iterable (generator / iterator / list of bytes).
+    assert not isinstance(chunks, bytes | bytearray | memoryview)
+    assert isinstance(chunks, Iterable)
+
+    chunk_list = list(chunks)
+
+    # Must yield more than one chunk (framing headers + json + separator + pdf + footer).
+    assert len(chunk_list) >= 2, f"expected chunked output, got {len(chunk_list)} chunk(s)"
+
+    # Every chunk is bytes.
+    for chunk in chunk_list:
+        assert isinstance(chunk, bytes)
+
+    # Critical: the PDF body must be passed through by identity — NOT embedded
+    # in a larger bytes object. This is what prevents the 2x memory blow-up
+    # under max_concurrent_extractions simultaneous BOTH requests.
+    assert any(chunk is pdf_body for chunk in chunk_list), (
+        "PDF body must be yielded as its own chunk (identity-preserved), "
+        "not concatenated into a framing blob"
+    )
+
+
+def test_multipart_builder_returns_generator_that_can_be_consumed_once() -> None:
+    """Builder returns a single-consumption iterator (generator semantics)."""
+    from app.features.extraction.router import build_multipart_mixed
+
+    chunks, _boundary = build_multipart_mixed(b"{}", b"%PDF-1.4")
+    # Must be an Iterator (not merely Iterable) so StreamingResponse treats it
+    # as a one-shot stream.
+    assert isinstance(chunks, Iterator)
+
+
+def test_handler_both_returns_streaming_response() -> None:
+    """BOTH mode returns a StreamingResponse, not a buffered Response."""
+    from app.features.extraction.router import _serialize_result
+    from app.features.extraction.schemas.output_mode import OutputMode
+
+    pdf_bytes = b"%PDF-1.4 annotated content"
+    result = _make_extraction_result(annotated_pdf_bytes=pdf_bytes)
+    response = _serialize_result(result, OutputMode.BOTH)
+
+    assert isinstance(response, StreamingResponse), (
+        "BOTH mode must stream via StreamingResponse to avoid buffering "
+        "the entire response body in memory (issue #387)"
+    )
+    assert response.media_type is not None
+    assert response.media_type.startswith('multipart/mixed; boundary="')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `build_multipart_mixed` previously concatenated header + JSON + separator + PDF bytes + footer into one `bytes` blob before FastAPI's `Response` writer sent it. Under `max_concurrent_extractions` simultaneous BOTH requests, worker RSS ballooned to roughly 2x (JSON + PDF) per in-flight response.
- Convert `build_multipart_mixed` to a generator yielding each part in order. The BOTH branch of `_serialize_result` now wraps it in `StreamingResponse`, preserving the existing `multipart/mixed; boundary=...` media type verbatim.
- The PDF body flows through by identity — no extra copy — pinned by a unit test asserting `chunk is pdf_body`.
- Existing integration + contract assertions stay green because `httpx` concatenates streaming chunks transparently on `.content`; the `email.parser.BytesParser` multipart parsing in `test_both_returns_200_multipart_mixed` still parses correctly.

Closes #387

## Test plan

- [x] New unit test `test_multipart_builder_yields_iterable_of_chunks_without_concatenating` — asserts non-`bytes` `Iterable`, ≥2 chunks, every chunk `bytes`, PDF-by-identity
- [x] New unit test `test_multipart_builder_returns_generator_that_can_be_consumed_once` — asserts `Iterator` for StreamingResponse one-shot semantics
- [x] New unit test `test_handler_both_returns_streaming_response` — asserts `StreamingResponse` with boundary-preserving media type
- [x] `task check` from `apps/backend/` — all gates green (lint, format, pyright strict, import-linter 11/11, unit 1086, integration 102, contract 25, errors 65)

AI-assisted with Claude.
