### PR TITLE
fix(core): preserve 32-char hex request_id in redaction (closes #375)

### DIFF
--- a/apps/backend/app/core/log_redaction_filter.py
+++ b/apps/backend/app/core/log_redaction_filter.py
@@ -49,6 +49,17 @@ _EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 _NUMERIC_PATTERN = re.compile(
     r"(?<!line )\b(?:\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d{4,}(?:\.\d+)?)\b"
 )
+# 32-char lowercase hex tokens — the request_id format mandated by
+# PDFX-E007-F003 (see ``RequestIdMiddleware``). `merge_contextvars` normally
+# surfaces request_id as its own event-dict key, but an f-string log call
+# (``logger.error(f"failed for {request_id}")``) can smuggle the id into a
+# rendered traceback. The numeric pattern would then scrub any digit-only
+# or digit-leading span that matches `\b\d{4,}\b` — destroying log
+# correlation. Masking these tokens before numeric scrubbing (and restoring
+# them after) pins the correlation invariant explicitly (issue #375).
+_REQUEST_ID_PATTERN = re.compile(r"\b[a-f0-9]{32}\b")
+_REQUEST_ID_PLACEHOLDER_PREFIX = "\x00REQID"
+_REQUEST_ID_PLACEHOLDER_SUFFIX = "\x00"
 
 
 class LogRedactionFilter:
@@ -104,8 +115,28 @@ class LogRedactionFilter:
         return result
 
     def _scrub_exception_string(self, value: str) -> str:
-        scrubbed = _EMAIL_PATTERN.sub(_REDACTED_EMAIL, value)
-        return _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, scrubbed)
+        # Mask 32-char hex request_id tokens with positional placeholders before
+        # running numeric redaction, then restore them verbatim. Without this,
+        # an all-digit uuid4.hex or a digit-leading id smuggled into a
+        # traceback via an f-string would be mangled to [REDACTED_NUMBER],
+        # breaking log correlation (issue #375).
+        preserved: list[str] = []
+
+        def _mask(match: re.Match[str]) -> str:
+            token = match.group(0)
+            placeholder = (
+                f"{_REQUEST_ID_PLACEHOLDER_PREFIX}{len(preserved)}{_REQUEST_ID_PLACEHOLDER_SUFFIX}"
+            )
+            preserved.append(token)
+            return placeholder
+
+        masked = _REQUEST_ID_PATTERN.sub(_mask, value)
+        scrubbed = _EMAIL_PATTERN.sub(_REDACTED_EMAIL, masked)
+        scrubbed = _NUMERIC_PATTERN.sub(_REDACTED_NUMBER, scrubbed)
+        for index, token in enumerate(preserved):
+            placeholder = f"{_REQUEST_ID_PLACEHOLDER_PREFIX}{index}{_REQUEST_ID_PLACEHOLDER_SUFFIX}"
+            scrubbed = scrubbed.replace(placeholder, token)
+        return scrubbed
 
     def _is_redacted_key(self, key: Any) -> bool:
         # Non-string keys cannot be case-folded and are not in the denylist.

--- a/apps/backend/tests/unit/core/test_log_redaction_filter.py
+++ b/apps/backend/tests/unit/core/test_log_redaction_filter.py
@@ -293,3 +293,53 @@ def test_exception_key_still_redacts_long_numbers_not_after_line_keyword() -> No
     out = _call(_filter(), event="unhandled_exception", exception=traceback)
     assert "987654321" not in out["exception"]
     assert "4321" not in out["exception"]
+
+
+@pytest.mark.parametrize(
+    "request_id",
+    [
+        # Mixed hex with long internal digit run; word-boundary flanking hex
+        # letters currently shields this from the regex, but the invariant is
+        # load-bearing for log correlation and must be pinned explicitly.
+        "abc12345678def0123456789abcdef01",
+        # All-digits uuid4.hex (statistically rare but valid `[a-f0-9]{32}`);
+        # without explicit preservation the 32-digit run trips `\b\d{4,}\b`.
+        "00000000000000000000000000000000",
+        "12345678901234567890123456789012",
+        # Digit run immediately preceded by a non-hex-letter boundary and
+        # terminated by a hex letter mid-id.
+        "deadbeef12345678abcdef0123456789",
+    ],
+)
+def test_exception_key_preserves_embedded_request_id(request_id: str) -> None:
+    """Issue #375: a 32-char hex request_id embedded in an exception message survives scrubbing.
+
+    Although ``request_id`` is normally bound as its own log key via
+    ``merge_contextvars`` and never appears inside ``exception``, any
+    f-string log call (``logger.error(f"failed for {request_id}")``) can
+    smuggle the id into a rendered traceback. The numeric redaction pattern
+    must preserve 32-char hex tokens so log correlation survives — mangling
+    an all-digit id to ``[REDACTED_NUMBER]`` destroys the link between the
+    failure and the request that caused it.
+    """
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"RuntimeError: failed for {request_id}"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+
+
+def test_exception_key_preserves_request_id_but_still_redacts_surrounding_numbers() -> None:
+    """Preserving 32-char hex ids must not leak adjacent numeric PII in the same message."""
+    request_id = "00000000000000000000000000000000"
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        f"RuntimeError: invoice 1847.50 for request {request_id} failed"
+    )
+    out = _call(_filter(), event="unhandled_exception", exception=traceback)
+    assert request_id in out["exception"]
+    assert "1847.50" not in out["exception"]
+    assert "1847" not in out["exception"]


### PR DESCRIPTION
## Summary

- `LogRedactionFilter._scrub_exception_string` used `\b\d{4,}\b` to scrub numeric PII from rendered tracebacks; a 32-char hex `request_id` smuggled into a traceback via an f-string could match this pattern when the id was all-digit or digit-leading with a non-hex-letter terminator, destroying log correlation.
- Mask 32-char hex tokens with positional placeholders before numeric scrubbing and restore them verbatim afterwards, pinning the invariant documented in PDFX-E007-F003.

## Test plan

- [x] `task check` green locally (lint, format, pyright strict, arch, skills, unit, integration, contract, errors)
- [x] New parametrized unit test `test_exception_key_preserves_embedded_request_id` covering mixed-hex, all-digit, and digit-leading 32-char ids
- [x] New regression test `test_exception_key_preserves_request_id_but_still_redacts_surrounding_numbers` confirming adjacent numeric PII (`1847.50`) is still scrubbed alongside the preserved id

Closes #375.

AI-assisted with Claude.
