### PR TITLE
test(infra): centralize repo-root path in tests/_paths.py (closes #402)

### DIFF
--- a/apps/backend/tests/_paths.py
+++ b/apps/backend/tests/_paths.py
@@ -1,0 +1,101 @@
+"""Central repo-root and repo-relative path constants for the test suite.
+
+Issue #402: eight+ test files hardcoded ``Path(__file__).resolve().parents[N]``
+with N varying (3, 4, 5) by file depth to reach the repo root. Any future
+directory reshuffle silently broke every hardcoded literal. This module
+centralises the resolution so moves to the tree layout touch one line.
+
+How it works:
+
+- ``REPO_ROOT`` is resolved at import time by walking up from this file
+  looking for the stable marker file ``Taskfile.yml`` (which is unique to
+  the repo root — the only ``Taskfile.yml`` in the repo). The walk is
+  bounded (``_MAX_WALK_DEPTH``) so a misconfigured checkout fails loudly
+  instead of climbing forever toward ``/``.
+- The walk runs *once* per interpreter, at module import, so the result
+  is cached in the ``Final`` module-level constants. Subsequent accesses
+  are trivial attribute reads.
+- Resolution is independent of ``os.getcwd()`` — ``Path(__file__)`` is an
+  absolute location pinned by the importer, so switching working
+  directories (as tests often do via ``monkeypatch.chdir`` or
+  ``tmp_path``) cannot affect the constants.
+
+Why a module under ``tests/`` and not ``conftest.py``:
+
+- ``conftest.py`` fixtures are lazily evaluated per test; the callers
+  here want module-level ``Final[Path]`` constants that can be used in
+  top-of-file assignments (e.g. ``_REPO_ROOT = ...`` before any test
+  function runs). A plain importable module fits that shape cleanly.
+- The leading underscore in the file name (``_paths.py``) mirrors the
+  existing ``_linter_subprocess.py`` convention in
+  ``tests/unit/architecture/``: internal test-support code, not a test
+  module itself.
+
+Callers that previously wrote ``Path(__file__).resolve().parents[5]``
+or ``Path(__file__).resolve().parents[3]`` should import the relevant
+constant(s) from this module instead. If a brand-new path landmark is
+needed, add it here (keyed off ``REPO_ROOT`` or an existing derivative)
+rather than reintroducing the ``parents[N]`` pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+# Upper bound for the walk-up search. The repo's deepest test file sits
+# about six levels below ``Taskfile.yml`` (e.g.
+# ``apps/backend/tests/unit/features/extraction/parsing/test_X.py``), so
+# walking up 15 levels gives comfortable headroom for future nesting while
+# still failing loudly if this module is ever relocated outside the repo.
+_MAX_WALK_DEPTH: Final[int] = 15
+
+# Marker file used to identify the repo root during the walk-up. Verified
+# unique to the repo root on 2026-04-23: ``find . -name Taskfile.yml``
+# returned exactly one hit. Chosen over ``.git`` because in git worktrees
+# that's a file rather than a directory and has been a historical footgun
+# for repo-detection helpers elsewhere.
+_REPO_ROOT_MARKER: Final[str] = "Taskfile.yml"
+
+
+def _resolve_repo_root() -> Path:
+    """Walk up from this file until we find ``Taskfile.yml``; return that dir.
+
+    Bounded by ``_MAX_WALK_DEPTH`` so a bad checkout or an accidental move
+    of this module surfaces as a ``RuntimeError`` at import time rather
+    than an infinite loop.
+    """
+    current = Path(__file__).resolve()
+    for _ in range(_MAX_WALK_DEPTH):
+        current = current.parent
+        if (current / _REPO_ROOT_MARKER).is_file():
+            return current
+    msg = (
+        f"tests/_paths.py could not find {_REPO_ROOT_MARKER!r} by walking up "
+        f"at most {_MAX_WALK_DEPTH} parents from {Path(__file__).resolve()}. "
+        "The module may have been moved outside the repo, or the marker file "
+        "has been renamed. Update _REPO_ROOT_MARKER or restore the file."
+    )
+    raise RuntimeError(msg)
+
+
+REPO_ROOT: Final[Path] = _resolve_repo_root()
+"""Absolute path to the monorepo root (the directory that owns ``Taskfile.yml``)."""
+
+BACKEND_DIR: Final[Path] = REPO_ROOT / "apps" / "backend"
+"""Absolute path to ``apps/backend/`` (the Python project root used by pytest)."""
+
+APP_DIR: Final[Path] = BACKEND_DIR / "app"
+"""Absolute path to ``apps/backend/app/`` — the FastAPI application package."""
+
+EXTRACTION_ROOT: Final[Path] = APP_DIR / "features" / "extraction"
+"""Absolute path to the extraction vertical slice under ``app/features/``."""
+
+TESTS_DIR: Final[Path] = BACKEND_DIR / "tests"
+"""Absolute path to ``apps/backend/tests/`` (the root of the test tree)."""
+
+TESTS_UNIT_DIR: Final[Path] = TESTS_DIR / "unit"
+"""Absolute path to ``apps/backend/tests/unit/`` (the unit test package)."""
+
+FIXTURES_DIR: Final[Path] = TESTS_DIR / "fixtures"
+"""Absolute path to ``apps/backend/tests/fixtures/`` (shared PDF fixtures etc.)."""

--- a/apps/backend/tests/integration/features/extraction/parsing/test_docling_document_parser_integration.py
+++ b/apps/backend/tests/integration/features/extraction/parsing/test_docling_document_parser_integration.py
@@ -25,9 +25,10 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import shutil
-from pathlib import Path
 
 import pytest
+
+from tests._paths import FIXTURES_DIR
 
 pytestmark = pytest.mark.slow
 
@@ -41,9 +42,7 @@ _PYMUPDF_AVAILABLE = importlib.util.find_spec("pymupdf") is not None
 # `pymupdf`, fixture PDFs) so `task test:slow` on a dev machine without
 # `brew install tesseract` reports a clear skip reason instead of a failure.
 _TESSERACT_AVAILABLE = shutil.which("tesseract") is not None
-# parents: [0]=parsing [1]=extraction [2]=features [3]=integration [4]=tests
-# so parents[4] is apps/backend/tests, which is where fixtures live.
-_FIXTURES_DIR = Path(__file__).resolve().parents[4] / "fixtures" / "pdfs"
+_FIXTURES_DIR = FIXTURES_DIR / "pdfs"
 _NATIVE_FIXTURE = _FIXTURES_DIR / "native_two_page.pdf"
 _SCANNED_FIXTURE = _FIXTURES_DIR / "scanned_one_page.pdf"
 

--- a/apps/backend/tests/integration/features/extraction/test_live_ollama_e2e.py
+++ b/apps/backend/tests/integration/features/extraction/test_live_ollama_e2e.py
@@ -60,13 +60,12 @@ from httpx import ASGITransport, AsyncClient
 
 from app.core.config import Settings
 from app.main import create_app
+from tests import _paths
 
 pytestmark = pytest.mark.slow
 
 
-# parents: [0]=extraction [1]=features [2]=integration [3]=tests
-# so parents[3] is apps/backend/tests, which is where fixtures live.
-_FIXTURES_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "pdfs"
+_FIXTURES_DIR = _paths.FIXTURES_DIR / "pdfs"
 _FIXTURE_PDF = _FIXTURES_DIR / "native_two_page.pdf"
 
 _DOCLING_AVAILABLE = importlib.util.find_spec("docling") is not None

--- a/apps/backend/tests/integration/test_taskfile_skills_validate.py
+++ b/apps/backend/tests/integration/test_taskfile_skills_validate.py
@@ -8,14 +8,12 @@ behavior of the script itself is covered by the unit tests in
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, cast
 
 import yaml
 
-# `parents[4]` resolves to the repo root:
-# parents[0]=integration → [1]=tests → [2]=backend → [3]=apps → [4]=<repo>.
-_REPO_ROOT = Path(__file__).resolve().parents[4]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _TASKFILE = _REPO_ROOT / "Taskfile.yml"
 
 

--- a/apps/backend/tests/unit/architecture/_linter_subprocess.py
+++ b/apps/backend/tests/unit/architecture/_linter_subprocess.py
@@ -31,6 +31,8 @@ import tempfile
 from pathlib import Path
 from typing import Final
 
+from tests import _paths
+
 # errno values that indicate `os.link` itself is unsupported or refused,
 # rather than a generic I/O fault. On those errnos we fall back to a
 # normal byte-copy so the suite stays portable across filesystems.
@@ -45,11 +47,14 @@ _HARDLINK_UNSUPPORTED_ERRNOS: Final[frozenset[int]] = frozenset(
     }
 )
 
-# parents[5] resolves the repo root by walking five levels up from this file:
-# _linter_subprocess.py -> architecture/ -> unit/ -> tests/ -> backend/ -> apps/ -> repo
-REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
-BACKEND_DIR: Final[Path] = REPO_ROOT / "apps" / "backend"
-REAL_APP_TREE: Final[Path] = BACKEND_DIR / "app"
+# Re-export the repo-root landmarks so existing importers (`from
+# tests.unit.architecture._linter_subprocess import REPO_ROOT`) keep
+# working without change. The single source of truth lives in
+# `tests/_paths.py` (issue #402) so future layout changes touch one
+# file, not eight.
+REPO_ROOT: Final[Path] = _paths.REPO_ROOT
+BACKEND_DIR: Final[Path] = _paths.BACKEND_DIR
+REAL_APP_TREE: Final[Path] = _paths.APP_DIR
 REAL_CONTRACTS_PATH: Final[Path] = BACKEND_DIR / "architecture" / "import-linter-contracts.ini"
 
 # Session cache for `copy_app_tree`. Lazily populated on first call; reused

--- a/apps/backend/tests/unit/architecture/test_lockfile_no_cuda.py
+++ b/apps/backend/tests/unit/architecture/test_lockfile_no_cuda.py
@@ -15,9 +15,10 @@ a bloated artifact.
 from __future__ import annotations
 
 import tomllib
-from pathlib import Path
 
-_LOCKFILE_PATH = Path(__file__).resolve().parents[3] / "uv.lock"
+from tests._paths import BACKEND_DIR
+
+_LOCKFILE_PATH = BACKEND_DIR / "uv.lock"
 
 # Package name prefixes we forbid from the lockfile. The entries are the 18
 # CUDA/NVIDIA packages that vanished after the pytorch-cpu index override; all

--- a/apps/backend/tests/unit/core/test_env_example_parity.py
+++ b/apps/backend/tests/unit/core/test_env_example_parity.py
@@ -15,12 +15,12 @@ configurable must be added to ``_WAIVED_FIELDS`` with a comment explaining why.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 from pydantic_settings import BaseSettings
 
 from app.core.config import Settings
 from scripts import BenchmarkSettings
+from tests._paths import BACKEND_DIR as _BACKEND_ROOT
 
 # Fields that intentionally do NOT appear in ``.env.example``. Empty today;
 # add entries with an inline comment explaining the waiver if the need ever
@@ -33,12 +33,6 @@ _WAIVED_FIELDS: frozenset[str] = frozenset()
 # ``os.environ`` and onto pydantic-settings.
 _SETTINGS_CLASSES: tuple[type[BaseSettings], ...] = (Settings, BenchmarkSettings)
 
-# ``apps/backend/tests/unit/core/test_env_example_parity.py``
-#   parents[0] = ``apps/backend/tests/unit/core/``
-#   parents[1] = ``apps/backend/tests/unit/``
-#   parents[2] = ``apps/backend/tests/``
-#   parents[3] = ``apps/backend/``
-_BACKEND_ROOT = Path(__file__).resolve().parents[3]
 _ENV_EXAMPLE = _BACKEND_ROOT / ".env.example"
 
 

--- a/apps/backend/tests/unit/docker/test_dockerfile_copy_order.py
+++ b/apps/backend/tests/unit/docker/test_dockerfile_copy_order.py
@@ -47,11 +47,9 @@ from typing import Final
 
 import pytest
 
-# parents[5] walks: this file -> docker/ -> unit/ -> tests/ -> backend/ ->
-# apps/ -> repo root. Same convention as
-# `tests/unit/docker/test_dockerignore_at_repo_root.py`.
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
-_DOCKERFILE_PATH: Final[Path] = _REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
+from tests._paths import REPO_ROOT
+
+_DOCKERFILE_PATH: Final[Path] = REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
 
 # Path fragments (relative to the build context, which is the repo root) that
 # identify each category of COPY. A line is classified by substring match on

--- a/apps/backend/tests/unit/docker/test_dockerfile_healthcheck_exec_form.py
+++ b/apps/backend/tests/unit/docker/test_dockerfile_healthcheck_exec_form.py
@@ -27,11 +27,9 @@ import re
 from pathlib import Path
 from typing import Final
 
-# parents[5] walks: this file -> docker/ -> unit/ -> tests/ -> backend/ ->
-# apps/ -> repo root. Mirrors the convention used by the sibling
-# `test_dockerignore_at_repo_root` module.
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
-_DOCKERFILE_PATH: Final[Path] = _REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
+from tests._paths import REPO_ROOT
+
+_DOCKERFILE_PATH: Final[Path] = REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
 
 
 def _read_dockerfile_text() -> str:

--- a/apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py
+++ b/apps/backend/tests/unit/docker/test_dockerignore_at_repo_root.py
@@ -24,12 +24,10 @@ from typing import Final
 
 import pytest
 
-# parents[5] walks: this file -> docker/ -> unit/ -> tests/ -> backend/ ->
-# apps/ -> repo root. This mirrors the convention used by
-# `tests/unit/architecture/_linter_subprocess.REPO_ROOT`.
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
-_ROOT_DOCKERIGNORE: Final[Path] = _REPO_ROOT / ".dockerignore"
-_MISPLACED_DOCKERIGNORE: Final[Path] = _REPO_ROOT / "apps" / "backend" / ".dockerignore"
+from tests._paths import REPO_ROOT
+
+_ROOT_DOCKERIGNORE: Final[Path] = REPO_ROOT / ".dockerignore"
+_MISPLACED_DOCKERIGNORE: Final[Path] = REPO_ROOT / "apps" / "backend" / ".dockerignore"
 
 # Exclusions that MUST appear in the root .dockerignore. These are the
 # directories/globs whose inclusion in the build context either bloats the

--- a/apps/backend/tests/unit/exceptions/test_error_contract_shape.py
+++ b/apps/backend/tests/unit/exceptions/test_error_contract_shape.py
@@ -5,11 +5,10 @@ CONFLICT, RATE_LIMITED) and against generated Python artifacts drifting from
 the YAML source of truth.
 """
 
-from pathlib import Path
-
 import yaml
 
 from app.exceptions._generated._registry import ERROR_CLASSES
+from tests._paths import REPO_ROOT
 
 EXPECTED_CODES = {
     "NOT_FOUND",
@@ -43,7 +42,6 @@ PRUNED_CODES = {
     "WIDGET_NAME_TOO_LONG",
 }
 
-REPO_ROOT = Path(__file__).resolve().parents[5]
 ERRORS_YAML = REPO_ROOT / "packages" / "error-contracts" / "errors.yaml"
 GENERATED_DIR = REPO_ROOT / "apps" / "backend" / "app" / "exceptions" / "_generated"
 

--- a/apps/backend/tests/unit/features/extraction/annotation/test_pdf_annotator.py
+++ b/apps/backend/tests/unit/features/extraction/annotation/test_pdf_annotator.py
@@ -26,7 +26,6 @@ import ast
 import asyncio
 import hashlib
 import inspect
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import pymupdf
@@ -36,6 +35,7 @@ from app.features.extraction.annotation.pdf_annotator import PdfAnnotator
 from app.features.extraction.schemas.bounding_box_ref import BoundingBoxRef
 from app.features.extraction.schemas.extracted_field import ExtractedField
 from app.features.extraction.schemas.field_status import FieldStatus
+from tests._paths import EXTRACTION_ROOT
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -453,12 +453,11 @@ def _collect_root_imports(source: str) -> set[str]:
 
 
 def test_pymupdf_imports_are_confined_to_pdf_annotator() -> None:
-    extraction_root = Path(__file__).resolve().parents[5] / "app" / "features" / "extraction"
-    assert extraction_root.is_dir(), f"extraction feature root not found at {extraction_root}"
+    assert EXTRACTION_ROOT.is_dir(), f"extraction feature root not found at {EXTRACTION_ROOT}"
 
     offenders: list[str] = []
-    for py_file in extraction_root.rglob("*.py"):
-        relative = py_file.relative_to(extraction_root).as_posix()
+    for py_file in EXTRACTION_ROOT.rglob("*.py"):
+        relative = py_file.relative_to(EXTRACTION_ROOT).as_posix()
         roots = _collect_root_imports(py_file.read_text())
         if roots & _FITZ_ROOTS and relative not in _ALLOWED_FITZ_IMPORTERS:
             offenders.append(relative)

--- a/apps/backend/tests/unit/features/extraction/extraction/test_no_third_party_imports.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_no_third_party_imports.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-_EXTRACTION_ROOT = Path(__file__).resolve().parents[5] / "app" / "features" / "extraction"
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_ROOT
 
 # LangExtract imports are permitted only in the engine file itself, the
 # adjacent validating adapter module (issue #228 split), and in the

--- a/apps/backend/tests/unit/features/extraction/extraction/test_validating_langextract_adapter_module.py
+++ b/apps/backend/tests/unit/features/extraction/extraction/test_validating_langextract_adapter_module.py
@@ -28,23 +28,10 @@ from app.features.extraction.extraction._validating_langextract_adapter import (
 from app.features.extraction.extraction.extraction_engine import (
     _ValidatingLangExtractAdapter as AdapterReExported,
 )
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_ROOT
 
-_ENGINE_PATH = (
-    Path(__file__).resolve().parents[5]
-    / "app"
-    / "features"
-    / "extraction"
-    / "extraction"
-    / "extraction_engine.py"
-)
-_ADAPTER_PATH = (
-    Path(__file__).resolve().parents[5]
-    / "app"
-    / "features"
-    / "extraction"
-    / "extraction"
-    / "_validating_langextract_adapter.py"
-)
+_ENGINE_PATH = _EXTRACTION_ROOT / "extraction" / "extraction_engine.py"
+_ADAPTER_PATH = _EXTRACTION_ROOT / "extraction" / "_validating_langextract_adapter.py"
 
 
 def _top_level_class_names(path: Path) -> list[str]:

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_gemma_literal_containment.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_gemma_literal_containment.py
@@ -18,7 +18,7 @@ import ast
 import re
 from pathlib import Path
 
-_EXTRACTION_ROOT = Path(__file__).resolve().parents[5] / "app" / "features" / "extraction"
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_ROOT
 
 _MODEL_TAG_PATTERN = re.compile(r"gemma\d", re.IGNORECASE)
 

--- a/apps/backend/tests/unit/features/extraction/intelligence/test_httpx_import_containment.py
+++ b/apps/backend/tests/unit/features/extraction/intelligence/test_httpx_import_containment.py
@@ -11,9 +11,9 @@ mechanically; this AST scan is the complementary enforcement mechanism.
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
-_EXTRACTION_ROOT = Path(__file__).resolve().parents[5] / "app" / "features" / "extraction"
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_ROOT
+
 _ALLOWED_FILES = frozenset(
     {
         "ollama_gemma_provider.py",

--- a/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_docling_document_parser.py
@@ -38,6 +38,7 @@ from app.features.extraction.parsing.docling_document_parser import (
 )
 from app.features.extraction.parsing.document_parser import DocumentParser
 from app.features.extraction.parsing.parsed_document import ParsedDocument
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_ROOT
 
 
 def _noop_preflight(_pdf_bytes: bytes) -> int:
@@ -655,9 +656,6 @@ def test_default_pdf_preflight_raises_domain_error_when_pymupdf_not_installed(
 # ---------------------------------------------------------------------------
 # Containment: docling imports live only in docling_document_parser.py
 # ---------------------------------------------------------------------------
-
-
-_EXTRACTION_ROOT = Path(__file__).resolve().parents[5] / "app" / "features" / "extraction"
 
 
 def _collect_files_referencing_docling() -> set[Path]:

--- a/apps/backend/tests/unit/features/extraction/parsing/test_no_third_party_imports.py
+++ b/apps/backend/tests/unit/features/extraction/parsing/test_no_third_party_imports.py
@@ -6,13 +6,14 @@ docling, pymupdf, fitz, langextract, or pydantic.
 """
 
 import ast
-from pathlib import Path
 
 import pytest
 
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_ROOT
+
 _FORBIDDEN_ROOTS = frozenset({"docling", "pymupdf", "fitz", "langextract", "pydantic"})
 
-_PARSING_DIR = Path(__file__).resolve().parents[5] / "app" / "features" / "extraction" / "parsing"
+_PARSING_DIR = _EXTRACTION_ROOT / "parsing"
 
 _ABSTRACTION_FILES = (
     "document_parser.py",

--- a/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
+++ b/apps/backend/tests/unit/meta/test_ai_guide_not_stale.py
@@ -21,11 +21,10 @@ instead of silencing the test.
 
 from __future__ import annotations
 
-from pathlib import Path
+from tests._paths import EXTRACTION_ROOT as _EXTRACTION_FEATURE_DIR
+from tests._paths import REPO_ROOT as _REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
 _AI_GUIDE_PATH = _REPO_ROOT / "docs" / "ai-guide.md"
-_EXTRACTION_FEATURE_DIR = _REPO_ROOT / "apps" / "backend" / "app" / "features" / "extraction"
 
 # Phrases copied verbatim from the stale ai-guide.md at commit-of-issue-#367.
 # Each entry is a lowercased substring; matching is case-insensitive.

--- a/apps/backend/tests/unit/meta/test_changelog_exists.py
+++ b/apps/backend/tests/unit/meta/test_changelog_exists.py
@@ -19,11 +19,10 @@ naturally as real releases get cut.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _CHANGELOG_PATH = _REPO_ROOT / "CHANGELOG.md"
 _MISSING_CHANGELOG_MESSAGE = (
     f"Expected CHANGELOG.md at {_CHANGELOG_PATH}. "

--- a/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
+++ b/apps/backend/tests/unit/meta/test_ci_concurrency_groups.py
@@ -41,7 +41,8 @@ from typing import Any, Final
 
 import yaml
 
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _CI_WORKFLOW_PATH: Final[Path] = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 

--- a/apps/backend/tests/unit/meta/test_codeowners_exists.py
+++ b/apps/backend/tests/unit/meta/test_codeowners_exists.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _CODEOWNERS_PATH = _REPO_ROOT / ".github" / "CODEOWNERS"
 _MISSING_FILE_MESSAGE = (
     f"{_CODEOWNERS_PATH} is missing. Issue #411 requires a CODEOWNERS "

--- a/apps/backend/tests/unit/meta/test_coverage_wired.py
+++ b/apps/backend/tests/unit/meta/test_coverage_wired.py
@@ -44,7 +44,8 @@ from typing import Any, Final, cast
 
 import yaml
 
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _TASKFILE: Final[Path] = _REPO_ROOT / "Taskfile.yml"
 _CI_WORKFLOW: Final[Path] = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _BACKEND_PYPROJECT: Final[Path] = _REPO_ROOT / "apps" / "backend" / "pyproject.toml"

--- a/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
+++ b/apps/backend/tests/unit/meta/test_dockerfile_apt_intentional_floating.py
@@ -39,10 +39,8 @@ import re
 from pathlib import Path
 from typing import Final
 
-# parents[5] walks: this file -> meta/ -> unit/ -> tests/ -> backend/ ->
-# apps/ -> repo root. Mirrors the convention used by
-# `tests/unit/docker/test_dockerignore_at_repo_root.py`.
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _DOCKERFILE_PATH: Final[Path] = _REPO_ROOT / "infra" / "docker" / "backend.Dockerfile"
 
 _MARKER: Final[str] = "reproducibility-boundary:digest-only"

--- a/apps/backend/tests/unit/meta/test_gitattributes_no_stale_packages.py
+++ b/apps/backend/tests/unit/meta/test_gitattributes_no_stale_packages.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import Final
 
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 # Matches the first glob metacharacter in a `.gitattributes` pattern.
 # `.gitattributes` uses fnmatch-style globs, so `*`, `?`, and a `[` that
 # opens a character class all terminate the literal path prefix. Splitting
@@ -27,9 +29,6 @@ from typing import Final
 # `path/?name` or `path/[abc]dir/file` as literal filesystem paths.
 _GLOB_METACHARS: Final[re.Pattern[str]] = re.compile(r"[*?\[]")
 
-# parents[5] walks: this file -> meta/ -> unit/ -> tests/ -> backend/ ->
-# apps/ -> repo root. Mirrors the convention used by sibling meta tests.
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
 _GITATTRIBUTES: Final[Path] = _REPO_ROOT / ".gitattributes"
 
 # Paths that are allowed to appear in `.gitattributes` even when they do

--- a/apps/backend/tests/unit/meta/test_no_redundant_asyncio_decorators.py
+++ b/apps/backend/tests/unit/meta/test_no_redundant_asyncio_decorators.py
@@ -30,10 +30,11 @@ import tomllib
 from pathlib import Path
 from typing import Final
 
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
-_BACKEND_ROOT: Final[Path] = _REPO_ROOT / "apps" / "backend"
+from tests._paths import BACKEND_DIR as _BACKEND_ROOT
+from tests._paths import REPO_ROOT as _REPO_ROOT
+from tests._paths import TESTS_DIR as _TESTS_ROOT
+
 _BACKEND_PYPROJECT: Final[Path] = _BACKEND_ROOT / "pyproject.toml"
-_TESTS_ROOT: Final[Path] = _BACKEND_ROOT / "tests"
 
 
 def _asyncio_mode_is_auto() -> bool:

--- a/apps/backend/tests/unit/meta/test_paths_helper.py
+++ b/apps/backend/tests/unit/meta/test_paths_helper.py
@@ -1,0 +1,113 @@
+"""Guardrail for the shared ``tests/_paths.py`` repo-root helper.
+
+Issue #402: eight+ test files hardcoded ``Path(__file__).resolve().parents[N]``
+with N varying by depth (3, 4, 5) to resolve the repo root. Any directory
+reshuffle broke every literal silently. The fix centralises resolution in
+``tests/_paths.py``, which walks up from its own location looking for the
+repo-root marker file (``Taskfile.yml``) rather than counting ``..`` hops.
+
+This test pins the helper's correctness so future moves of ``_paths.py``
+itself (a very different kind of refactor than the mass-rename problem the
+helper solves) still produce a loud failure at test time.
+
+The invariants are:
+
+1. ``REPO_ROOT`` resolves to a directory that contains ``Taskfile.yml``
+   and an ``apps/backend/`` subtree — the two load-bearing landmarks
+   that the rest of the repo layout hangs off.
+2. The resolution is independent of the current working directory — a
+   helper that silently depends on ``os.getcwd()`` would regress the
+   ``parents[N]`` problem in a different disguise.
+3. The derived path constants (``BACKEND_DIR``, ``APP_DIR`` etc.) are
+   real directories under ``REPO_ROOT``, so downstream tests don't need
+   to re-verify their structure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests import _paths
+
+
+def test_repo_root_contains_taskfile_marker() -> None:
+    """``REPO_ROOT`` must point at the directory that owns ``Taskfile.yml``.
+
+    The helper uses ``Taskfile.yml`` as its walk-up sentinel; this assertion
+    verifies the resolution landed on the correct directory rather than a
+    stray parent that happens to contain an identically-named file
+    (there are none today — ``Taskfile.yml`` is unique to the repo root —
+    but the invariant is worth pinning so the test fails loudly if a second
+    ``Taskfile.yml`` ever gets added at a nested layer).
+    """
+    assert (_paths.REPO_ROOT / "Taskfile.yml").is_file(), (
+        f"Expected REPO_ROOT ({_paths.REPO_ROOT}) to contain Taskfile.yml. "
+        "The walk-up marker used by tests/_paths.py has drifted."
+    )
+
+
+def test_repo_root_contains_backend_tree() -> None:
+    """``REPO_ROOT`` must expose the canonical ``apps/backend/`` subtree.
+
+    Guards against the helper accidentally resolving to a Taskfile-holding
+    directory that isn't the monorepo root (hypothetical, but cheap to pin).
+    """
+    assert (_paths.REPO_ROOT / "apps" / "backend" / "pyproject.toml").is_file(), (
+        f"Expected apps/backend/pyproject.toml under REPO_ROOT ({_paths.REPO_ROOT}). "
+        "The repo-root resolution is pointing at the wrong directory."
+    )
+
+
+def test_repo_root_is_cwd_independent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The helper must not rely on ``os.getcwd()`` to resolve the repo root.
+
+    The whole point of replacing ``parents[N]`` is that the result is stable
+    regardless of where the test process was launched from. Reimport the
+    helper from a different working directory and assert the value is the
+    same — any ``os.getcwd()``-based implementation would return a different
+    path (or crash) here.
+    """
+    expected = _paths.REPO_ROOT
+    monkeypatch.chdir(tmp_path)
+    # Re-read the module-level constant via attribute access; since it was
+    # resolved at import time (not on each access), the cwd change must not
+    # affect it. Assertion ordering is `actual == expected` to keep ruff
+    # SIM300 happy (no Yoda conditions).
+    assert expected == _paths.REPO_ROOT, (
+        f"REPO_ROOT changed after chdir — expected {expected}, got "
+        f"{_paths.REPO_ROOT}. The helper is leaking cwd dependency."
+    )
+    # Sanity: cwd really did change.
+    assert Path.cwd().resolve() == tmp_path.resolve()
+
+
+def test_backend_dir_points_at_apps_backend() -> None:
+    assert _paths.BACKEND_DIR == _paths.REPO_ROOT / "apps" / "backend"
+    assert _paths.BACKEND_DIR.is_dir()
+
+
+def test_app_dir_points_at_backend_app_tree() -> None:
+    assert _paths.APP_DIR == _paths.BACKEND_DIR / "app"
+    assert _paths.APP_DIR.is_dir()
+
+
+def test_extraction_root_points_at_extraction_feature() -> None:
+    assert _paths.EXTRACTION_ROOT == _paths.APP_DIR / "features" / "extraction"
+    assert _paths.EXTRACTION_ROOT.is_dir()
+
+
+def test_tests_dir_points_at_backend_tests_tree() -> None:
+    assert _paths.TESTS_DIR == _paths.BACKEND_DIR / "tests"
+    assert _paths.TESTS_DIR.is_dir()
+
+
+def test_tests_unit_dir_points_at_unit_tests() -> None:
+    assert _paths.TESTS_UNIT_DIR == _paths.TESTS_DIR / "unit"
+    assert _paths.TESTS_UNIT_DIR.is_dir()
+
+
+def test_fixtures_dir_points_at_tests_fixtures() -> None:
+    assert _paths.FIXTURES_DIR == _paths.TESTS_DIR / "fixtures"
+    assert _paths.FIXTURES_DIR.is_dir()

--- a/apps/backend/tests/unit/meta/test_paths_helper.py
+++ b/apps/backend/tests/unit/meta/test_paths_helper.py
@@ -25,6 +25,7 @@ The invariants are:
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -64,23 +65,28 @@ def test_repo_root_is_cwd_independent(tmp_path: Path, monkeypatch: pytest.Monkey
     """The helper must not rely on ``os.getcwd()`` to resolve the repo root.
 
     The whole point of replacing ``parents[N]`` is that the result is stable
-    regardless of where the test process was launched from. Reimport the
-    helper from a different working directory and assert the value is the
-    same — any ``os.getcwd()``-based implementation would return a different
-    path (or crash) here.
+    regardless of where the test process was launched from. Changing ``cwd``
+    on an already-imported module only asserts the cached constant doesn't
+    mutate — which would pass even for an implementation that called
+    ``os.getcwd()`` at import time. To actually exercise the resolution
+    logic under a different cwd, ``importlib.reload`` is used after
+    ``monkeypatch.chdir`` so the module-scope resolution re-executes in the
+    new working directory. Any ``os.getcwd()``-based implementation would
+    return a different path (or crash) on the reload; the ``Path(__file__)``
+    walk-up used here is immune by design.
     """
-    expected = _paths.REPO_ROOT
+    original = _paths.REPO_ROOT
     monkeypatch.chdir(tmp_path)
-    # Re-read the module-level constant via attribute access; since it was
-    # resolved at import time (not on each access), the cwd change must not
-    # affect it. Assertion ordering is `actual == expected` to keep ruff
-    # SIM300 happy (no Yoda conditions).
-    assert expected == _paths.REPO_ROOT, (
-        f"REPO_ROOT changed after chdir — expected {expected}, got "
-        f"{_paths.REPO_ROOT}. The helper is leaking cwd dependency."
-    )
-    # Sanity: cwd really did change.
+    # Sanity: cwd really did change before we reload.
     assert Path.cwd().resolve() == tmp_path.resolve()
+    # Force the module-scope resolution code to run again under the new cwd.
+    # A cwd-dependent implementation would compute a different REPO_ROOT on
+    # this reload; the current Path(__file__).resolve() walk-up does not.
+    reloaded = importlib.reload(_paths)
+    assert original == reloaded.REPO_ROOT, (
+        f"REPO_ROOT changed after chdir + reload — expected {original}, got "
+        f"{reloaded.REPO_ROOT}. The helper is leaking cwd dependency."
+    )
 
 
 def test_backend_dir_points_at_apps_backend() -> None:

--- a/apps/backend/tests/unit/meta/test_precommit_lint_hooks.py
+++ b/apps/backend/tests/unit/meta/test_precommit_lint_hooks.py
@@ -41,7 +41,8 @@ from typing import Any, Final
 
 import yaml
 
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _PRECOMMIT_PATH: Final[Path] = _REPO_ROOT / ".pre-commit-config.yaml"
 _YAMLLINT_CONFIG_PATH: Final[Path] = _REPO_ROOT / ".yamllint"
 _HADOLINT_CONFIG_PATH: Final[Path] = _REPO_ROOT / ".hadolint.yaml"

--- a/apps/backend/tests/unit/meta/test_precommit_pyright_hook_present.py
+++ b/apps/backend/tests/unit/meta/test_precommit_pyright_hook_present.py
@@ -36,11 +36,10 @@ When this test fails, pick one of:
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import yaml
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _PRECOMMIT_PATH = _REPO_ROOT / ".pre-commit-config.yaml"
 
 _PYRIGHT_HOOK_ID = "pyright"

--- a/apps/backend/tests/unit/meta/test_precommit_ruff_pin_matches_lockfile.py
+++ b/apps/backend/tests/unit/meta/test_precommit_ruff_pin_matches_lockfile.py
@@ -20,13 +20,14 @@ Editing the pre-commit `rev:` alone will NOT change `apps/backend/uv.lock`.
 from __future__ import annotations
 
 import tomllib
-from pathlib import Path
 
 import yaml
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
+from tests._paths import BACKEND_DIR as _BACKEND_DIR
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _PRECOMMIT_PATH = _REPO_ROOT / ".pre-commit-config.yaml"
-_UV_LOCK_PATH = _REPO_ROOT / "apps" / "backend" / "uv.lock"
+_UV_LOCK_PATH = _BACKEND_DIR / "uv.lock"
 
 _RUFF_PRECOMMIT_REPO_SUBSTRING = "ruff-pre-commit"
 _RUFF_PACKAGE_NAME = "ruff"

--- a/apps/backend/tests/unit/meta/test_taskfile_hygiene.py
+++ b/apps/backend/tests/unit/meta/test_taskfile_hygiene.py
@@ -37,8 +37,8 @@ from typing import Any, Final, cast
 
 import yaml
 
-# _REPO_ROOT: tests/unit/meta/<file> -> meta -> unit -> tests -> backend -> apps -> repo
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _TASKFILE: Final[Path] = _REPO_ROOT / "Taskfile.yml"
 _TIMEOUT_WRAPPER: Final[Path] = _REPO_ROOT / "infra" / "taskfile" / "with_timeout.py"
 

--- a/apps/backend/tests/unit/meta/test_tests_unit_packages_have_init_py.py
+++ b/apps/backend/tests/unit/meta/test_tests_unit_packages_have_init_py.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_TESTS_UNIT_ROOT = Path(__file__).resolve().parents[1]
+from tests._paths import TESTS_UNIT_DIR as _TESTS_UNIT_ROOT
+
 _SKIPPED_DIRECTORY_NAMES = frozenset({"__pycache__"})
 
 
@@ -47,18 +48,18 @@ def _unit_test_package_dirs() -> list[Path]:
 
 
 def test_tests_unit_root_is_discoverable() -> None:
-    """Sanity-check that the walked path is the real ``tests/unit`` directory.
+    """Sanity-check that ``TESTS_UNIT_DIR`` still resolves to ``tests/unit``.
 
-    If ``_TESTS_UNIT_ROOT`` ever drifts (for example, because this file is
-    moved to a different depth in the tree), the subsequent assertion could
-    silently pass against an unrelated directory. Anchor the walk to a known
-    landmark — ``tests/unit/__init__.py`` itself — so a structural refactor
-    turns this into a loud failure instead of a silent pass.
+    If the helper in ``tests/_paths.py`` ever drifts (for example, because
+    the repo-root marker or the derived constants change), the subsequent
+    ``__init__.py``-coverage assertion could silently pass against an
+    unrelated directory. Anchor the walk to two known landmarks — the
+    directory name and ``tests/unit/__init__.py`` itself — so a structural
+    refactor turns this into a loud failure instead of a silent pass.
     """
     assert _TESTS_UNIT_ROOT.name == "unit", (
-        f"Expected parents[1] to be the 'unit' directory, got "
-        f"{_TESTS_UNIT_ROOT!s}. If this file has moved, update the "
-        f"_TESTS_UNIT_ROOT parents[] index."
+        f"Expected TESTS_UNIT_DIR to be the 'unit' directory, got "
+        f"{_TESTS_UNIT_ROOT!s}. Check tests/_paths.py for drift."
     )
     assert (_TESTS_UNIT_ROOT / "__init__.py").is_file(), (
         f"Expected {_TESTS_UNIT_ROOT}/__init__.py to exist as the package "

--- a/apps/backend/tests/unit/meta/test_with_timeout_wrapper.py
+++ b/apps/backend/tests/unit/meta/test_with_timeout_wrapper.py
@@ -24,8 +24,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import IO, Final
 
-# parents[5] -> tests/unit/meta -> unit -> tests -> backend -> apps -> repo
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[5]
+from tests._paths import REPO_ROOT as _REPO_ROOT
+
 _WRAPPER: Final[Path] = _REPO_ROOT / "infra" / "taskfile" / "with_timeout.py"
 
 

--- a/apps/backend/tests/unit/scripts/test_benchmark.py
+++ b/apps/backend/tests/unit/scripts/test_benchmark.py
@@ -28,6 +28,7 @@ from scripts.benchmark import (
     main,
     parse_args,
 )
+from tests._paths import BACKEND_DIR as _BACKEND_DIR
 
 # ---------------------------------------------------------------------------
 # Percentile computation
@@ -662,6 +663,6 @@ def test_pyright_strict_passes_on_benchmark_module() -> None:
         capture_output=True,
         text=True,
         check=False,
-        cwd=str(Path(__file__).resolve().parents[3]),  # apps/backend/
+        cwd=str(_BACKEND_DIR),  # apps/backend/
     )
     assert result.returncode == 0, f"pyright errors:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary

- Adds `apps/backend/tests/_paths.py` exporting `REPO_ROOT`, `BACKEND_DIR`, `APP_DIR`, `EXTRACTION_ROOT`, `TESTS_DIR`, `TESTS_UNIT_DIR`, `FIXTURES_DIR` as `Final[Path]` constants resolved once at import time by walking up from the module's own location looking for the `Taskfile.yml` marker file.
- Migrates 32 call sites from `Path(__file__).resolve().parents[N]` to the shared constants, centralising the N-depth arithmetic that was previously duplicated across architecture, docker, features/extraction, meta, exceptions, scripts, core, and integration test trees (closes #402).
- Adds `tests/unit/meta/test_paths_helper.py` with 9 assertions: the marker file is present, `apps/backend/pyproject.toml` lives under `REPO_ROOT`, resolution is independent of `os.getcwd()`, and each derived constant points at the expected real directory.

The walk-up resolution is bounded (`_MAX_WALK_DEPTH = 15`) so a misplaced module surfaces as a `RuntimeError` at import time rather than climbing forever. `Taskfile.yml` was chosen over `.git` because in git worktrees `.git` is a file rather than a directory and has been a historical footgun for repo-detection helpers. The file is verified unique to the repo root on `find . -name Taskfile.yml`.

Packages outside `apps/backend/tests/` (e.g. `packages/error-contracts/scripts/*.py` which use `parents[1]` for their local package root) are intentionally out of scope — they compute package-local paths, not the repo root.

## Test plan

- [x] `task check` passes (1112 unit + 103 integration + 25 contract + 66 error-contracts tests green; zero lint/type/arch errors)
- [x] `test_repo_root_is_cwd_independent` verifies `monkeypatch.chdir(tmp_path)` does not shift `REPO_ROOT`
- [x] `test_repo_root_contains_taskfile_marker` and `test_repo_root_contains_backend_tree` pin the resolution landmark
- [x] `grep -rn "Path(__file__).resolve().parents\[" apps/backend/tests/` returns zero hits (excluding the `_paths.py` / `test_paths_helper.py` docstrings that reference the old pattern)