### PR TITLE
chore(error-contracts): add regenerate-command provenance to Python docstring (closes #373)

### DIFF
--- a/apps/backend/app/exceptions/_generated/__init__.py
+++ b/apps/backend/app/exceptions/_generated/__init__.py
@@ -1,4 +1,7 @@
-"""Generated error classes. Do not edit."""
+"""Generated error classes. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from app.exceptions._generated.extraction_budget_exceeded_error import ExtractionBudgetExceededError
 from app.exceptions._generated.extraction_budget_exceeded_params import (

--- a/apps/backend/app/exceptions/_generated/_registry.py
+++ b/apps/backend/app/exceptions/_generated/_registry.py
@@ -1,4 +1,7 @@
-"""Generated error registry. Do not edit."""
+"""Generated error registry. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from __future__ import annotations
 

--- a/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_error.py
+++ b/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_params.py
+++ b/apps/backend/app/exceptions/_generated/extraction_budget_exceeded_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/extraction_overloaded_error.py
+++ b/apps/backend/app/exceptions/_generated/extraction_overloaded_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/extraction_overloaded_params.py
+++ b/apps/backend/app/exceptions/_generated/extraction_overloaded_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/intelligence_timeout_error.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_timeout_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/intelligence_timeout_params.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_timeout_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/intelligence_unavailable_error.py
+++ b/apps/backend/app/exceptions/_generated/intelligence_unavailable_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/internal_error.py
+++ b/apps/backend/app/exceptions/_generated/internal_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/not_found_error.py
+++ b/apps/backend/app/exceptions/_generated/not_found_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_invalid_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_invalid_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_no_text_extractable_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_no_text_extractable_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_parser_unavailable_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/pdf_password_protected_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_password_protected_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_large_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_large_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_large_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_large_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_many_pages_error.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_many_pages_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/pdf_too_many_pages_params.py
+++ b/apps/backend/app/exceptions/_generated/pdf_too_many_pages_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/skill_not_found_error.py
+++ b/apps/backend/app/exceptions/_generated/skill_not_found_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/skill_not_found_params.py
+++ b/apps/backend/app/exceptions/_generated/skill_not_found_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/skill_validation_failed_error.py
+++ b/apps/backend/app/exceptions/_generated/skill_validation_failed_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/skill_validation_failed_params.py
+++ b/apps/backend/app/exceptions/_generated/skill_validation_failed_params.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from pydantic import BaseModel
 

--- a/apps/backend/app/exceptions/_generated/structured_output_failed_error.py
+++ b/apps/backend/app/exceptions/_generated/structured_output_failed_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/apps/backend/app/exceptions/_generated/validation_failed_error.py
+++ b/apps/backend/app/exceptions/_generated/validation_failed_error.py
@@ -1,4 +1,7 @@
-"""Generated from errors.yaml. Do not edit."""
+"""Generated from errors.yaml. Do not edit.
+
+Run ``task errors:generate`` to regenerate after editing errors.yaml.
+"""
 
 from typing import ClassVar
 

--- a/packages/error-contracts/scripts/generate.py
+++ b/packages/error-contracts/scripts/generate.py
@@ -240,7 +240,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
                 for name, ptype in sorted_param_items
             )
             params_file.write_text(
-                f'"""Generated from errors.yaml. Do not edit."""\n\n'
+                f'"""Generated from errors.yaml. Do not edit.\n\n'
+                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+                f'"""\n\n'
                 f"from pydantic import BaseModel\n\n\n"
                 f"class {params_class_name}(BaseModel):\n"
                 f'    """Parameters for {code} error."""\n\n'
@@ -279,7 +281,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
                 f"app.exceptions._generated.{params_file_stem}", params_class_name
             )
             error_content = (
-                f'"""Generated from errors.yaml. Do not edit."""\n\n'
+                f'"""Generated from errors.yaml. Do not edit.\n\n'
+                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+                f'"""\n\n'
                 f"from typing import ClassVar\n\n"
                 f"{params_import_line}\n"
                 f"from app.exceptions.base import DomainError\n\n\n"
@@ -291,7 +295,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
             )
         else:
             error_content = (
-                f'"""Generated from errors.yaml. Do not edit."""\n\n'
+                f'"""Generated from errors.yaml. Do not edit.\n\n'
+                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+                f'"""\n\n'
                 f"from typing import ClassVar\n\n"
                 f"from app.exceptions.base import DomainError\n\n\n"
                 f"class {error_class_name}(DomainError):\n"
@@ -315,7 +321,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
     sorted_imports = sorted(init_imports, key=lambda entry: entry[1])
     init_file = output_dir / "__init__.py"
     init_content = (
-        '"""Generated error classes. Do not edit."""\n\n'
+        '"""Generated error classes. Do not edit.\n\n'
+        "Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+        '"""\n\n'
         + "\n".join(_py_import_line(module, name) for module, name in sorted_imports)
         + "\n\n__all__ = [\n"
         + "\n".join(f'    "{name}",' for _module, name in sorted_imports)
@@ -346,7 +354,9 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
     # affects the user-visible dict-key order.
     sorted_registry_entries = sorted(registry_entries)
     registry_content = (
-        '"""Generated error registry. Do not edit."""\n\n'
+        '"""Generated error registry. Do not edit.\n\n'
+        "Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
+        '"""\n\n'
         "from __future__ import annotations\n\n"
         "from typing import TYPE_CHECKING\n\n"
         "if TYPE_CHECKING:\n"

--- a/packages/error-contracts/scripts/generate.py
+++ b/packages/error-contracts/scripts/generate.py
@@ -57,6 +57,29 @@ PARAM_TYPE_TO_TS: dict[str, str] = {
 # generated imports are pre-formatted consistently with ruff format --check.
 _PY_LINE_LENGTH_LIMIT = 100
 
+# Shared regenerate-command pointer embedded in every emitted Python file's
+# module docstring (issue #373). Factored to a module-level constant so the
+# five emitter sites below (params class, error class with params, error
+# class without params, __init__.py, _registry.py) cannot drift — each site
+# composes its file-specific first line with this trailer via
+# ``_py_generated_header`` rather than copy-pasting the three-line docstring
+# (PR #517 review).
+_PY_GENERATED_REGENERATE_HINT = (
+    "Run ``task errors:generate`` to regenerate after editing errors.yaml."
+)
+
+
+def _py_generated_header(first_line: str) -> str:
+    """Return the shared triple-quoted module docstring header.
+
+    ``first_line`` is the file-specific one-liner (e.g. ``"Generated from
+    errors.yaml. Do not edit."``) that precedes the shared regenerate-command
+    pointer. The returned string is a complete, standalone module docstring
+    terminated with ``\\n\\n`` so emitters can concatenate imports / class
+    bodies directly after it.
+    """
+    return f'"""{first_line}\n\n{_PY_GENERATED_REGENERATE_HINT}\n"""\n\n'
+
 
 def _py_import_line(module: str, name: str) -> str:
     """Format a `from <module> import <name>` line, wrapping if > line-length.
@@ -240,13 +263,11 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
                 for name, ptype in sorted_param_items
             )
             params_file.write_text(
-                f'"""Generated from errors.yaml. Do not edit.\n\n'
-                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
-                f'"""\n\n'
-                f"from pydantic import BaseModel\n\n\n"
-                f"class {params_class_name}(BaseModel):\n"
-                f'    """Parameters for {code} error."""\n\n'
-                f"{fields}\n"
+                _py_generated_header("Generated from errors.yaml. Do not edit.")
+                + "from pydantic import BaseModel\n\n\n"
+                + f"class {params_class_name}(BaseModel):\n"
+                + f'    """Parameters for {code} error."""\n\n'
+                + f"{fields}\n"
             )
             generated_files.append(params_file)
             init_imports.append(
@@ -281,31 +302,28 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
                 f"app.exceptions._generated.{params_file_stem}", params_class_name
             )
             error_content = (
-                f'"""Generated from errors.yaml. Do not edit.\n\n'
-                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
-                f'"""\n\n'
-                f"from typing import ClassVar\n\n"
-                f"{params_import_line}\n"
-                f"from app.exceptions.base import DomainError\n\n\n"
-                f"class {error_class_name}(DomainError):\n"
-                f'    """Error: {code}."""\n\n'
-                f'    code: ClassVar[str] = "{code}"\n'
-                f"    http_status: ClassVar[int] = {http_status}\n\n"
-                f"    def __init__(self, *, {init_signature}) -> None:\n" + super_block
+                _py_generated_header("Generated from errors.yaml. Do not edit.")
+                + "from typing import ClassVar\n\n"
+                + f"{params_import_line}\n"
+                + "from app.exceptions.base import DomainError\n\n\n"
+                + f"class {error_class_name}(DomainError):\n"
+                + f'    """Error: {code}."""\n\n'
+                + f'    code: ClassVar[str] = "{code}"\n'
+                + f"    http_status: ClassVar[int] = {http_status}\n\n"
+                + f"    def __init__(self, *, {init_signature}) -> None:\n"
+                + super_block
             )
         else:
             error_content = (
-                f'"""Generated from errors.yaml. Do not edit.\n\n'
-                f"Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
-                f'"""\n\n'
-                f"from typing import ClassVar\n\n"
-                f"from app.exceptions.base import DomainError\n\n\n"
-                f"class {error_class_name}(DomainError):\n"
-                f'    """Error: {code}."""\n\n'
-                f'    code: ClassVar[str] = "{code}"\n'
-                f"    http_status: ClassVar[int] = {http_status}\n\n"
-                f"    def __init__(self) -> None:\n"
-                f"        super().__init__(params=None)\n"
+                _py_generated_header("Generated from errors.yaml. Do not edit.")
+                + "from typing import ClassVar\n\n"
+                + "from app.exceptions.base import DomainError\n\n\n"
+                + f"class {error_class_name}(DomainError):\n"
+                + f'    """Error: {code}."""\n\n'
+                + f'    code: ClassVar[str] = "{code}"\n'
+                + f"    http_status: ClassVar[int] = {http_status}\n\n"
+                + "    def __init__(self) -> None:\n"
+                + "        super().__init__(params=None)\n"
             )
 
         error_file.write_text(error_content)
@@ -321,9 +339,7 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
     sorted_imports = sorted(init_imports, key=lambda entry: entry[1])
     init_file = output_dir / "__init__.py"
     init_content = (
-        '"""Generated error classes. Do not edit.\n\n'
-        "Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
-        '"""\n\n'
+        _py_generated_header("Generated error classes. Do not edit.")
         + "\n".join(_py_import_line(module, name) for module, name in sorted_imports)
         + "\n\n__all__ = [\n"
         + "\n".join(f'    "{name}",' for _module, name in sorted_imports)
@@ -354,13 +370,11 @@ def generate_python(errors_path: Path, output_dir: Path) -> list[Path]:
     # affects the user-visible dict-key order.
     sorted_registry_entries = sorted(registry_entries)
     registry_content = (
-        '"""Generated error registry. Do not edit.\n\n'
-        "Run ``task errors:generate`` to regenerate after editing errors.yaml.\n"
-        '"""\n\n'
-        "from __future__ import annotations\n\n"
-        "from typing import TYPE_CHECKING\n\n"
-        "if TYPE_CHECKING:\n"
-        "    from app.exceptions.base import DomainError\n\n"
+        _py_generated_header("Generated error registry. Do not edit.")
+        + "from __future__ import annotations\n\n"
+        + "from typing import TYPE_CHECKING\n\n"
+        + "if TYPE_CHECKING:\n"
+        + "    from app.exceptions.base import DomainError\n\n"
         + "\n".join(_py_import_line(module, name) for module, name in error_imports)
         + "\n\n"
         + "ERROR_CLASSES: dict[str, type[DomainError]] = {\n"

--- a/packages/error-contracts/tests/test_generate.py
+++ b/packages/error-contracts/tests/test_generate.py
@@ -1,5 +1,6 @@
 """Tests for the error contracts code generator."""
 
+import ast
 import json
 from pathlib import Path
 
@@ -575,6 +576,12 @@ def test_generated_python_files_mention_regenerate_command(
     ``task errors:generate`` so a contributor reading the file sees the
     regeneration command without having to check the TypeScript output or
     the root Taskfile (issue #373).
+
+    The check is pinned against the module docstring specifically (the
+    first statement in the file, via ``ast.get_docstring``) rather than
+    a whole-file substring search. A whole-file check would silently pass
+    if the hint regressed out of the docstring but appeared later in a
+    class docstring, comment, or string literal (PR #517 review).
     """
     from scripts.generate import generate_python
 
@@ -593,8 +600,13 @@ def test_generated_python_files_mention_regenerate_command(
         "_registry.py",
     ):
         content = (output_dir / py_file).read_text()
-        assert "task errors:generate" in content, (
-            f"{py_file} docstring must mention `task errors:generate` "
+        module_docstring = ast.get_docstring(ast.parse(content))
+        assert module_docstring is not None, (
+            f"{py_file} must have a module docstring as its first statement "
+            f"(issue #373). Got file content:\n{content[:300]}"
+        )
+        assert "task errors:generate" in module_docstring, (
+            f"{py_file} module docstring must mention `task errors:generate` "
             f"so contributors find the regeneration command in-file "
-            f"(issue #373). Got:\n{content[:300]}"
+            f"(issue #373). Got docstring:\n{module_docstring}"
         )

--- a/packages/error-contracts/tests/test_generate.py
+++ b/packages/error-contracts/tests/test_generate.py
@@ -539,3 +539,62 @@ def test_generate_required_keys_is_deterministic_across_param_key_order(
     )
 
     assert json_forward.read_bytes() == json_swapped.read_bytes()
+
+
+# Provenance-in-docstring regression test for issue #373.
+#
+# The TypeScript generator output begins with:
+#   `// THIS FILE IS GENERATED FROM errors.yaml`
+#   `// DO NOT EDIT BY HAND. Run `task errors:generate` to regenerate.`
+# while the Python module docstrings only said
+#   `"""Generated from errors.yaml. Do not edit."""`
+# Contributors reading a generated Python file had no in-file pointer to
+# the regenerate command, forcing them to hunt for it. These tests pin
+# the regenerate-command mention in every Python artifact type the
+# generator emits (per-error class, params class, __init__.py, _registry.py)
+# so the provenance cannot silently regress.
+_PROVENANCE_YAML = """
+version: 1
+errors:
+  NOT_FOUND:
+    http_status: 404
+    description: Resource not found
+    params: {}
+  WIDGET_NOT_FOUND:
+    http_status: 404
+    description: Widget not found
+    params:
+      widget_id: string
+"""
+
+
+def test_generated_python_files_mention_regenerate_command(
+    tmp_path: Path, output_dir: Path
+):
+    """Every generated Python artifact's module docstring must reference
+    ``task errors:generate`` so a contributor reading the file sees the
+    regeneration command without having to check the TypeScript output or
+    the root Taskfile (issue #373).
+    """
+    from scripts.generate import generate_python
+
+    errors_path = tmp_path / "errors.yaml"
+    errors_path.write_text(_PROVENANCE_YAML)
+
+    generate_python(errors_path, output_dir)
+
+    # Every emitted file type: per-error class, params class, aggregate
+    # __init__.py, and _registry.py.
+    for py_file in (
+        "not_found_error.py",
+        "widget_not_found_error.py",
+        "widget_not_found_params.py",
+        "__init__.py",
+        "_registry.py",
+    ):
+        content = (output_dir / py_file).read_text()
+        assert "task errors:generate" in content, (
+            f"{py_file} docstring must mention `task errors:generate` "
+            f"so contributors find the regeneration command in-file "
+            f"(issue #373). Got:\n{content[:300]}"
+        )


### PR DESCRIPTION
Closes #373.

## Summary

- Python generator in `packages/error-contracts/scripts/generate.py` now emits module docstrings that mention `` `task errors:generate` ``, matching the existing TypeScript header's regenerate-command provenance.
- Contributors reading a generated Python file (per-error class, params class, `__init__.py`, or `_registry.py`) see the escape hatch in-file instead of having to cross-reference the TS output or the root Taskfile.
- All 26 generated Python files regenerated via `task errors:generate` to pick up the new template.

## Template change

Before (per-error/params class):
```python
"""Generated from errors.yaml. Do not edit."""
```

After:
```python
"""Generated from errors.yaml. Do not edit.

Run ``task errors:generate`` to regenerate after editing errors.yaml.
"""
```

(Same shape for the `__init__.py` and `_registry.py` aggregate docstrings, which keep their original first-line wording and gain the same regenerate hint.)

## Test plan

- [x] New TDD regression test `test_generated_python_files_mention_regenerate_command` in `packages/error-contracts/tests/test_generate.py` — asserts every emitted artifact type contains `task errors:generate`. Started RED on the old template, GREEN after the fix.
- [x] Full `packages/error-contracts/tests/` suite (66 tests) passes locally.
- [x] `apps/backend/tests/unit/` suite (1083 tests) passes — no downstream regression from the regenerated files.
- [x] `apps/backend/tests/unit/architecture/` (126 tests) passes.
- [x] `scripts.check.main()` (the `task errors:check` drift gate) reports "in sync with errors.yaml" — template change and regenerated files are consistent.
- [x] `ruff check` + `ruff format --check` pass on backend and error-contracts trees.
- [x] Pre-push hook (pyright strict + backend unit tests) passed on `git push`.

AI-assisted with Claude.

