### PR TITLE
test(support): share make_canned_result helper (closes #404)

### DIFF
--- a/apps/backend/tests/_support/__init__.py
+++ b/apps/backend/tests/_support/__init__.py
@@ -1,0 +1,8 @@
+"""Cross-tree test-support helpers.
+
+Modules under ``tests/_support/`` host helpers that are shared across
+multiple test levels (unit, integration, contract) and cannot live in a
+single ``conftest.py`` because they must be importable by name, not
+injected via fixtures. Keep this tree small and narrowly scoped: if a
+helper is only needed by one test file, inline it there instead.
+"""

--- a/apps/backend/tests/_support/extraction_fixtures.py
+++ b/apps/backend/tests/_support/extraction_fixtures.py
@@ -1,0 +1,72 @@
+"""Shared builders for extraction-pipeline test doubles (issue #404).
+
+Three near-identical ``_make_canned_result`` copies used to live inline in
+``tests/contract/_helpers.py``, ``tests/integration/features/extraction/
+test_extract_endpoint.py``, and ``tests/integration/scripts/test_benchmark.py``.
+When the extraction schemas grew, each copy had to be edited
+independently — exactly the kind of drift CLAUDE.md's "one way to do each
+thing" rule exists to prevent. The callers vary the field name, the
+page count, and whether an annotated-PDF byte blob is attached, but
+otherwise produce a structurally identical ``ExtractionResult`` shape.
+
+Callers pass the diverging values as keyword arguments; defaults
+reproduce the single-field ``"number"``-shaped happy-path result used by
+the contract layer and most integration tests.
+"""
+
+from __future__ import annotations
+
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.extract_response import ExtractResponse
+from app.features.extraction.schemas.extracted_field import ExtractedField
+from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
+from app.features.extraction.schemas.field_status import FieldStatus
+
+_DEFAULT_BBOX = BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)
+
+
+def make_canned_result(  # noqa: PLR0913  # each field maps to a distinct knob; merging loses call-site clarity
+    *,
+    field_name: str = "number",
+    field_value: str = "INV-001",
+    page_count: int = 1,
+    duration_ms: int = 500,
+    skill_name: str = "invoice",
+    skill_version: int = 1,
+    bbox_refs: list[BoundingBoxRef] | None = None,
+    annotated_pdf_bytes: bytes | None = None,
+) -> ExtractionResult:
+    """Return an ``ExtractionResult`` shaped for the 200 happy path.
+
+    All arguments are keyword-only so adding a new knob is backward-
+    compatible. When ``bbox_refs`` is ``None`` the helper falls back to a
+    single-bbox default; pass ``[]`` explicitly to produce an ungrounded
+    field with no bounding boxes.
+
+    The returned object exercises the same field/metadata/response
+    shape the extraction router emits on success; callers override just
+    the field name and page count they need for their specific skill
+    fixture.
+    """
+    refs = [_DEFAULT_BBOX] if bbox_refs is None else bbox_refs
+    field = ExtractedField(
+        name=field_name,
+        value=field_value,
+        status=FieldStatus.extracted,
+        source="document",
+        grounded=True,
+        bbox_refs=refs,
+    )
+    metadata = ExtractionMetadata(
+        page_count=page_count,
+        duration_ms=duration_ms,
+        attempts_per_field={field_name: 1},
+    )
+    response = ExtractResponse(
+        skill_name=skill_name,
+        skill_version=skill_version,
+        fields={field_name: field},
+        metadata=metadata,
+    )
+    return ExtractionResult(response=response, annotated_pdf_bytes=annotated_pdf_bytes)

--- a/apps/backend/tests/_support/extraction_fixtures.py
+++ b/apps/backend/tests/_support/extraction_fixtures.py
@@ -16,6 +16,8 @@ the contract layer and most integration tests.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from app.features.extraction.extraction_result import ExtractionResult
 from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
 from app.features.extraction.schemas.extract_response import ExtractResponse
@@ -23,7 +25,16 @@ from app.features.extraction.schemas.extracted_field import ExtractedField
 from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
 from app.features.extraction.schemas.field_status import FieldStatus
 
-_DEFAULT_BBOX = BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)
+
+def _default_bbox() -> BoundingBoxRef:
+    """Construct a fresh default ``BoundingBoxRef`` per call.
+
+    A module-level singleton would be reused across every caller, and
+    ``BoundingBoxRef`` is a mutable Pydantic model — mutation in one test
+    could leak into subsequent calls. Building a new instance per call
+    isolates fixtures from each other.
+    """
+    return BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)
 
 
 def make_canned_result(  # noqa: PLR0913  # each field maps to a distinct knob; merging loses call-site clarity
@@ -41,21 +52,26 @@ def make_canned_result(  # noqa: PLR0913  # each field maps to a distinct knob; 
 
     All arguments are keyword-only so adding a new knob is backward-
     compatible. When ``bbox_refs`` is ``None`` the helper falls back to a
-    single-bbox default; pass ``[]`` explicitly to produce an ungrounded
-    field with no bounding boxes.
+    single-bbox default and produces a grounded, document-sourced field;
+    pass ``[]`` explicitly to produce an ungrounded, inferred field with
+    no bounding boxes. ``grounded`` and ``source`` are always derived
+    from whether any refs were supplied so the two shapes stay in lock-
+    step with the extraction pipeline's invariant.
 
     The returned object exercises the same field/metadata/response
     shape the extraction router emits on success; callers override just
     the field name and page count they need for their specific skill
     fixture.
     """
-    refs = [_DEFAULT_BBOX] if bbox_refs is None else bbox_refs
+    refs = [_default_bbox()] if bbox_refs is None else bbox_refs
+    grounded = bool(refs)
+    source: Literal["document", "inferred"] = "document" if grounded else "inferred"
     field = ExtractedField(
         name=field_name,
         value=field_value,
         status=FieldStatus.extracted,
-        source="document",
-        grounded=True,
+        source=source,
+        grounded=grounded,
         bbox_refs=refs,
     )
     metadata = ExtractionMetadata(

--- a/apps/backend/tests/contract/_helpers.py
+++ b/apps/backend/tests/contract/_helpers.py
@@ -7,6 +7,13 @@ so `/openapi.json` is exposed), and a canned `ExtractionResult` for the
 200 happy path. Keeping one definition here instead of two copies means
 a contract-envelope change lands in one place; the two test files drift
 less as the spec evolves.
+
+The canned-result builder itself (`make_canned_result`) lives in
+``tests/_support/extraction_fixtures`` so the contract layer, the
+``/extract`` integration suite, and the benchmark integration suite all
+consume a single parametrized helper (issue #404). It is re-exported
+here so existing contract-test imports (``from tests.contract._helpers
+import make_canned_result``) keep working without a second path.
 """
 
 from __future__ import annotations
@@ -16,12 +23,9 @@ from pathlib import Path
 import yaml
 
 from app.core.config import Settings
-from app.features.extraction.extraction_result import ExtractionResult
-from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
-from app.features.extraction.schemas.extract_response import ExtractResponse
-from app.features.extraction.schemas.extracted_field import ExtractedField
-from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
-from app.features.extraction.schemas.field_status import FieldStatus
+from tests._support.extraction_fixtures import make_canned_result
+
+__all__ = ["make_canned_result", "settings", "write_valid_skill"]
 
 
 def write_valid_skill(base: Path) -> None:
@@ -50,27 +54,3 @@ def settings(skills_dir: Path, **overrides: object) -> Settings:
     `create_app` uses to disable the OpenAPI route in prod).
     """
     return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
-
-
-def make_canned_result() -> ExtractionResult:
-    """Return a canned `ExtractionResult` for the 200 happy-path contract test."""
-    field = ExtractedField(
-        name="number",
-        value="INV-001",
-        status=FieldStatus.extracted,
-        source="document",
-        grounded=True,
-        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
-    )
-    metadata = ExtractionMetadata(
-        page_count=1,
-        duration_ms=500,
-        attempts_per_field={"number": 1},
-    )
-    response = ExtractResponse(
-        skill_name="invoice",
-        skill_version=1,
-        fields={"number": field},
-        metadata=metadata,
-    )
-    return ExtractionResult(response=response, annotated_pdf_bytes=None)

--- a/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
+++ b/apps/backend/tests/integration/features/extraction/test_extract_endpoint.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import email.parser
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import yaml
@@ -18,14 +19,12 @@ from httpx import ASGITransport, AsyncClient
 from app.api.deps import get_extraction_service
 from app.core.config import Settings
 from app.exceptions import IntelligenceTimeoutError
-from app.features.extraction.extraction_result import ExtractionResult
-from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
-from app.features.extraction.schemas.extract_response import ExtractResponse
-from app.features.extraction.schemas.extracted_field import ExtractedField
-from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
-from app.features.extraction.schemas.field_status import FieldStatus
 from app.features.extraction.service import ExtractionService
 from app.main import create_app
+from tests._support.extraction_fixtures import make_canned_result as _make_canned_result
+
+if TYPE_CHECKING:
+    from app.features.extraction.extraction_result import ExtractionResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,32 +52,6 @@ def _write_valid_skill(base: Path) -> None:
 
 def _settings(skills_dir: Path, **overrides) -> Settings:
     return Settings(skills_dir=skills_dir, app_env="development", **overrides)  # type: ignore[reportCallIssue]
-
-
-def _make_canned_result(
-    *,
-    annotated_pdf_bytes: bytes | None = None,
-) -> ExtractionResult:
-    field = ExtractedField(
-        name="number",
-        value="INV-001",
-        status=FieldStatus.extracted,
-        source="document",
-        grounded=True,
-        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
-    )
-    metadata = ExtractionMetadata(
-        page_count=1,
-        duration_ms=500,
-        attempts_per_field={"number": 1},
-    )
-    response = ExtractResponse(
-        skill_name="invoice",
-        skill_version=1,
-        fields={"number": field},
-        metadata=metadata,
-    )
-    return ExtractionResult(response=response, annotated_pdf_bytes=annotated_pdf_bytes)
 
 
 def _stub_service(result: ExtractionResult | None = None, *, side_effect=None) -> ExtractionService:

--- a/apps/backend/tests/integration/scripts/test_benchmark.py
+++ b/apps/backend/tests/integration/scripts/test_benchmark.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import socket
 import threading
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -30,15 +30,13 @@ import yaml
 from app.api.deps import get_extraction_service
 from app.core.config import Settings
 from app.exceptions import IntelligenceUnavailableError
-from app.features.extraction.extraction_result import ExtractionResult
-from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
-from app.features.extraction.schemas.extract_response import ExtractResponse
-from app.features.extraction.schemas.extracted_field import ExtractedField
-from app.features.extraction.schemas.extraction_metadata import ExtractionMetadata
-from app.features.extraction.schemas.field_status import FieldStatus
 from app.features.extraction.service import ExtractionService
 from app.main import create_app
 from scripts.benchmark import main as bench_main
+from tests._support.extraction_fixtures import make_canned_result
+
+if TYPE_CHECKING:
+    from app.features.extraction.extraction_result import ExtractionResult
 
 pytestmark = pytest.mark.slow
 
@@ -89,32 +87,6 @@ def _write_bench_skill(base: Path) -> None:
     (target / "1.yaml").write_text(yaml.safe_dump(body), encoding="utf-8")
 
 
-def _make_canned_result(
-    *,
-    annotated_pdf_bytes: bytes | None = None,
-) -> ExtractionResult:
-    field = ExtractedField(
-        name="invoice_number",
-        value="INV-001",
-        status=FieldStatus.extracted,
-        source="document",
-        grounded=True,
-        bbox_refs=[BoundingBoxRef(page=1, x0=10.0, y0=20.0, x1=100.0, y1=30.0)],
-    )
-    metadata = ExtractionMetadata(
-        page_count=10,
-        duration_ms=500,
-        attempts_per_field={"invoice_number": 1},
-    )
-    response = ExtractResponse(
-        skill_name="invoice",
-        skill_version=1,
-        fields={"invoice_number": field},
-        metadata=metadata,
-    )
-    return ExtractionResult(response=response, annotated_pdf_bytes=annotated_pdf_bytes)
-
-
 def _stub_service(
     result: ExtractionResult | None = None,
     *,
@@ -124,7 +96,9 @@ def _stub_service(
     if side_effect is not None:
         svc.extract.side_effect = side_effect
     else:
-        svc.extract.return_value = result or _make_canned_result(
+        svc.extract.return_value = result or make_canned_result(
+            field_name="invoice_number",
+            page_count=10,
             annotated_pdf_bytes=_FAKE_PDF_BYTES,
         )
     return svc

--- a/apps/backend/tests/unit/meta/test_support_extraction_fixtures.py
+++ b/apps/backend/tests/unit/meta/test_support_extraction_fixtures.py
@@ -1,0 +1,83 @@
+"""Meta-tests for ``tests/_support/extraction_fixtures.make_canned_result``.
+
+This test file documents the shared canned-result builder's contract. The
+helper itself replaced three near-identical inline copies (issue #404);
+the existing contract and integration suites that now import it are the
+primary regression net. These cases pin the load-bearing behaviours that
+callers rely on so a future tweak cannot silently break the three
+callers together.
+"""
+
+from __future__ import annotations
+
+from app.features.extraction.extraction_result import ExtractionResult
+from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
+from app.features.extraction.schemas.field_status import FieldStatus
+from tests._support.extraction_fixtures import make_canned_result
+
+
+def test_make_canned_result_defaults_are_happy_path_shape() -> None:
+    """Default call yields the single-field `"number"` happy-path result."""
+    result = make_canned_result()
+
+    assert isinstance(result, ExtractionResult)
+    assert result.annotated_pdf_bytes is None
+
+    response = result.response
+    assert response.skill_name == "invoice"
+    assert response.skill_version == 1
+    assert list(response.fields) == ["number"]
+    assert response.metadata.page_count == 1
+    assert response.metadata.duration_ms == 500
+    assert response.metadata.attempts_per_field == {"number": 1}
+
+    field = response.fields["number"]
+    assert field.name == "number"
+    assert field.value == "INV-001"
+    assert field.status is FieldStatus.extracted
+    assert field.grounded is True
+    assert len(field.bbox_refs) == 1
+    bbox = field.bbox_refs[0]
+    assert (bbox.page, bbox.x0, bbox.y0, bbox.x1, bbox.y1) == (1, 10.0, 20.0, 100.0, 30.0)
+
+
+def test_make_canned_result_field_name_propagates_to_fields_and_attempts() -> None:
+    """``field_name`` drives the ``fields`` key and the ``attempts_per_field`` key together."""
+    result = make_canned_result(field_name="invoice_number")
+
+    response = result.response
+    assert list(response.fields) == ["invoice_number"]
+    assert response.fields["invoice_number"].name == "invoice_number"
+    assert response.metadata.attempts_per_field == {"invoice_number": 1}
+
+
+def test_make_canned_result_page_count_is_propagated() -> None:
+    """``page_count`` is forwarded to the metadata verbatim."""
+    result = make_canned_result(page_count=10)
+
+    assert result.response.metadata.page_count == 10
+
+
+def test_make_canned_result_annotated_pdf_bytes_are_attached() -> None:
+    """An ``annotated_pdf_bytes`` blob survives onto the result untouched."""
+    payload = b"%PDF-1.4 annotated"
+
+    result = make_canned_result(annotated_pdf_bytes=payload)
+
+    assert result.annotated_pdf_bytes == payload
+
+
+def test_make_canned_result_explicit_empty_bbox_refs_ungrounded_field() -> None:
+    """Passing ``bbox_refs=[]`` overrides the default single-bbox fallback."""
+    result = make_canned_result(bbox_refs=[])
+
+    assert result.response.fields["number"].bbox_refs == []
+
+
+def test_make_canned_result_custom_bbox_refs_are_used_as_is() -> None:
+    """A caller-supplied ``bbox_refs`` list is preserved without a default prepend."""
+    bbox = BoundingBoxRef(page=2, x0=1.0, y0=2.0, x1=3.0, y1=4.0)
+
+    result = make_canned_result(bbox_refs=[bbox])
+
+    assert result.response.fields["number"].bbox_refs == [bbox]

--- a/apps/backend/tests/unit/meta/test_support_extraction_fixtures.py
+++ b/apps/backend/tests/unit/meta/test_support_extraction_fixtures.py
@@ -68,10 +68,13 @@ def test_make_canned_result_annotated_pdf_bytes_are_attached() -> None:
 
 
 def test_make_canned_result_explicit_empty_bbox_refs_ungrounded_field() -> None:
-    """Passing ``bbox_refs=[]`` overrides the default single-bbox fallback."""
+    """Passing ``bbox_refs=[]`` yields an explicitly ungrounded, inferred field."""
     result = make_canned_result(bbox_refs=[])
 
-    assert result.response.fields["number"].bbox_refs == []
+    field = result.response.fields["number"]
+    assert field.bbox_refs == []
+    assert field.grounded is False
+    assert field.source == "inferred"
 
 
 def test_make_canned_result_custom_bbox_refs_are_used_as_is() -> None:


### PR DESCRIPTION
## Summary

- Three near-identical `_make_canned_result` inline builders in `tests/contract/_helpers.py`, `tests/integration/features/extraction/test_extract_endpoint.py`, and `tests/integration/scripts/test_benchmark.py` had drifted (different field names, different page counts, different bbox lists). If `ExtractionResult` grew a required field, all three needed editing and drift risk was high.
- Extract the builder into `tests/_support/extraction_fixtures.py::make_canned_result` with keyword-only knobs (`field_name`, `field_value`, `page_count`, `duration_ms`, `skill_name`, `skill_version`, `bbox_refs`, `annotated_pdf_bytes`). Defaults reproduce the single-field `"number"` happy-path shape. Each caller now passes just the arguments it needs.
- The contract helper re-exports `make_canned_result` from the shared module so the existing `from tests.contract._helpers import make_canned_result` imports in `test_extract_contract.py` and `test_schemathesis.py` keep working without a second path.
- Add a focused meta-test (`tests/unit/meta/test_support_extraction_fixtures.py`) pinning the helper's contract: defaults, field-name propagation to both `fields` and `attempts_per_field`, page-count propagation, annotated-PDF blob pass-through, and the empty/custom `bbox_refs` overrides.
- A 4th copy exists in `tests/integration/test_degraded_startup.py` (not listed in issue #404) — left in place to keep this PR tightly scoped to the 3 named files.

## Test plan

- [x] `task check` — all gates green (lint, format, pyright strict backend + error-contracts, import-linter 11/11 contracts kept, skills:validate, unit 1109 passed / 95.75% coverage, integration 103 passed, contract 25 passed, errors:check + errors:test 66 passed).
- [x] Pre-commit hooks (ruff, ruff-format, pyright, unit tests) pass on commit.
- [x] Pre-push hooks pass.
- [x] Pre-existing `test_extract_contract.py` / `test_schemathesis.py` / `test_extract_endpoint.py` / `test_benchmark.py` (slow-marked, run explicitly with `pytest -m slow`) behave unchanged because the helper preserves each caller's prior output byte-for-byte.