### PR TITLE
docs(graphs): bump 8 drifted features to implemented (closes #366)

### DIFF
--- a/docs/graphs/PDFX/PDFX-E001-F002.md
+++ b/docs/graphs/PDFX/PDFX-E001-F002.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E001-F002
 parent: PDFX-E001
 title: Dependency swap in pyproject.toml
-status: detailed
+status: implemented
 priority: 20
 dependencies: [PDFX-E001-F001]
 ---

--- a/docs/graphs/PDFX/PDFX-E001-F004.md
+++ b/docs/graphs/PDFX/PDFX-E001-F004.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E001-F004
 parent: PDFX-E001
 title: CRUD error contract pruning
-status: detailed
+status: implemented
 priority: 40
 dependencies: [PDFX-E001-F001]
 ---

--- a/docs/graphs/PDFX/PDFX-E001-F005.md
+++ b/docs/graphs/PDFX/PDFX-E001-F005.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E001-F005
 parent: PDFX-E001
 title: CLAUDE.md + docs refresh for post-cleanup state
-status: verifiable
+status: implemented
 priority: 50
 dependencies: [PDFX-E001-F001, PDFX-E001-F002, PDFX-E001-F003, PDFX-E001-F004]
 ---

--- a/docs/graphs/PDFX/PDFX-E002-F001.md
+++ b/docs/graphs/PDFX/PDFX-E002-F001.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E002-F001
 parent: PDFX-E002
 title: Skill YAML schema + Skill domain object
-status: verifiable
+status: implemented
 priority: 60
 dependencies: []
 ---

--- a/docs/graphs/PDFX/PDFX-E002-F004.md
+++ b/docs/graphs/PDFX/PDFX-E002-F004.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E002-F004
 parent: PDFX-E002
 title: task skills:validate standalone Taskfile target
-status: verifiable
+status: implemented
 priority: 90
 dependencies: [PDFX-E002-F002]
 ---

--- a/docs/graphs/PDFX/PDFX-E003-F001.md
+++ b/docs/graphs/PDFX/PDFX-E003-F001.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E003-F001
 parent: PDFX-E003
 title: DocumentParser protocol + TextBlock / ParsedDocument / BoundingBox types
-status: verifiable
+status: implemented
 priority: 100
 dependencies: []
 ---

--- a/docs/graphs/PDFX/PDFX-E004-F001.md
+++ b/docs/graphs/PDFX/PDFX-E004-F001.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E004-F001
 parent: PDFX-E004
 title: IntelligenceProvider protocol + GenerationResult + StructuredOutputValidator
-status: detailed
+status: implemented
 priority: 140
 dependencies: []
 ---

--- a/docs/graphs/PDFX/PDFX-E007-F005.md
+++ b/docs/graphs/PDFX/PDFX-E007-F005.md
@@ -3,7 +3,7 @@ type: feature
 id: PDFX-E007-F005
 parent: PDFX-E007
 title: Local latency benchmark script + fixture PDF corpus
-status: implementing
+status: implemented
 priority: 290
 dependencies: [PDFX-E006-F003]
 ---


### PR DESCRIPTION
## Summary
- Audit surfaces 8 feature nodes under `docs/graphs/PDFX/` whose `status:` frontmatter never got bumped as implementation landed on `main` (5 flagged in issue #366 + 3 more found during audit).
- Bumps each to `implemented` based on the graph-README's entry criteria (source + tests on main, `task check` green).
- Only `status:` lines touched — no prose or structural changes.

## Test plan
- [x] `task check` passes locally (lint, types, arch, skills, unit/integration/contract/errors all green).
- [x] Each bump verified against the implemented-feature criteria in the graph-README before being applied.