### PR TITLE
test(conftest): move make_skill to tests/_support (closes #354)

### DIFF
--- a/apps/backend/tests/_support/__init__.py
+++ b/apps/backend/tests/_support/__init__.py
@@ -1,0 +1,10 @@
+"""Opt-in test helpers that would otherwise force heavy imports at conftest load.
+
+Lives under ``tests/_support/`` (not ``tests/conftest.py``) so that only the
+test modules that actually need a helper pay the import cost of the
+production packages the helper depends on. Centralising these in
+``conftest.py`` forced every test file pytest discovers to load the
+transitive closure of every helper's dependencies -- a real drag on unit
+test startup for tests that only touch coordinates, schemas, or the core
+logger (issue #354).
+"""

--- a/apps/backend/tests/_support/skill_factory.py
+++ b/apps/backend/tests/_support/skill_factory.py
@@ -1,0 +1,40 @@
+"""Factory for building minimal valid ``Skill`` objects in tests.
+
+Moved out of ``tests/conftest.py`` (issue #354) so that unit tests which
+never touch the skills feature do not pay the extraction-skills import
+tax at conftest load time. Callers that need a skill instance import
+``make_skill`` directly from this module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.extraction.skills import Skill, SkillDoclingConfig, SkillExample
+from app.features.extraction.skills.deep_freeze import deep_freeze_mapping
+
+
+def make_skill(name: str, version: int) -> Skill:
+    """Construct a minimal valid ``Skill`` for test fixtures.
+
+    Lives in ``tests/_support/`` (not under any specific test package)
+    because multiple test modules across unit and integration need it --
+    keeping it co-located with ``test_skill_manifest.py`` forced cross-test
+    imports that coupled unrelated files to that module's private helper.
+    """
+    output_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"number": {"type": "string"}},
+        "required": ["number"],
+    }
+    # Deep-freeze to match production `Skill.from_schema` behaviour so
+    # accidental in-test mutations fail the same way they would at runtime.
+    return Skill(
+        name=name,
+        version=version,
+        description=None,
+        prompt="Extract header fields.",
+        examples=(SkillExample(input="INV-1", output={"number": "INV-1"}),),
+        output_schema=deep_freeze_mapping(output_schema),
+        docling_config=SkillDoclingConfig(),
+    )

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,23 +1,25 @@
-"""Shared test fixtures and fakes used across unit and integration tests."""
+"""Shared test fixtures and fakes used across unit and integration tests.
+
+Kept deliberately skinny -- this module loads for every test file pytest
+collects, so any import here is a tax paid by the entire suite (issue
+#354). Helpers whose construction needs production-module imports live
+under ``tests/_support/`` and are imported explicitly by the test
+modules that actually use them.
+"""
 
 from __future__ import annotations
-
-from typing import Any
-
-from app.features.extraction.skills import Skill, SkillDoclingConfig, SkillExample
-from app.features.extraction.skills.deep_freeze import deep_freeze_mapping
 
 
 class FakeProbeExhausted(BaseException):
     """Raised by ``FakeProbe.check`` when scripted results are exhausted.
 
-    Subclasses ``BaseException`` — *not* ``Exception`` — deliberately.
+    Subclasses ``BaseException`` -- *not* ``Exception`` -- deliberately.
 
     Production code paths that consume ``probe.check()`` (``ProbeCache.is_ready``
     and ``app.main._lifespan``) wrap the call in a broad ``except Exception``
     so that any unexpected ``Exception`` subclass is degraded into a cached
     ``False`` instead of propagating and turning ``/ready`` into a 500 (issue
-    #144). That guard is load-bearing for the ``/ready`` contract — but it
+    #144). That guard is load-bearing for the ``/ready`` contract -- but it
     would silently swallow an ``AssertionError`` from an exhausted ``FakeProbe``,
     converting a misconfigured test into a green ``False`` result instead of a
     loud pytest failure.
@@ -59,29 +61,3 @@ class FakeProbe:
         result = self._results[self.call_count]
         self.call_count += 1
         return result
-
-
-def make_skill(name: str, version: int) -> Skill:
-    """Construct a minimal valid ``Skill`` for test fixtures.
-
-    Lives here (not in ``tests/unit/features/extraction/skills/...``) because
-    multiple test modules across unit and integration need it — keeping it
-    co-located with ``test_skill_manifest.py`` forced cross-test imports
-    that coupled unrelated files to that module's private helper.
-    """
-    output_schema: dict[str, Any] = {
-        "type": "object",
-        "properties": {"number": {"type": "string"}},
-        "required": ["number"],
-    }
-    # Deep-freeze to match production `Skill.from_schema` behaviour so
-    # accidental in-test mutations fail the same way they would at runtime.
-    return Skill(
-        name=name,
-        version=version,
-        description=None,
-        prompt="Extract header fields.",
-        examples=(SkillExample(input="INV-1", output={"number": "INV-1"}),),
-        output_schema=deep_freeze_mapping(output_schema),
-        docling_config=SkillDoclingConfig(),
-    )

--- a/apps/backend/tests/integration/test_health.py
+++ b/apps/backend/tests/integration/test_health.py
@@ -21,7 +21,8 @@ from app.api.deps import get_probe_cache, get_skill_manifest
 from app.api.probe_cache import ProbeCache
 from app.features.extraction.skills import SkillManifest
 from app.main import app
-from tests.conftest import FakeProbe, make_skill
+from tests._support.skill_factory import make_skill
+from tests.conftest import FakeProbe
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/apps/backend/tests/unit/api/test_health_router.py
+++ b/apps/backend/tests/unit/api/test_health_router.py
@@ -19,7 +19,7 @@ from app.api.health_router import health, ready
 from app.api.schemas.not_ready_response import NotReadyResponse
 from app.api.schemas.ready_response import ReadyResponse
 from app.features.extraction.skills import SkillManifest
-from tests.conftest import make_skill
+from tests._support.skill_factory import make_skill
 
 # ---------------------------------------------------------------------------
 # Fakes

--- a/apps/backend/tests/unit/architecture/test_conftest_import_cost.py
+++ b/apps/backend/tests/unit/architecture/test_conftest_import_cost.py
@@ -1,0 +1,107 @@
+"""Architecture gate: ``tests/conftest.py`` stays lazy w.r.t. extraction.
+
+Issue #354: importing ``tests/conftest.py`` used to eagerly pull in
+``app.features.extraction.skills`` (including deep-freeze mapping, skill
+manifest validation, Skill / SkillExample / SkillDoclingConfig dataclasses)
+for every test file pytest discovers -- unit tests that only touch
+coordinates, schemas, or the core logger paid that load-time tax.
+
+The fix moved ``make_skill`` and its extraction imports into an explicit
+``tests/_support/skill_factory.py`` module that callers opt into. This
+architecture test pins that invariant: ``tests.conftest`` must not
+statically import from ``app.features.extraction.*`` at module scope, and
+importing it at runtime must not load the extraction skills package
+transitively.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+from ._linter_subprocess import BACKEND_DIR
+
+_CONFTEST_PATH: Final[Path] = BACKEND_DIR / "tests" / "conftest.py"
+
+
+def _collect_static_dotted_imports(source: str) -> set[str]:
+    """Return every dotted module name referenced by a top-level import."""
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None and node.level == 0:
+            names.add(node.module)
+    return names
+
+
+def test_conftest_has_no_static_extraction_feature_imports() -> None:
+    """``tests/conftest.py`` must not statically import from ``app.features.*``.
+
+    Extraction-feature modules are heavy (deep-freeze validation, docling
+    config dataclasses, skill manifest). Pulling them in at conftest scope
+    forces every test file pytest collects to pay the load cost -- even
+    unit tests that only touch coordinates or schemas. ``make_skill`` now
+    lives in ``tests/_support/skill_factory.py``; callers import it
+    explicitly from there.
+    """
+    source = _CONFTEST_PATH.read_text()
+    dotted = _collect_static_dotted_imports(source)
+    offending = {name for name in dotted if name.startswith("app.features.")}
+    assert not offending, (
+        "tests/conftest.py must not import from app.features.* at module scope; "
+        f"found: {sorted(offending)!r} -- move heavy helpers into "
+        "tests/_support/ and import from there at each call site (issue #354)"
+    )
+
+
+def test_importing_conftest_does_not_load_extraction_skills_package() -> None:
+    """Importing ``tests.conftest`` must not transitively load the skills pkg.
+
+    Guards against regression via a re-export / star-import that hides a
+    heavy dependency behind an indirect module reference. Runs the import
+    inside a subprocess with a clean ``sys.modules`` so the check is not
+    confounded by sibling test modules that legitimately import the
+    skills package via ``tests/_support/skill_factory.py``. A subprocess
+    is the honest way to observe the transitive-import cost of
+    ``tests.conftest`` in isolation.
+    """
+    script = (
+        "import sys\n"
+        "import importlib\n"
+        "importlib.import_module('tests.conftest')\n"
+        "leaked = sorted(\n"
+        "    name for name in sys.modules\n"
+        "    if name.startswith('app.features.extraction.skills')\n"
+        ")\n"
+        "print(repr(leaked))\n"
+    )
+    # The CLAUDE.md prohibition on ``os.environ`` targets reading config
+    # values that belong behind pydantic-settings. Here it is only used to
+    # inherit the parent process environment into the subprocess and prepend
+    # ``BACKEND_DIR`` so the subprocess can resolve the ``tests.`` package
+    # the same way pytest does via its ``pythonpath = ["."]`` setting.
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{BACKEND_DIR}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=BACKEND_DIR,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    leaked_repr = result.stdout.strip()
+    assert leaked_repr == "[]", (
+        "importing tests.conftest must not transitively load "
+        f"app.features.extraction.skills; leaked modules: {leaked_repr} "
+        "(issue #354)"
+    )

--- a/apps/backend/tests/unit/architecture/test_conftest_import_cost.py
+++ b/apps/backend/tests/unit/architecture/test_conftest_import_cost.py
@@ -20,6 +20,7 @@ import ast
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Final
 
@@ -28,15 +29,57 @@ from ._linter_subprocess import BACKEND_DIR
 _CONFTEST_PATH: Final[Path] = BACKEND_DIR / "tests" / "conftest.py"
 
 
+def _iter_module_scope_imports(tree: ast.Module) -> Iterator[ast.Import | ast.ImportFrom]:
+    """Yield every Import/ImportFrom that binds a name at module scope.
+
+    Descends into top-level compound statements (If/Try/TryStar/With/For/
+    While/Match) because their bodies execute at module scope in Python —
+    names bound inside them are visible at module scope. Function,
+    async-function, and class bodies DO create their own lexical scopes and
+    are skipped so a deliberately-lazy ``import heavy_mod`` inside a
+    fixture body is not flagged by this gate (PR #524 review). Mirrors
+    ``_iter_module_scope_imports`` in ``test_dynamic_import_containment.py``
+    so the same descent policy applies to both containment gates.
+    """
+    try_star_type: type[ast.AST] | None = getattr(ast, "TryStar", None)
+    stack: list[ast.stmt] = list(tree.body)
+    while stack:
+        node = stack.pop(0)
+        if isinstance(node, ast.Import | ast.ImportFrom):
+            yield node
+            continue
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        if isinstance(node, ast.If):
+            stack[:0] = list(node.body) + list(node.orelse)
+        elif isinstance(node, ast.Try):
+            handlers: list[ast.stmt] = [s for h in node.handlers for s in h.body]
+            stack[:0] = list(node.body) + handlers + list(node.orelse) + list(node.finalbody)
+        elif try_star_type is not None and isinstance(node, try_star_type):
+            handlers = [s for h in node.handlers for s in h.body]  # type: ignore[attr-defined]  # TryStar exposes handlers like Try
+            stack[:0] = (
+                list(node.body)  # type: ignore[attr-defined]
+                + handlers
+                + list(node.orelse)  # type: ignore[attr-defined]
+                + list(node.finalbody)  # type: ignore[attr-defined]
+            )
+        elif isinstance(node, ast.With | ast.AsyncWith):
+            stack[:0] = list(node.body)
+        elif isinstance(node, ast.For | ast.AsyncFor | ast.While):
+            stack[:0] = list(node.body) + list(node.orelse)
+        elif isinstance(node, ast.Match):
+            stack[:0] = [s for c in node.cases for s in c.body]
+
+
 def _collect_static_dotted_imports(source: str) -> set[str]:
-    """Return every dotted module name referenced by a top-level import."""
+    """Return every dotted module name referenced by a module-scope import."""
     tree = ast.parse(source)
     names: set[str] = set()
-    for node in ast.walk(tree):
+    for node in _iter_module_scope_imports(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 names.add(alias.name)
-        elif isinstance(node, ast.ImportFrom) and node.module is not None and node.level == 0:
+        elif node.module is not None and node.level == 0:
             names.add(node.module)
     return names
 
@@ -105,3 +148,46 @@ def test_importing_conftest_does_not_load_extraction_skills_package() -> None:
         f"app.features.extraction.skills; leaked modules: {leaked_repr} "
         "(issue #354)"
     )
+
+
+def test_collect_static_dotted_imports_skips_imports_inside_function_body() -> None:
+    """Lazy imports inside a fixture body MUST NOT be flagged as module-scope.
+
+    PR #524 review: the previous ``ast.walk`` implementation descended into
+    function bodies, so a fixture that did ``import heavy_mod`` lazily
+    inside its body was flagged even though the whole point of the lazy
+    import is to avoid the module-scope tax. The module-scope visitor now
+    used by ``_collect_static_dotted_imports`` correctly skips function and
+    method bodies.
+    """
+    source = (
+        "def fixture_maker() -> object:\n"
+        "    import app.features.extraction.skills\n"
+        "    return None\n"
+    )
+    assert "app.features.extraction.skills" not in _collect_static_dotted_imports(source)
+
+
+def test_collect_static_dotted_imports_catches_module_scope_import() -> None:
+    """A plain module-scope import IS still flagged (control case)."""
+    source = "import app.features.extraction.skills\n"
+    assert "app.features.extraction.skills" in _collect_static_dotted_imports(source)
+
+
+def test_collect_static_dotted_imports_catches_conditional_module_scope_import() -> None:
+    """A module-scope ``try: import X`` at top level IS flagged.
+
+    Compound statements (``try``/``if``/``with``/``for``/``match``) don't
+    introduce a new lexical scope in Python — a name bound inside their
+    body is visible at module scope. So the visitor must descend into
+    them, matching the policy of ``_iter_module_scope_imports`` in the
+    sibling ``test_dynamic_import_containment.py``.
+    """
+    source = "try:\n    import app.features.extraction.skills\nexcept ImportError:\n    pass\n"
+    assert "app.features.extraction.skills" in _collect_static_dotted_imports(source)
+
+
+def test_collect_static_dotted_imports_skips_imports_inside_class_body() -> None:
+    """Class-body imports are local to the class scope and MUST NOT be flagged."""
+    source = "class _Holder:\n    import app.features.extraction.skills as _skills_mod\n"
+    assert "app.features.extraction.skills" not in _collect_static_dotted_imports(source)

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_manifest.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_manifest.py
@@ -4,7 +4,7 @@ import pytest
 
 from app.exceptions import SkillNotFoundError
 from app.features.extraction.skills.skill_manifest import SkillManifest
-from tests.conftest import make_skill
+from tests._support.skill_factory import make_skill
 
 
 @pytest.fixture
@@ -77,10 +77,11 @@ def test_populated_manifest_is_empty_false(manifest: SkillManifest) -> None:
 def test_make_skill_helper_produces_valid_skill() -> None:
     """Guard against silent ``make_skill`` breakage across test modules.
 
-    ``make_skill`` lives in ``tests/conftest.py`` and is imported by
-    unit and integration tests; if its shape drifts from ``Skill``'s
-    runtime invariants, the callers surface misleading errors. This
-    test is the canonical check so breakage shows up here first.
+    ``make_skill`` lives in ``tests/_support/skill_factory.py`` and is
+    imported by unit and integration tests; if its shape drifts from
+    ``Skill``'s runtime invariants, the callers surface misleading
+    errors. This test is the canonical check so breakage shows up here
+    first.
     """
     skill = make_skill("invoice", 7)
     assert skill.name == "invoice"

--- a/apps/backend/tests/unit/features/extraction/skills/test_skill_manifest_empty_warning.py
+++ b/apps/backend/tests/unit/features/extraction/skills/test_skill_manifest_empty_warning.py
@@ -14,7 +14,7 @@ import pytest
 from app.exceptions import SkillNotFoundError
 from app.features.extraction.skills import skill_manifest as skill_manifest_module
 from app.features.extraction.skills.skill_manifest import SkillManifest
-from tests.conftest import make_skill
+from tests._support.skill_factory import make_skill
 
 
 class _SpyLogger:


### PR DESCRIPTION
## Summary

- `tests/conftest.py` was eagerly importing `app.features.extraction.skills`
  (Skill, SkillExample, SkillDoclingConfig, deep_freeze_mapping) to back the
  `make_skill` factory. pytest loads `conftest.py` for every test file it
  collects, so every unit test -- including ones that only touch coordinates,
  schemas, or the core logger -- paid the transitive extraction-skills import
  tax at collection time (issue #354).
- Moves `make_skill` and its imports into a new `tests/_support/skill_factory.py`
  module. The four call sites now import the factory explicitly. `FakeProbe` /
  `FakeProbeExhausted` stay in `conftest.py` because they have no production
  imports.
- New architecture test `test_conftest_import_cost.py` pins the invariant two
  ways: an AST scan that fails if `tests/conftest.py` declares any
  `from app.features.*` top-level import, and a subprocess-isolated check that
  imports `tests.conftest` and asserts no `app.features.extraction.skills*`
  entry lands in `sys.modules`.

## Test plan

- [x] `task check` passes locally (lint, types, architecture, skills, unit
      1105 passed, integration 103 passed, contract 25 passed, error-contracts
      66 passed)
- [x] New architecture tests `test_conftest_has_no_static_extraction_feature_imports`
      and `test_importing_conftest_does_not_load_extraction_skills_package`
      collected and pass
- [x] The four updated call sites (`test_skill_manifest.py`,
      `test_skill_manifest_empty_warning.py`, `test_health_router.py`,
      `test_health.py`) still resolve `make_skill` after the move and continue
      passing
