### PR TITLE
test: move pyright-strict benchmark check to integration (closes #398)

### DIFF
--- a/apps/backend/tests/integration/scripts/test_benchmark_pyright_strict.py
+++ b/apps/backend/tests/integration/scripts/test_benchmark_pyright_strict.py
@@ -1,0 +1,45 @@
+"""Integration test: ``scripts/benchmark.py`` passes ``pyright --strict``.
+
+Relocated from ``tests/unit/scripts/test_benchmark.py`` per issue #398: the
+assertion requires spawning a full ``pyright`` subprocess, which cold-starts
+in 5-15 s because pyright walks the project's reachability graph. That
+magnitude of wall time blows the sacred <10 s unit-suite budget enshrined in
+CLAUDE.md's Testing Rules, so the test must live outside the unit layer.
+
+Integration was chosen over architecture because the architecture suite sits
+under ``tests/unit/architecture/`` and is executed as part of ``test:unit``,
+inheriting the same <10 s budget. Only ``tests/integration/`` (600 s budget
+under ``test:integration`` in ``Taskfile.yml``) accommodates a ~10 s pyright
+subprocess without risking a suite-wide timeout.
+
+The test is intentionally NOT marked ``slow``: ``test:integration`` runs with
+``-m "not slow"``, which is exactly the gate we want this pin to ride on so
+``task check`` keeps covering the benchmark module specifically. Sibling
+``test_benchmark.py`` in this directory is ``slow``-marked (runs a real
+uvicorn server) and therefore excluded from ``task check`` by design — this
+file is deliberately separate so its single fast subprocess test does not
+inherit that marker.
+
+Redundancy note: ``task check:types:backend`` already runs ``pyright
+app/ scripts/ tests/`` across the whole backend, so the benchmark module is
+type-checked there too. This test is an explicit, grep-able pin that the
+benchmark module in particular stays strict-clean as it evolves.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_pyright_strict_passes_on_benchmark_module() -> None:
+    """pyright --strict reports zero errors on scripts/benchmark.py."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pyright", "--pythonversion", "3.13", "scripts/benchmark.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(Path(__file__).resolve().parents[3]),  # apps/backend/
+    )
+    assert result.returncode == 0, f"pyright errors:\n{result.stdout}\n{result.stderr}"

--- a/apps/backend/tests/unit/scripts/test_benchmark.py
+++ b/apps/backend/tests/unit/scripts/test_benchmark.py
@@ -1,16 +1,19 @@
 """Unit tests for ``scripts.benchmark`` — local latency benchmark script.
 
-Covers the sixteen unit scenarios in PDFX-E007-F005: percentile computation
-(happy path, single value, empty), report formatting (per-fixture table,
-memory section, NFR comparison), fixture discovery (all present, one
-missing, all missing), CLI parsing (--help, defaults, overrides, validation),
-warm-up discard, and pyright strict pass.
+Covers the PDFX-E007-F005 unit scenarios: percentile computation (happy path,
+single value, empty), report formatting (per-fixture table, memory section,
+NFR comparison), fixture discovery (all present, one missing, all missing),
+CLI parsing (--help, defaults, overrides, validation), and warm-up discard.
+
+The pyright-strict-on-benchmark-module check was relocated to
+``tests/integration/scripts/test_benchmark_pyright_strict.py`` under issue
+#398 because spinning up a pyright subprocess cold-starts in 5-15 s and
+blew the <10 s unit-suite budget enshrined in CLAUDE.md's Testing Rules.
 """
 
 from __future__ import annotations
 
 import io
-import subprocess
 import sys
 from pathlib import Path
 
@@ -648,20 +651,3 @@ def test_warmup_discard_removes_first_value() -> None:
     # p50 should be near 5.0, not skewed by the 60.0 outlier
     p50 = compute_percentile(warmed, 50)
     assert p50 < 10.0
-
-
-# ---------------------------------------------------------------------------
-# Pyright strict
-# ---------------------------------------------------------------------------
-
-
-def test_pyright_strict_passes_on_benchmark_module() -> None:
-    """pyright --strict reports zero errors on scripts/benchmark.py."""
-    result = subprocess.run(
-        [sys.executable, "-m", "pyright", "--pythonversion", "3.13", "scripts/benchmark.py"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=str(Path(__file__).resolve().parents[3]),  # apps/backend/
-    )
-    assert result.returncode == 0, f"pyright errors:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary
- Relocate the pyright-strict subprocess test out of the unit suite (which has a <10 s budget per CLAUDE.md) into a new `tests/integration/scripts/test_benchmark_pyright_strict.py`.
- Kept inside `task check` via `test:integration`'s default selector (test not marked `slow`).
- Architecture suite was rejected as destination because it inherits the unit-suite budget.

## Test plan
- [x] `task check` green: unit 1102 passed in 11.44 s (down from ~20+ s with pyright subprocess), integration 104 passed (includes relocated test), contract 25 passed, errors 66 passed.
- [x] Relocated test confirmed running under `test:integration` and PASSED.