### PR TITLE
refactor(config): centralize reportCallIssue ignore (closes #378)

### DIFF
--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -293,3 +293,21 @@ class Settings(BaseSettings):
     # queued on a semaphore wait list. Queuing would pile up callers behind
     # their own 504 timeout budget and defeat the backpressure contract.
     max_concurrent_extractions: Annotated[int, Field(gt=0)] = 4
+
+
+def load_settings() -> Settings:
+    """Construct a ``Settings`` instance from environment / dotenv / defaults.
+
+    Thin wrapper around ``Settings()`` whose sole purpose is centralizing the
+    ``# type: ignore[reportCallIssue]`` suppression that every no-arg call site
+    would otherwise repeat. Pyright (strict) flags ``Settings()`` because
+    pydantic-settings does not expose a ``.from_env()`` classmethod that
+    returns ``Self`` — every field is declared with a default or a
+    ``default_factory`` and the runtime pulls values from env / ``.env`` /
+    defaults, but pyright cannot see that path through the ``BaseSettings``
+    signature. Narrowly suppressing the complaint here means production call
+    sites (``app/main.py``, ``ollama_gemma_provider.py``,
+    ``extraction_engine.py``) can call ``load_settings()`` with no inline
+    pragma, and the justification lives in exactly one place (issue #378).
+    """
+    return Settings()  # type: ignore[reportCallIssue]  # pydantic-settings populates fields from env / .env / defaults

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -322,4 +322,6 @@ def load_settings() -> Settings:
     ``extraction_engine.py``) can call ``load_settings()`` with no inline
     pragma, and the justification lives in exactly one place (issue #378).
     """
-    return Settings()  # type: ignore[reportCallIssue]  # pydantic-settings populates fields from env / .env / defaults
+    # pydantic-settings populates fields from env / .env / defaults at
+    # runtime, even though pyright cannot prove that through BaseSettings.
+    return Settings()  # type: ignore[reportCallIssue]

--- a/apps/backend/app/features/extraction/extraction/extraction_engine.py
+++ b/apps/backend/app/features/extraction/extraction/extraction_engine.py
@@ -52,7 +52,7 @@ from typing import TYPE_CHECKING, Any, cast
 import langextract
 from langextract.core.data import AnnotatedDocument, ExampleData, Extraction
 
-from app.core.config import Settings
+from app.core.config import Settings, load_settings
 from app.features.extraction.extraction._validating_langextract_adapter import (
     _ValidatingLangExtractAdapter,  # pyright: ignore[reportPrivateUsage]
     # ^ The adapter and this module are co-owners of the LangExtract
@@ -92,7 +92,7 @@ class ExtractionEngine:
         # env variables, matching the rest of the service.
         settings = self._settings
         if settings is None:
-            settings = Settings()  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
+            settings = load_settings()
             self._settings = settings
         return settings.ollama_timeout_seconds
 

--- a/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
+++ b/apps/backend/app/features/extraction/intelligence/ollama_gemma_provider.py
@@ -49,7 +49,7 @@ from langextract.core.base_model import BaseLanguageModel
 from langextract.core.types import ScoredOutput
 from langextract.providers.router import register
 
-from app.core.config import Settings
+from app.core.config import Settings, load_settings
 from app.exceptions import IntelligenceTimeoutError, IntelligenceUnavailableError
 from app.features.extraction.intelligence.correction_prompt_builder import (
     CorrectionPromptBuilder,
@@ -227,7 +227,7 @@ class OllamaGemmaProvider(BaseLanguageModel):
         **_langextract_kwargs: Any,
     ) -> None:
         super().__init__()
-        effective_settings = settings if settings is not None else Settings()  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
+        effective_settings = settings if settings is not None else load_settings()
         effective_validator = (
             validator
             if validator is not None

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -14,7 +14,7 @@ from app.api.errors import register_exception_handlers
 from app.api.health_router import router as health_router
 from app.api.middleware import configure_middleware
 from app.api.probe_cache import ProbeCache
-from app.core.config import Settings
+from app.core.config import Settings, load_settings
 from app.core.logging import configure_logging
 from app.exceptions import SkillValidationFailedError
 from app.features.extraction.intelligence.ollama_health_probe import (
@@ -301,7 +301,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     `application.state.settings` so `get_settings` (and every dependency
     that depends on it) reads it back through the FastAPI request path.
     """
-    resolved_settings = settings or Settings()  # type: ignore[reportCallIssue]  # pydantic-settings loads fields from env
+    resolved_settings = settings or load_settings()
 
     # Compute the production flag once and reuse it for every prod-only
     # branch (JSON logging + hidden ``/docs`` / ``/redoc`` / ``/openapi.json``).

--- a/apps/backend/tests/unit/core/test_config.py
+++ b/apps/backend/tests/unit/core/test_config.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from app.core.config import Settings
+from app.core.config import Settings, load_settings
 
 
 def test_settings_defaults() -> None:
@@ -359,3 +359,37 @@ def test_settings_app_env_accepts_three_known_values() -> None:
     for value in ("development", "production", "testing"):
         s = Settings(app_env=value)  # type: ignore[arg-type]
         assert s.app_env == value
+
+
+# -- load_settings() helper (issue #378) ------------------------------------
+#
+# ``load_settings()`` centralizes the ``# type: ignore[reportCallIssue]``
+# suppression previously repeated at three production call sites
+# (``app/main.py``, ``features/extraction/intelligence/ollama_gemma_provider.py``,
+# ``features/extraction/extraction/extraction_engine.py``). Pyright strict
+# flags ``Settings()`` because pydantic-settings does not surface the
+# "fields-from-env" construction path in its class signature. Wrapping the
+# call in one narrowly-suppressed helper removes the repeated justification
+# comments and keeps the suppression in a single location.
+
+
+def test_load_settings_returns_settings_instance() -> None:
+    """``load_settings()`` must return a ``Settings`` instance loaded from env."""
+    result = load_settings()
+    assert isinstance(result, Settings)
+
+
+def test_load_settings_equivalent_to_direct_construction() -> None:
+    """``load_settings()`` must behave identically to ``Settings()``.
+
+    The helper is a pure re-export of the no-arg ``Settings()`` call — its
+    sole purpose is centralizing the ``reportCallIssue`` suppression, not
+    changing semantics. Key defaults must match to prove the helper is not
+    silently mutating inputs.
+    """
+    via_helper = load_settings()
+    direct = Settings()
+    assert via_helper.app_env == direct.app_env
+    assert via_helper.log_level == direct.log_level
+    assert via_helper.ollama_model == direct.ollama_model
+    assert via_helper.ollama_base_url == direct.ollama_base_url


### PR DESCRIPTION
## Summary

- Centralize the `# type: ignore[reportCallIssue]` suppression previously repeated at three production call sites (`app/main.py`, `features/extraction/intelligence/ollama_gemma_provider.py`, `features/extraction/extraction/extraction_engine.py`) into a single `load_settings()` helper in `app/core/config.py`.
- Pyright strict flags `Settings()` because pydantic-settings populates fields from env/.env/defaults rather than surfacing a typed no-arg constructor. The wrapper narrows the suppression to one spot with a single justification comment; all three call sites now call `load_settings()` with no inline pragma.
- Covered by two new unit tests in `tests/unit/core/test_config.py` that pin the return type and behavioral equivalence to direct `Settings()` construction.

## Test plan

- [x] `task check` passes locally (lint, pyright strict on `app/` + `scripts/` + `tests/`, import-linter contracts, skills:validate, unit, integration, contract, errors:check, errors:test).
- [x] Pre-commit + pre-push hooks pass (pyright strict + backend unit tests green).
- [x] `grep -rn reportCallIssue apps/backend/app/` returns only the single centralized occurrence in `core/config.py`.