### PR TITLE
fix(extraction): clamp end lookup at block boundary (closes #382)

### DIFF
--- a/apps/backend/app/features/extraction/coordinates/span_resolver.py
+++ b/apps/backend/app/features/extraction/coordinates/span_resolver.py
@@ -6,6 +6,7 @@ import structlog
 
 from app.features.extraction.coordinates.char_range import CharRange
 from app.features.extraction.coordinates.offset_index import OffsetIndex
+from app.features.extraction.coordinates.offset_index_entry import OffsetIndexEntry
 from app.features.extraction.coordinates.sub_block_matcher import SubBlockMatcher
 from app.features.extraction.extraction.raw_extraction import RawExtraction
 from app.features.extraction.parsing.parsed_document import ParsedDocument
@@ -127,6 +128,20 @@ class SpanResolver:
 
         start_lookup = offset_index.lookup(start_offset)
         end_lookup = offset_index.lookup(end_offset - 1)
+        if start_lookup is not None and end_lookup is None:
+            # Issue #382: LangExtract sometimes reports `end_offset` a few chars
+            # past the exclusive end of the start block, so `end_offset - 1`
+            # lands in the separator gap that immediately follows the block and
+            # `OffsetIndex.lookup` returns None even though the span is
+            # genuinely grounded at the block boundary. When the overshoot is
+            # bounded by the next block's start (not hallucinated well past all
+            # blocks), clamp the end lookup to the start block's last inclusive
+            # offset so the single-block grounded path is taken.
+            end_lookup = _retry_end_lookup_at_block_boundary(
+                offset_index=offset_index,
+                start_offset=start_offset,
+                end_offset=end_offset,
+            )
         if start_lookup is None or end_lookup is None:
             _logger.info(
                 "span_resolver_hallucinated_offsets",
@@ -205,6 +220,75 @@ class SpanResolver:
             reason="matcher_failed",
         )
         return _whole_block_bbox(block)
+
+
+def _retry_end_lookup_at_block_boundary(
+    *,
+    offset_index: OffsetIndex,
+    start_offset: int,
+    end_offset: int,
+) -> tuple[str, int] | None:
+    """Retry the end lookup when ``end_offset - 1`` falls into the gap right
+    after the start block (issue #382).
+
+    Returns an ``OffsetIndex.lookup`` result for the start block's last
+    inclusive offset when:
+
+    - there is a start entry containing ``start_offset``; and
+    - ``end_offset - 1`` is past the start entry's exclusive end but before
+      the next (non-empty) entry begins — i.e. the overshoot is bounded by
+      the adjacent separator gap and is not a span reaching past all blocks.
+
+    Returns ``None`` otherwise, preserving the hallucinated-offsets behavior
+    guarded by the existing tests for end offsets that overshoot well past
+    the last block.
+    """
+    start_entry = _entry_containing(offset_index, start_offset)
+    if start_entry is None:
+        return None
+    next_entry = _next_content_entry_after(offset_index, start_entry)
+    if next_entry is None:
+        # No bounded gap — end_offset could be anywhere past the last block,
+        # which is a genuine hallucination and must stay ungrounded.
+        return None
+    if end_offset - 1 < start_entry.end:
+        # The original end lookup would have succeeded; nothing to clamp.
+        return None
+    if end_offset - 1 >= next_entry.start:
+        # Overshoot crosses into (or past) the next content block. If the
+        # original end lookup still returned None, the span is hallucinated
+        # past multiple blocks — leave it alone.
+        return None
+    # Clamp end_offset - 1 down to the start block's last inclusive offset.
+    return offset_index.lookup(start_entry.end - 1)
+
+
+def _entry_containing(
+    offset_index: OffsetIndex,
+    offset: int,
+) -> OffsetIndexEntry | None:
+    for entry in offset_index.entries:
+        if entry.start <= offset < entry.end:
+            return entry
+    return None
+
+
+def _next_content_entry_after(
+    offset_index: OffsetIndex,
+    target: OffsetIndexEntry,
+) -> OffsetIndexEntry | None:
+    # Skip zero-width entries (empty-text blocks) — they have no characters
+    # the clamp could legally reach, so the gap after ``target`` is bounded by
+    # the next entry with positive width.
+    passed_target = False
+    for entry in offset_index.entries:
+        if passed_target:
+            if entry.start < entry.end:
+                return entry
+            continue
+        if entry is target:
+            passed_target = True
+    return None
 
 
 def _synthesize_missing(name: str) -> ExtractedField:

--- a/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
+++ b/apps/backend/tests/unit/features/extraction/coordinates/test_span_resolver.py
@@ -366,6 +366,48 @@ def test_hallucinated_end_offset_past_block_returns_grounded_false() -> None:
     assert result[0].source == "inferred"
 
 
+def test_single_char_span_end_in_adjacent_separator_gap_resolves_to_start_block() -> None:
+    # Issue #382: LangExtract sometimes reports `end_offset` one (or a few)
+    # chars past the last inclusive offset of the start block, so `end_offset
+    # - 1` lands in the separator gap that immediately follows the block. The
+    # start side resolves normally, but `OffsetIndex.lookup(end_offset - 1)`
+    # returns `None` because the offset is past the block's exclusive end,
+    # kicking a span that is genuinely grounded in the start block into the
+    # hallucinated-offsets branch. The resolver must recognize this
+    # block-boundary overshoot — bounded by the immediately-following next
+    # block's start — and clamp the end lookup to the start block's last
+    # inclusive offset so the single-block grounded path is taken.
+    resolver = SpanResolver()
+    b0 = _block(block_id="b0", text="abcde", bbox=(0, 0, 50, 10))
+    b1 = _block(block_id="b1", text="fghij", bbox=(0, 20, 50, 30))
+    doc = _doc(b0, b1)
+    # b0 [0,5), separator gap [5,7) (two chars — matches default "\n\n"),
+    # b1 [7,12).
+    index = _index((0, 5, "b0"), (7, 12, "b1"))
+    # end_offset=6 is one past b0's exclusive end (5); end_offset - 1 = 5 is
+    # in the separator gap. The value "e" is b0's last character.
+    raw = RawExtraction(
+        field_name="last_char",
+        value="e",
+        char_offset_start=4,
+        char_offset_end=6,
+        grounded=True,
+        attempts=1,
+    )
+
+    result = resolver.resolve([raw], index, doc, ["last_char"])
+
+    field = result[0]
+    assert field.grounded is True
+    assert field.source == "document"
+    assert field.status == FieldStatus.extracted
+    assert len(field.bbox_refs) == 1
+    # Single-block resolution: whole-block bbox for b0 (glyph-level geometry
+    # is still unavailable per issue #151).
+    ref = field.bbox_refs[0]
+    assert (ref.page, ref.x0, ref.y0, ref.x1, ref.y1) == (1, 0.0, 0.0, 50.0, 10.0)
+
+
 def test_hallucinated_offsets_emit_info_log() -> None:
     resolver = SpanResolver()
     block = _block(block_id="b0", text="hello")


### PR DESCRIPTION
## Summary

- LangExtract sometimes reports `end_offset` one or more chars past the start block's exclusive end, so `end_offset - 1` falls in the separator gap that immediately follows the block. `OffsetIndex.lookup` then returns `None` and `SpanResolver._resolve_one` treats the span as hallucinated even though the value is genuinely grounded at the block boundary (issue #382).
- Retry the end lookup clamped to the start block's last inclusive offset, but only when the overshoot is bounded by the start of the next content block. Spans reaching past all blocks still fall through to the hallucinated-offsets branch so the existing behavior for that case (see `test_hallucinated_end_offset_past_block_returns_grounded_false`) is preserved.

## Test plan

- [x] New unit test `test_single_char_span_end_in_adjacent_separator_gap_resolves_to_start_block` reproduces the bug on `main` and passes with the fix.
- [x] All existing span_resolver / offset_index hallucinated-offset tests still pass.
- [x] `task check` green (lint, format, pyright strict, import-linter, skills validate, unit / integration / contract tests, errors check + tests).